### PR TITLE
Fix the build and remove AvoidStarImport from checkstyle

### DIFF
--- a/functions/alb-update/pom.xml
+++ b/functions/alb-update/pom.xml
@@ -34,7 +34,7 @@ limitations under the License.
     </licenses>
 
     <properties>
-        <checkstyle.maxAllowedViolations>33</checkstyle.maxAllowedViolations>
+        <checkstyle.maxAllowedViolations>30</checkstyle.maxAllowedViolations>
     </properties>
 
     <build>

--- a/functions/ecs-deploy/pom.xml
+++ b/functions/ecs-deploy/pom.xml
@@ -34,7 +34,7 @@ limitations under the License.
     </licenses>
 
     <properties>
-        <checkstyle.maxAllowedViolations>25</checkstyle.maxAllowedViolations>
+        <checkstyle.maxAllowedViolations>24</checkstyle.maxAllowedViolations>
     </properties>
 
     <build>

--- a/functions/onboarding-notification/pom.xml
+++ b/functions/onboarding-notification/pom.xml
@@ -34,7 +34,7 @@ limitations under the License.
     </licenses>
 
     <properties>
-        <checkstyle.maxAllowedViolations>24</checkstyle.maxAllowedViolations>
+        <checkstyle.maxAllowedViolations>23</checkstyle.maxAllowedViolations>
     </properties>
 
     <build>

--- a/installer/pom.xml
+++ b/installer/pom.xml
@@ -36,7 +36,7 @@ limitations under the License.
 
     <properties>
         <aws.java.sdk.version>2.13.68</aws.java.sdk.version>
-        <checkstyle.maxAllowedViolations>154</checkstyle.maxAllowedViolations>
+        <checkstyle.maxAllowedViolations>147</checkstyle.maxAllowedViolations>
     </properties>
 
     <build>

--- a/layers/apigw-helper/pom.xml
+++ b/layers/apigw-helper/pom.xml
@@ -28,13 +28,13 @@ limitations under the License.
     <packaging>jar</packaging>
     <licenses>
         <license>
-            <name>MIT No Attribution License (MIT-0)</name>
-            <url>https://spdx.org/licenses/MIT-0.html</url>
+            <name>Apache-2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
     </licenses>
 
     <properties>
-        <checkstyle.maxAllowedViolations>26</checkstyle.maxAllowedViolations>
+        <checkstyle.maxAllowedViolations>24</checkstyle.maxAllowedViolations>
     </properties>
 
     <build>

--- a/layers/utils/pom.xml
+++ b/layers/utils/pom.xml
@@ -34,7 +34,7 @@ limitations under the License.
     </licenses>
 
     <properties>
-        <checkstyle.maxAllowedViolations>343</checkstyle.maxAllowedViolations>
+        <checkstyle.maxAllowedViolations>342</checkstyle.maxAllowedViolations>
     </properties>
 
     <build>

--- a/metering-billing/lambdas/pom.xml
+++ b/metering-billing/lambdas/pom.xml
@@ -35,7 +35,7 @@ limitations under the License.
     </licenses>
 
     <properties>
-        <checkstyle.maxAllowedViolations>218</checkstyle.maxAllowedViolations>
+        <checkstyle.maxAllowedViolations>208</checkstyle.maxAllowedViolations>
     </properties>
 
     <build>

--- a/resources/checkstyle/checkstyle.xml
+++ b/resources/checkstyle/checkstyle.xml
@@ -57,7 +57,8 @@
             <property name="allowByTailComment" value="true"/>
             <property name="allowNonPrintableEscapes" value="true"/>
         </module>
-        <module name="AvoidStarImport"/>
+        <!-- In the interest of easily onboarding new users, we've decided to allow star imports -->
+        <!--<module name="AvoidStarImport"/>-->
         <module name="OneTopLevelClass"/>
         <module name="NoLineWrap">
             <property name="tokens" value="PACKAGE_DEF, IMPORT, STATIC_IMPORT"/>

--- a/resources/custom-resources/cidr-dynamodb/pom.xml
+++ b/resources/custom-resources/cidr-dynamodb/pom.xml
@@ -33,7 +33,7 @@ limitations under the License.
         </license>
     </licenses>
     <properties>
-        <checkstyle.maxAllowedViolations>19</checkstyle.maxAllowedViolations>
+        <checkstyle.maxAllowedViolations>16</checkstyle.maxAllowedViolations>
     </properties>
 
     <build>

--- a/resources/custom-resources/clear-s3-bucket/pom.xml
+++ b/resources/custom-resources/clear-s3-bucket/pom.xml
@@ -33,7 +33,7 @@ limitations under the License.
         </license>
     </licenses>
     <properties>
-        <checkstyle.maxAllowedViolations>18</checkstyle.maxAllowedViolations>
+        <checkstyle.maxAllowedViolations>16</checkstyle.maxAllowedViolations>
     </properties>
 
     <build>

