### PR TITLE
Implement automatic PR validation using GitHub Actions

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,71 @@
+name: PR Build Validation
+on:
+  pull_request
+jobs:
+  Build-Java:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v2
+
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      # We use Corretto Java 11 for Lambda: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
+      # Currently amazon-corretto Java is not supported for GitHub actions on Ubuntu-latest. By default we're using Adopt JDK11
+      #   https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
+      # We may want to either switch to using an AL2 container (to give us corretto) or contribute a new JDK to the GitHub runners
+      #   There is an open issue (as of 2021/06/30) requesting Corretto support: https://github.com/actions/setup-java/issues/68
+      # - name: Set up JDK 11
+      #   uses: actions/setup-java@v2
+      #   with:
+      #     java-version: '11'
+      #     distribution: 'adopt'
+
+      - name: Run Compilation Check
+        run: mvn clean compile -DskipTests -Dcheckstyle.skip -Dspotbugs.skip
+
+      - name: Run Unit Tests
+        run: mvn test -Dcheckstyle.skip -Dspotbugs.skip
+
+      - name: Run Spotbugs Check
+        run: mvn spotbugs:check
+
+      - name: Run Code Style Check
+        run: mvn checkstyle:check
+
+  Build-WebClient:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      # CI=false is required because GitHub hosted runners set CI=true, which causes Warnings to be treated as Errors when doing yarn build
+      # this is a workaround to allow the build to succeed until we can get around to fixing the warnings generated
+      # https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables
+      # TODO remove CI=false
+      - name: Build WebClient
+        run: |
+          cd ${{ github.workspace }}/client/web
+          yarn
+          CI=false yarn build

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -26,16 +26,13 @@ jobs:
       #     java-version: '11'
       #     distribution: 'adopt'
 
-      - name: Run Compilation Check
-        run: mvn clean compile -DskipTests -Dcheckstyle.skip -Dspotbugs.skip
+      - name: Maven Compile, Test, Install
+        run: mvn install -Dcheckstyle.skip -Dspotbugs.skip
 
-      - name: Run Unit Tests
-        run: mvn test -Dcheckstyle.skip -Dspotbugs.skip
-
-      - name: Run Spotbugs Check
+      - name: Spotbugs Check
         run: mvn spotbugs:check
 
-      - name: Run Code Style Check
+      - name: Code Style Check
         run: mvn checkstyle:check
 
   Build-WebClient:


### PR DESCRIPTION
This pull request implements basic PR validation for new PRs coming in against SaaS Boost. For any new Pull Request opened against SaaS Boost, two checks will be started: "Build-Java" and "Build-Webclient". If these checks fail, the PR will not be able to be merged and new commits should be added to the PR to alleviate the issues and automatically rerun the checks.

For example, look at this PR I opened against my own fork: https://github.com/PoeppingT/aws-saas-boost/pull/3

You can see that three commits were added to this pull request: 
```
Thomas Poepping added 3 commits 34 minutes ago
Change docs to install correct maven version using cloud9. f9fcc0f
merge compile and test action, add install so spotbugs and checkstyle… 322440c
Raise allowed checkstyle violations to 156 to pass checkstyle. 0364c12 
```
Next to each of these commits (by the commit id) is either a red ❌  or a green ✅ . To view details on the checks run, you can click on each of those to discover what went wrong. 

For example, if you click on the red ❌ next to 322440c, you will see that the "Build-Java" job failed. Clicking through to details, you can inspect the stages of the job that ran and see that the "Code Style Check" failed because there were too many violations in the installer. 

The third commit on the PR raises the allowed violations, and the automatic checks are shown to have passed by a green ✅ .

This PR will close https://github.com/awslabs/aws-saas-boost/issues/96

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
