### PR TITLE
Save the lambdas source folder as a parameter

### DIFF
--- a/resources/saas-boost-svc-onboarding.yaml
+++ b/resources/saas-boost-svc-onboarding.yaml
@@ -1180,6 +1180,9 @@ Resources:
       Environment:
         Variables:
           ONBOARDING_TABLE: !Ref OnboardingTable
+          API_TRUST_ROLE: !Sub arn:aws:iam::${AWS::AccountId}:role/sb-private-api-trust-role-${Environment}-${AWS::Region}
+          API_GATEWAY_HOST: !Sub ${SaaSBoostPrivateApi}.execute-api.${AWS::Region}.amazonaws.com
+          API_GATEWAY_STAGE: !Ref PrivateApiStage
       Tags:
         - Key: "Application"
           Value: "SaaSBoost"

--- a/resources/saas-boost.yaml
+++ b/resources/saas-boost.yaml
@@ -71,6 +71,12 @@ Resources:
       Name: !Sub /saas-boost/${Environment}/SAAS_BOOST_BUCKET
       Type: String
       Value: !Ref SaaSBoostBucket
+  SSMParamLambdaSourceFolder:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub /saas-boost/${Environment}/SAAS_BOOST_LAMBDAS_FOLDER
+      Type: String
+      Value: !Ref LambdaSourceFolder
   # Create all the S3 buckets SaaS Boost needs up front so we can create
   # a single Lambda IAM policy to clean up the buckets on stack delete
   #

--- a/resources/tenant-onboarding.yaml
+++ b/resources/tenant-onboarding.yaml
@@ -18,16 +18,13 @@ Parameters:
   Environment:
     Description: Environment (test, uat, prod, etc.)
     Type: String
-    Default: oct12
   SaaSBoostBucket:
     Description: SaaS Boost assets S3 bucket
     Type: String
-    Default: sb-oct12-artifacts-e7389e84-cdae
   LambdaSourceFolder:
     Description: Folder for lambda source code to change on each deployment
     Type: String
     Default: lambdas
-    #Default: lambdas-2020-10-12-15-26
   TenantId:
     Description: The GUID for the tenant
     Type: String
@@ -65,7 +62,6 @@ Parameters:
   ContainerRepository:
     Description: The name of the ECR repository hosting the container image
     Type: String
-    Default: ecsrepository-o9zf9rbljvnt
   ContainerPort:
     Description: The TCP port the container is listening on via EXPOSE in the Dockerfile
     Type: Number
@@ -73,8 +69,7 @@ Parameters:
   ContainerHealthCheckPath:
     Description: The destination on the Container for the Load Balancer to use for health checks
     Type: String
-    #Default: '/index.html'
-    Default: /
+    Default: '/'
   CodePipelineRoleArn:
     Description: The IAM role for CodePipeline
     Type: String
@@ -86,20 +81,15 @@ Parameters:
   CidrPrefix:
     Description: Prefix of Cidr for this tenant such as 10.1, 10.2 etc.
     Type: String
-    #Default: 10.0
-    Default: 10.10
   TransitGateway:
     Description: Id of Transit Gateway for Egress
     Type: String
-    Default: tgw-0e8f91a21d14b1e5e
   TenantTransitGatewayRouteTable:
     Description: Id of the Tenants Route table for Transit Gateway
     Type: String
-    Default: tgw-rtb-034f653af0d951d46
   EgressTransitGatewayRouteTable:
     Description: Id of the Egress Route table for Transit Gateway
     Type: String
-    Default: tgw-rtb-06222a87e38f4df69
   DomainName:
     Description: The hosted zone domain name
     Type: String
@@ -168,16 +158,12 @@ Parameters:
   ALBAccessLogsBucket:
     Description: SaaS Boost bucket for Access logs
     Type: String
-    Default: sb-oct12-albaccesslogs-15ofqujyc1ley
   EventBus:
     Description: Optional. SaaS boost Metering and Billing Event Bridge
     Type: String
-    Default: sb-events-oct12-us-east-2
   BillingPlan:
     Description: The billing plan to assign this tenant to after the stack completes
     Type: String
-    Default: plan_none
-#Fsx for Windows
   UseFSx:
     Description: Deploy the FSX nested stack?
     Type: String