--- a/resources/custom-resources/disable-instance-protection/pom.xml
+++ b/resources/custom-resources/disable-instance-protection/pom.xml
@@ -33,7 +33,7 @@ limitations under the License.
         </license>
     </licenses>
     <properties>
-        <checkstyle.maxAllowedViolations>16</checkstyle.maxAllowedViolations>
+        <checkstyle.maxAllowedViolations>13</checkstyle.maxAllowedViolations>
     </properties>
 
     <build>

--- a/resources/custom-resources/fsx-dns-name/pom.xml
+++ b/resources/custom-resources/fsx-dns-name/pom.xml
@@ -33,7 +33,7 @@ limitations under the License.
         </license>
     </licenses>
     <properties>
-        <checkstyle.maxAllowedViolations>14</checkstyle.maxAllowedViolations>
+        <checkstyle.maxAllowedViolations>12</checkstyle.maxAllowedViolations>
     </properties>
 
     <build>

--- a/resources/custom-resources/rds-bootstrap/pom.xml
+++ b/resources/custom-resources/rds-bootstrap/pom.xml
@@ -33,7 +33,7 @@ limitations under the License.
         </license>
     </licenses>
     <properties>
-        <checkstyle.maxAllowedViolations>28</checkstyle.maxAllowedViolations>
+        <checkstyle.maxAllowedViolations>24</checkstyle.maxAllowedViolations>
     </properties>
 
     <build>

--- a/resources/custom-resources/rds-options/pom.xml
+++ b/resources/custom-resources/rds-options/pom.xml
@@ -33,7 +33,7 @@ limitations under the License.
         </license>
     </licenses>
     <properties>
-        <checkstyle.maxAllowedViolations>48</checkstyle.maxAllowedViolations>
+        <checkstyle.maxAllowedViolations>45</checkstyle.maxAllowedViolations>
     </properties>
 
     <build>

--- a/resources/custom-resources/redshift-table/pom.xml
+++ b/resources/custom-resources/redshift-table/pom.xml
@@ -33,7 +33,7 @@ limitations under the License.
         </license>
     </licenses>
     <properties>
-        <checkstyle.maxAllowedViolations>49</checkstyle.maxAllowedViolations>
+        <checkstyle.maxAllowedViolations>46</checkstyle.maxAllowedViolations>
     </properties>
 
     <build>

--- a/services/metric-service/pom.xml
+++ b/services/metric-service/pom.xml
@@ -34,7 +34,7 @@ limitations under the License.
     </licenses>
 
     <properties>
-        <checkstyle.maxAllowedViolations>221</checkstyle.maxAllowedViolations>
+        <checkstyle.maxAllowedViolations>214</checkstyle.maxAllowedViolations>
     </properties>
 
     <build>

--- a/services/onboarding-service/pom.xml
+++ b/services/onboarding-service/pom.xml
@@ -34,7 +34,7 @@ limitations under the License.
     </licenses>
 
     <properties>
-        <checkstyle.maxAllowedViolations>202</checkstyle.maxAllowedViolations>
+        <checkstyle.maxAllowedViolations>196</checkstyle.maxAllowedViolations>
     </properties>
 
     <build>

--- a/services/quotas-service/pom.xml
+++ b/services/quotas-service/pom.xml
@@ -34,7 +34,7 @@ limitations under the License.
     </licenses>
 
     <properties>
-        <checkstyle.maxAllowedViolations>36</checkstyle.maxAllowedViolations>
+        <checkstyle.maxAllowedViolations>33</checkstyle.maxAllowedViolations>
     </properties>
 
     <build>

--- a/services/settings-service/pom.xml
+++ b/services/settings-service/pom.xml
@@ -34,7 +34,7 @@ limitations under the License.
     </licenses>
 
     <properties>
-        <checkstyle.maxAllowedViolations>199</checkstyle.maxAllowedViolations>
+        <checkstyle.maxAllowedViolations>193</checkstyle.maxAllowedViolations>
     </properties>
 
     <build>

--- a/services/tenant-service/pom.xml
+++ b/services/tenant-service/pom.xml
@@ -34,7 +34,7 @@ limitations under the License.
     </licenses>
 
     <properties>
-        <checkstyle.maxAllowedViolations>47</checkstyle.maxAllowedViolations>
+        <checkstyle.maxAllowedViolations>44</checkstyle.maxAllowedViolations>
     </properties>
 
     <build>

--- a/services/user-service/pom.xml
+++ b/services/user-service/pom.xml
@@ -34,7 +34,7 @@ limitations under the License.
     </licenses>
 
     <properties>
-        <checkstyle.maxAllowedViolations>41</checkstyle.maxAllowedViolations>
+        <checkstyle.maxAllowedViolations>39</checkstyle.maxAllowedViolations>
     </properties>
 
     <build>


### PR DESCRIPTION
Remove AvoidStarImports checkstyle, reduce checkstyle violation limits, fix ApiGatewayHelper License.

Checkstyle violation limits have been lowered to the number of current violations. This PR also serves to fix the build on main.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
