### PR TITLE
Fix discrepancy between licenses in installer pom

### DIFF
--- a/installer/pom.xml
+++ b/installer/pom.xml
@@ -25,8 +25,8 @@ limitations under the License.
     <packaging>jar</packaging>
     <licenses>
         <license>
-            <name>MIT No Attribution License (MIT-0)</name>
-            <url>https://spdx.org/licenses/MIT-0.html</url>
+            <name>Apache-2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
     </licenses>
 


### PR DESCRIPTION
The installer pom used to show MIT-0 license. This changes it to be Apache-2.0.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