@@ -194,7 +180,7 @@ Parameters:
     Type: Number
   FSxThroughputCapacity:
     Default: 8
-    Description: Specify the throughput of the Amazon FSx file system. Valid values are 8 -  2048.
+    Description: Specify the throughput of the Amazon FSx file system. Valid values are 8 - 2048.
       Consider choosing a higher value for better performance.
     Type: Number
   FSxBackupRetention:
@@ -214,7 +200,6 @@ Parameters:
   SSLCertArnParam:
     Description: The Parameter Store string parameter and version containing the certficate ARN to use
     Type: String
-  #  Default: /saas-boost/<environment>/SSL_CERT_ARN:1
     Default: ''
   ## These params are here to read the image values from the public SSM. Leave the defaults
   WIN2019FULL:
@@ -236,7 +221,6 @@ Conditions:
   WindowsOS: !Not [!Equals [!Ref DockerHostOS, 'LINUX']]
   HasCertificate: !Not [!Equals [!Ref SSLCertArnParam, '']]
   NoCertificate: !Not [Condition: HasCertificate]
-  # FSX
   ProvisionFsx: !And
     - !Equals [!Ref UseFSx, 'true']
     - Condition: WindowsOS
@@ -499,7 +483,6 @@ Resources:
                   - events:PutEvents
                 Resource:
                   - !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:event-bus/${EventBus}
-              #added to access config files for tenant.
               - Effect: Allow
                 Action:
                   - s3:GetObject
@@ -1200,6 +1183,8 @@ Resources:
   fsx:
     Type: AWS::CloudFormation::Stack
     Condition: ProvisionFsx
+    Metadata:
+      ForceUpdate: !Ref LambdaSourceFolder
     DependsOn:
       - SubnetPublicA
       - SubnetPublicB
@@ -1237,6 +1222,8 @@ Resources:
   efs:
     Type: AWS::CloudFormation::Stack
     Condition: ProvisionEFS
+    Metadata:
+      ForceUpdate: !Ref LambdaSourceFolder
     Properties:
       TemplateURL: !Sub https://${SaaSBoostBucket}.s3.amazonaws.com/tenant-onboarding-efs.yaml
       TimeoutInMinutes: 15
@@ -1252,6 +1239,8 @@ Resources:
   rds:
     Type: AWS::CloudFormation::Stack
     Condition: ProvisionRDS
+    Metadata:
+      ForceUpdate: !Ref LambdaSourceFolder
     # Have to make sure the entire network is still up when you delete
     # or we won't be able to call back to the CFN response URL
     DependsOn:

