### PR TITLE
Fix for powershell close #26

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -135,4 +135,4 @@ Write-host "Launch Java Installer for SaaS Boost"
 
 $env:AWS_REGION = $AWS_REGION
 
-java -Djava.util.logging.config.file=logging.properties -jar ${CURRENT_DIR}\installer\target\SaaSBoostInstall-1.0.0-shaded.jar
+java "-Djava.util.logging.config.file=logging.properties" -jar ${CURRENT_DIR}\installer\target\SaaSBoostInstall-1.0.0-shaded.jar


### PR DESCRIPTION
Powershell requires -D be inside a double quote to avoid argument error


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