--- a/services/onboarding-service/update_service.sh
+++ b/services/onboarding-service/update_service.sh
@@ -48,8 +48,9 @@ fi
 aws s3 cp target/$LAMBDA_CODE s3://$SAAS_BOOST_BUCKET/$LAMBDA_STAGE_FOLDER/
 
 FUNCTIONS=(
-  "sb-${ENVIRONMENT}-onboarding-get-all"
+	"sb-${ENVIRONMENT}-onboarding-get-all"
 	"sb-${ENVIRONMENT}-onboarding-get-by-id"
+	"sb-${ENVIRONMENT}-onboarding-delete"
 	"sb-${ENVIRONMENT}-onboarding-listener"
 	"sb-${ENVIRONMENT}-onboarding-provision"
 	"sb-${ENVIRONMENT}-onboarding-start"
@@ -57,7 +58,6 @@ FUNCTIONS=(
 	"sb-${ENVIRONMENT}-onboarding-update-status"
 	"sb-${ENVIRONMENT}-onboarding-update-tenant"
 	"sb-${ENVIRONMENT}-tenants-update-onboarding"
-	"sb-${ENVIRONMENT}-onboarding-listener"
 )
 
 

--- a/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SettingsService.java
+++ b/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SettingsService.java
@@ -58,7 +58,7 @@ public class SettingsService implements RequestHandler<Map<String, Object>, APIG
     final static List<String> REQUIRED_PARAMS = Collections.unmodifiableList(
             Arrays.asList("SAAS_BOOST_BUCKET", "CODE_PIPELINE_BUCKET", "CODE_PIPELINE_ROLE", "ECR_REPO", "ONBOARDING_WORKFLOW",
                     "ONBOARDING_SNS", "ONBOARDING_TEMPLATE", "TRANSIT_GATEWAY", "TRANSIT_GATEWAY_ROUTE_TABLE", "EGRESS_ROUTE_TABLE",
-                    "SAAS_BOOST_ENVIRONMENT", "SAAS_BOOST_STACK")
+                    "SAAS_BOOST_ENVIRONMENT", "SAAS_BOOST_STACK", "SAAS_BOOST_LAMBDAS_FOLDER")
     );
     final static List<String> READ_WRITE_PARAMS = Collections.unmodifiableList(
             Arrays.asList("DOMAIN_NAME", "HOSTED_ZONE", "SSL_CERT_ARN","COMPUTE_SIZE", "TASK_CPU", "TASK_MEMORY", "CONTAINER_PORT", "HEALTH_CHECK", "APP_NAME",

--- a/services/tenant-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/TenantServiceDAL.java
+++ b/services/tenant-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/TenantServiceDAL.java
@@ -322,22 +322,24 @@ public class TenantServiceDAL {
         if (tenant.getOverrideDefaults() != null) {
             item.put("overrideDefaults", AttributeValue.builder().bool(tenant.getOverrideDefaults()).build());
         }
-        if (Utils.isNotEmpty(tenant.getComputeSize())) {
-            item.put("computeSize", AttributeValue.builder().s(tenant.getComputeSize()).build());
+        if (Boolean.TRUE == tenant.getOverrideDefaults()) {
+            if (Utils.isNotEmpty(tenant.getComputeSize())) {
+                item.put("computeSize", AttributeValue.builder().s(tenant.getComputeSize()).build());
+            }
+            if (tenant.getMemory() != null) {
+                item.put("memory", AttributeValue.builder().n(tenant.getMemory().toString()).build());
+            }
+            if (tenant.getCpu() != null) {
+                item.put("cpu", AttributeValue.builder().n(tenant.getCpu().toString()).build());
+            }
+            if (tenant.getMinCount() != null) {
+                item.put("minCount", AttributeValue.builder().n(tenant.getMinCount().toString()).build());
+            }
+            if (tenant.getMaxCount() != null) {
+                item.put("maxCount", AttributeValue.builder().n(tenant.getMaxCount().toString()).build());
+            }
         }
-        if (tenant.getMemory() != null) {
-            item.put("memory", AttributeValue.builder().n(tenant.getMemory().toString()).build());
-        }
-        if (tenant.getCpu() != null) {
-            item.put("cpu", AttributeValue.builder().n(tenant.getCpu().toString()).build());
-        }
-        if (tenant.getMinCount() != null) {
-            item.put("minCount", AttributeValue.builder().n(tenant.getMinCount().toString()).build());
-        }
-        if (tenant.getMaxCount() != null) {
-            item.put("maxCount", AttributeValue.builder().n(tenant.getMaxCount().toString()).build());
-        }
-        if (tenant.getPlanId() != null && !tenant.getPlanId().isEmpty()) {
+        if (Utils.isNotBlank(tenant.getPlanId())) {
             item.put("planId", AttributeValue.builder().s(tenant.getPlanId()).build());
         }
         if (tenant.getResources() != null) {
@@ -396,43 +398,45 @@ public class TenantServiceDAL {
             if (item.containsKey("overrideDefaults")) {
                 tenant.setOverrideDefaults(item.get("overrideDefaults").bool());
             }
-            if (item.containsKey("computeSize")) {
-                tenant.setComputeSize(item.get("computeSize").s());
-            }
-            if (item.containsKey("memory")) {
-                try {
-                    Integer memory = Integer.valueOf(item.get("memory").n());
-                    tenant.setMemory(memory);
-                } catch (NumberFormatException nfe) {
-                    LOGGER.error("Failed to parse memory from database: {}", item.get("memory").n());
-                    LOGGER.error(Utils.getFullStackTrace(nfe));
+            if (Boolean.TRUE == tenant.getOverrideDefaults()) {
+                if (item.containsKey("computeSize")) {
+                    tenant.setComputeSize(item.get("computeSize").s());
                 }
-            }
-            if (item.containsKey("cpu")) {
-                try {
-                    Integer cpu = Integer.valueOf(item.get("cpu").n());
-                    tenant.setCpu(cpu);
-                } catch (NumberFormatException nfe) {
-                    LOGGER.error("Failed to parse CPU from database: {}", item.get("cpu").n());
-                    LOGGER.error(Utils.getFullStackTrace(nfe));
+                if (item.containsKey("memory")) {
+                    try {
+                        Integer memory = Integer.valueOf(item.get("memory").n());
+                        tenant.setMemory(memory);
+                    } catch (NumberFormatException nfe) {
+                        LOGGER.error("Failed to parse memory from database: {}", item.get("memory").n());
+                        LOGGER.error(Utils.getFullStackTrace(nfe));
+                    }
                 }
-            }
-            if (item.containsKey("minCount")) {
-                try {
-                    Integer minCount = Integer.valueOf(item.get("minCount").n());
-                    tenant.setMinCount(minCount);
-                } catch (NumberFormatException nfe) {
-                    LOGGER.error("Failed to parse min task count from database: {}", item.get("minCount").n());
-                    LOGGER.error(Utils.getFullStackTrace(nfe));
+                if (item.containsKey("cpu")) {
+                    try {
+                        Integer cpu = Integer.valueOf(item.get("cpu").n());
+                        tenant.setCpu(cpu);
+                    } catch (NumberFormatException nfe) {
+                        LOGGER.error("Failed to parse CPU from database: {}", item.get("cpu").n());
+                        LOGGER.error(Utils.getFullStackTrace(nfe));
+                    }
                 }
-            }
-            if (item.containsKey("maxCount")) {
-                try {
-                    Integer maxCount = Integer.valueOf(item.get("maxCount").n());
-                    tenant.setMaxCount(maxCount);
-                } catch (NumberFormatException nfe) {
-                    LOGGER.error("Failed to parse max task count from database: {}", item.get("maxCount").n());
-                    LOGGER.error(Utils.getFullStackTrace(nfe));
+                if (item.containsKey("minCount")) {
+                    try {
+                        Integer minCount = Integer.valueOf(item.get("minCount").n());
+                        tenant.setMinCount(minCount);
+                    } catch (NumberFormatException nfe) {
+                        LOGGER.error("Failed to parse min task count from database: {}", item.get("minCount").n());
+                        LOGGER.error(Utils.getFullStackTrace(nfe));
+                    }
+                }
+                if (item.containsKey("maxCount")) {
+                    try {
+                        Integer maxCount = Integer.valueOf(item.get("maxCount").n());
+                        tenant.setMaxCount(maxCount);
+                    } catch (NumberFormatException nfe) {
+                        LOGGER.error("Failed to parse max task count from database: {}", item.get("maxCount").n());
+                        LOGGER.error(Utils.getFullStackTrace(nfe));
+                    }
                 }
             }
             if (item.containsKey("planId")) {


### PR DESCRIPTION
Save the lambdas source folder as a parameter from the main SaaS Boost stack so it can be passed to the tenant onboarding stack(s). Resolves the immediate cause of Issue #92.

To make this work, the Onboarding service now needs to invoke the Settings service during provisioned tenant update to go fetch the necessary settings for the lambda folder and other CloudFormation data.

I also discovered during testing the CloudFormation considers a no updates to perform state to be an error. I'm now swallowing this error and just logging it.

There are some updates (for example just changing the lambdas folder) that _does not_ trigger a CloudFormation update. I could not figure out a way to force CloudFormation to perform a stack update consistently. I did add the metadata property to the onboarding templates as suggested by the documentation as a way to get CloudFormation to notice a change.

This flow also brings up some questions about whether the installer should be the place controlling these installation state changes and whether we should trigger a CloudFormation update on all provisioned tenants when we run update from the installer (we do not do that now). This could leave tenant environments in various states of infrastructure setup...

This PR also cleans up old developer cruft in the tenant onboarding CloudFormation template and clarifies that a tenant is either overriding the default compute settings or they're not. When override defaults is FALSE, the tenant does not have values for the individual compute settings.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
