### PR TITLE
Make installer play nice with new parent POM. Fixes Issue #130.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -67,7 +67,7 @@ fi
 
 cd ${CURRENT_DIR}/installer
 echo "Building installer..."
-mvn --quiet -Dspotbugs.skip
+mvn --quiet -Dspotbugs.skip > /dev/null 2>&1
 if [ $? -ne 0 ]; then
 	echo "Error building installer for SaaS Boost."
 	exit 2

--- a/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostInstall.java
+++ b/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostInstall.java
@@ -1433,10 +1433,14 @@ public class SaaSBoostInstall {
             executeCommand("mvn --non-recursive install", null, workingDir.toAbsolutePath().toFile());
 
             // Because the parent pom for the layers modules defines its own artifact name
-            // we have to build from the parent pom or maven won't be able to find the individual
-            // artifacts in the local maven cache. The parent pom will build the modules in the
-            // correct order (utils first).
-            sourceDirectories.add(workingDir.resolve(Path.of("layers")));
+            // we have to build from the parent pom or maven won't be able to find the
+            // artifact in the local maven cache.
+            executeCommand("mvn --non-recursive install", null, workingDir.resolve(Path.of("layers")).toFile());
+
+            // Now add the separate layers directories to the list so we can upload the lambda
+            // package to S3 below. Build utils before anything else.
+            sourceDirectories.add(workingDir.resolve(Path.of("layers", "utils")));
+            sourceDirectories.add(workingDir.resolve(Path.of("layers", "apigw-helper")));
 
             DirectoryStream<Path> functions = Files.newDirectoryStream(workingDir.resolve(Path.of("functions")), Files::isDirectory);
             functions.forEach(sourceDirectories::add);

--- a/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostInstall.java
+++ b/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostInstall.java
@@ -100,7 +100,7 @@ public class SaaSBoostInstall {
         UPDATE(4, "Update existing AWS SaaS Boost deployment.", true),
         DELETE(5, "Delete existing AWS SaaS Boost deployment.", true),
         CANCEL(6, "Exit installer.", false);
-        //DEBUG(7, "Debug", false);
+//        DEBUG(7, "Debug", false);
 
         private final int choice;
         private final String prompt;
@@ -187,9 +187,10 @@ public class SaaSBoostInstall {
         }
     }
 
-//    protected void debug() {
-//
-//    }
+    protected void debug() {
+//        getExistingSaaSBoostLambdasFolder();
+//        processLambdas();
+    }
 
     public void start() {
         outputMessage("===========================================================");
@@ -751,7 +752,11 @@ public class SaaSBoostInstall {
                 quickSightRegion = AWS_REGION;
             } else {
                 // Make sure we got a valid AWS region string
-                quickSightRegion = Region.regions().stream().filter(r -> r.id().equals(quickSightAccountRegion)).findAny().orElse(null);
+                quickSightRegion = Region.regions().stream().filter(request -> request
+                        .id()
+                        .equals(quickSightAccountRegion))
+                        .findAny()
+                        .orElse(null);
             }
             if (quickSightRegion != null) {
                 // Update the SDK client for the proper AWS region if we need to
@@ -1049,7 +1054,9 @@ public class SaaSBoostInstall {
                 )
                 .permissions(ResourcePermission.builder()
                         .principal(this.quickSightUserArn)
-                        .actions("quicksight:DescribeDataSource","quicksight:DescribeDataSourcePermissions","quicksight:PassDataSource","quicksight:UpdateDataSource","quicksight:DeleteDataSource","quicksight:UpdateDataSourcePermissions")
+                        .actions("quicksight:DescribeDataSource","quicksight:DescribeDataSourcePermissions",
+                                "quicksight:PassDataSource","quicksight:UpdateDataSource","quicksight:DeleteDataSource",
+                                "quicksight:UpdateDataSourcePermissions")
                         .build()
                 )
                 .sslProperties(SslProperties.builder()
@@ -1106,7 +1113,10 @@ public class SaaSBoostInstall {
                 .importMode(DataSetImportMode.DIRECT_QUERY)
                 .permissions(ResourcePermission.builder()
                         .principal(this.quickSightUserArn)
-                        .actions("quicksight:DescribeDataSet","quicksight:DescribeDataSetPermissions","quicksight:PassDataSet","quicksight:DescribeIngestion","quicksight:ListIngestions","quicksight:UpdateDataSet","quicksight:DeleteDataSet","quicksight:CreateIngestion","quicksight:CancelIngestion","quicksight:UpdateDataSetPermissions")
+                        .actions("quicksight:DescribeDataSet","quicksight:DescribeDataSetPermissions",
+                                "quicksight:PassDataSet","quicksight:DescribeIngestion","quicksight:ListIngestions",
+                                "quicksight:UpdateDataSet","quicksight:DeleteDataSet","quicksight:CreateIngestion",
+                                "quicksight:CancelIngestion","quicksight:UpdateDataSetPermissions")
                         .build()
                 )
                 .tags(Tag.builder()
@@ -1137,8 +1147,10 @@ public class SaaSBoostInstall {
                 .map(Role::path)
                 .forEachOrdered(existingRoles::add);
 
-        List<String> serviceRoles = new ArrayList<>(Arrays.asList("elasticloadbalancing.amazonaws.com", "ecs.amazonaws.com",
-                "ecs.application-autoscaling.amazonaws.com", "rds.amazonaws.com", "fsx.amazonaws.com", "autoscaling.amazonaws.com"));
+        List<String> serviceRoles = new ArrayList<>(Arrays.asList("elasticloadbalancing.amazonaws.com",
+                "ecs.amazonaws.com", "ecs.application-autoscaling.amazonaws.com", "rds.amazonaws.com",
+                "fsx.amazonaws.com", "autoscaling.amazonaws.com")
+        );
         for (String serviceRole : serviceRoles) {
             if (existingRoles.contains("/aws-service-role/" + serviceRole + "/")) {
                 LOGGER.info("Service role exists for {}", serviceRole);
@@ -1146,7 +1158,7 @@ public class SaaSBoostInstall {
             }
             LOGGER.info("Creating AWS service role in IAM for {}", serviceRole);
             try {
-                CreateServiceLinkedRoleResponse response = iam.createServiceLinkedRole(request -> request.awsServiceName(serviceRole));
+                iam.createServiceLinkedRole(request -> request.awsServiceName(serviceRole));
             } catch (SdkServiceException iamError) {
                 LOGGER.error("iam:CreateServiceLinkedRole error", iamError);
                 LOGGER.error(getFullStackTrace(iamError));
@@ -1253,7 +1265,7 @@ public class SaaSBoostInstall {
             }
         }
         try {
-            GetParameterResponse response = ssm.getParameter(GetParameterRequest.builder().name("/saas-boost/" + environment + "/SAAS_BOOST_ENVIRONMENT").build());
+            ssm.getParameter(GetParameterRequest.builder().name("/saas-boost/" + environment + "/SAAS_BOOST_ENVIRONMENT").build());
         } catch (SdkServiceException ssmError) {
             outputMessage("Cannot find existing SaaS Boost environment " + environment + " in this AWS account and region.");
             System.exit(2);
@@ -1290,10 +1302,12 @@ public class SaaSBoostInstall {
         LOGGER.info("Getting existing SaaS Boost artifact bucket name from Parameter Store");
         String artifactsBucket = null;
         if (isBlank(this.envName)) {
-            getExistingSaaSBoostEnvironment();
+            this.envName = getExistingSaaSBoostEnvironment();
         }
         try {
-            GetParameterResponse response = ssm.getParameter(request -> request.name("/saas-boost/" + this.envName + "/SAAS_BOOST_BUCKET"));
+            GetParameterResponse response = ssm.getParameter(request -> request
+                    .name("/saas-boost/" + this.envName + "/SAAS_BOOST_BUCKET")
+            );
             artifactsBucket = response.parameter().value();
         } catch (SdkServiceException ssmError) {
             LOGGER.error("ssm:GetParameter error {}", ssmError.getMessage());
@@ -1308,10 +1322,12 @@ public class SaaSBoostInstall {
         LOGGER.info("Getting existing SaaS Boost CloudFormation stack name from Parameter Store");
         String stackName = null;
         if (isBlank(this.envName)) {
-            getExistingSaaSBoostEnvironment();
+            this.envName = getExistingSaaSBoostEnvironment();
         }
         try {
-            GetParameterResponse response = ssm.getParameter(request -> request.name("/saas-boost/" + this.envName + "/SAAS_BOOST_STACK"));
+            GetParameterResponse response = ssm.getParameter(request -> request
+                    .name("/saas-boost/" + this.envName + "/SAAS_BOOST_STACK")
+            );
             stackName = response.parameter().value();
         } catch (ParameterNotFoundException paramStoreError) {
             LOGGER.warn("Parameter /saas-boost/" + this.envName + "/SAAS_BOOST_STACK not found setting to default 'sb-" + this.envName + "'");
@@ -1329,10 +1345,12 @@ public class SaaSBoostInstall {
         LOGGER.info("Getting existing SaaS Boost Lambdas folder from Parameter Store");
         String lambdasFolder = null;
         if (isBlank(this.envName)) {
-            getExistingSaaSBoostEnvironment();
+            this.envName = getExistingSaaSBoostEnvironment();
         }
         try {
-            GetParameterResponse response = ssm.getParameter(request -> request.name("/saas-boost/" + this.envName + "/SAAS_BOOST_LAMBDAS_FOLDER"));
+            GetParameterResponse response = ssm.getParameter(request -> request
+                    .name("/saas-boost/" + this.envName + "/SAAS_BOOST_LAMBDAS_FOLDER")
+            );
             lambdasFolder = response.parameter().value();
         } catch (ParameterNotFoundException paramStoreError) {
             LOGGER.warn("Parameter /saas-boost/" + this.envName + "/SAAS_BOOST_LAMBDAS_FOLDER not found setting to default 'lambdas'");
@@ -1350,11 +1368,13 @@ public class SaaSBoostInstall {
         LOGGER.info("Getting existing SaaS Boost Analytics module deployed from Parameter Store");
         boolean analyticsDeployed = false;
         if (isBlank(this.envName)) {
-            getExistingSaaSBoostEnvironment();
+            this.envName = getExistingSaaSBoostEnvironment();
         }
         try {
-            GetParameterResponse response = ssm.getParameter(request -> request.name("/saas-boost/" + this.envName + "/METRICS_ANALYTICS_DEPLOYED"));
-            analyticsDeployed = Boolean.valueOf(response.parameter().value());
+            GetParameterResponse response = ssm.getParameter(request -> request
+                    .name("/saas-boost/" + this.envName + "/METRICS_ANALYTICS_DEPLOYED")
+            );
+            analyticsDeployed = Boolean.parseBoolean(response.parameter().value());
         } catch (SdkServiceException ssmError) {
             // TODO CloudFormation should own this parameter, not the installer... it's possible the parameter doesn't exist
             // parameter not found is an exception
@@ -1405,9 +1425,18 @@ public class SaaSBoostInstall {
         try {
             List<Path> sourceDirectories = new ArrayList<>();
 
-            // This has to be in specific order because apigw-helper depends on utils
-            sourceDirectories.add(workingDir.resolve(Path.of("layers", "utils")));
-            sourceDirectories.add(workingDir.resolve(Path.of("layers", "apigw-helper")));
+            // The parent pom installs an artifact in the local maven cache that child projects
+            // expect to exist or you'll get a failed to read artifact descriptor error when you
+            // try to build them directly from the child pom. So, before we do anything, install
+            // just the parent pom into the local maven cache (and then we'll actually build the
+            // things we need to below)
+            executeCommand("mvn --non-recursive install", null, workingDir.toAbsolutePath().toFile());
+
+            // Because the parent pom for the layers modules defines its own artifact name
+            // we have to build from the parent pom or maven won't be able to find the individual
+            // artifacts in the local maven cache. The parent pom will build the modules in the
+            // correct order (utils first).
+            sourceDirectories.add(workingDir.resolve(Path.of("layers")));
 
             DirectoryStream<Path> functions = Files.newDirectoryStream(workingDir.resolve(Path.of("functions")), Files::isDirectory);
             functions.forEach(sourceDirectories::add);
@@ -1582,13 +1611,13 @@ public class SaaSBoostInstall {
         String stackId = null;
         try {
             CreateStackResponse cfnResponse = cfn.createStack(CreateStackRequest.builder()
-                            .stackName(stackName)
-                            //.onFailure("DO_NOTHING") // TODO bug on roll back?
-                            //.timeoutInMinutes(90)
-                            .capabilitiesWithStrings("CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND")
-                            .templateURL("https://" + this.s3ArtifactBucket + ".s3.amazonaws.com/saas-boost-metrics-analytics.yaml")
-                            .parameters(templateParameters)
-                            .build()
+                    .stackName(stackName)
+                    //.onFailure("DO_NOTHING") // TODO bug on roll back?
+                    //.timeoutInMinutes(90)
+                    .capabilitiesWithStrings("CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND")
+                    .templateURL("https://" + this.s3ArtifactBucket + ".s3.amazonaws.com/saas-boost-metrics-analytics.yaml")
+                    .parameters(templateParameters)
+                    .build()
             );
             stackId = cfnResponse.stackId();
             LOGGER.info("createMetricsStack::stack id " + stackId);
@@ -1642,7 +1671,10 @@ public class SaaSBoostInstall {
             while (true) {
                 //cfn = CloudFormationClient.create(); // TODO figure out how to extend the timeout in the client
                 try {
-                    DescribeStacksResponse response = cfn.describeStacks(DescribeStacksRequest.builder().stackName(stackId).build());
+                    DescribeStacksResponse response = cfn.describeStacks(DescribeStacksRequest.builder()
+                            .stackName(stackId)
+                            .build()
+                    );
                     if (response.hasStacks()) {
                         Stack stack = response.stacks().get(0);
                         String stackStatus = stack.stackStatusAsString();
@@ -1703,13 +1735,13 @@ public class SaaSBoostInstall {
         this.s3ArtifactBucket = "sb-" + this.envName + "-artifacts-" + parts[0] + "-" + parts[1];
         LOGGER.info("Make S3 Artifact Bucket {}", this.s3ArtifactBucket);
         try {
-            CreateBucketResponse createResponse = s3.createBucket(request -> request
+            s3.createBucket(request -> request
                     .createBucketConfiguration(
                             config -> config.locationConstraint(BucketLocationConstraint.fromValue(AWS_REGION.id()))
                     )
                     .bucket(this.s3ArtifactBucket)
             );
-            PutBucketEncryptionResponse encryptionResponse = s3.putBucketEncryption(request -> request
+            s3.putBucketEncryption(request -> request
                     .serverSideEncryptionConfiguration(
                             config -> config.rules(rules -> rules
                                     .applyServerSideEncryptionByDefault(encrypt -> encrypt
@@ -1719,7 +1751,7 @@ public class SaaSBoostInstall {
                     )
                     .bucket(this.s3ArtifactBucket)
             );
-            PutBucketPolicyResponse policyResponse = s3.putBucketPolicy(request -> request
+            s3.putBucketPolicy(request -> request
                     .policy("{\n" +
                             "    \"Version\": \"2012-10-17\",\n" +
                             "    \"Statement\": [\n" +
@@ -1845,7 +1877,8 @@ public class SaaSBoostInstall {
         }
 
         // Sync files to the web bucket
-        outputMessage("Copying AWS SaaS Boost web application files to s3 web bucket");
+        outputMessage("Synchronizing AWS SaaS Boost web application files to s3 web bucket");
+        cleanUpS3(webBucket, "");
         Map<String, String> metadata = Stream
                 .of(new AbstractMap.SimpleEntry<>("Cache-Control", "no-store"))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));

--- a/layers/apigw-helper/pom.xml
+++ b/layers/apigw-helper/pom.xml
@@ -52,27 +52,6 @@ limitations under the License.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-install-plugin</artifactId>
-                <version>3.0.0-M1</version>
-                <configuration>
-                    <groupId>${project.groupId}</groupId>
-                    <artifactId>${project.artifactId}</artifactId>
-                    <version>${project.version}</version>
-                    <packaging>jar</packaging>
-                    <file>${project.build.directory}/${project.artifactId}.jar</file>
-                    <localRepositoryPath>${project.local-repo.path}</localRepositoryPath>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>install</phase>
-                        <goals>
-                            <goal>install-file</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 

--- a/layers/apigw-helper/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/ApiGatewayHelper.java
+++ b/layers/apigw-helper/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/ApiGatewayHelper.java
@@ -43,12 +43,12 @@ import java.util.stream.Collectors;
 
 public class ApiGatewayHelper {
 
-    private final static Logger LOGGER = LoggerFactory.getLogger(ApiGatewayHelper.class);
-    private final static String AWS_REGION = System.getenv("AWS_REGION");
-    private final static String SAAS_BOOST_ENV = System.getenv("SAAS_BOOST_ENV");
-    private final static Aws4Signer SIG_V4 = Aws4Signer.create();
+    private static final Logger LOGGER = LoggerFactory.getLogger(ApiGatewayHelper.class);
+    private static final String AWS_REGION = System.getenv("AWS_REGION");
+    private static final String SAAS_BOOST_ENV = System.getenv("SAAS_BOOST_ENV");
+    private static final Aws4Signer SIG_V4 = Aws4Signer.create();
     private static SdkHttpClient HTTP_CLIENT = ApacheHttpClient.builder().build();
-    private final static StsClient sts = Utils.sdkClient(StsClient.builder(), StsClient.SERVICE_NAME);;
+    private static final StsClient sts = Utils.sdkClient(StsClient.builder(), StsClient.SERVICE_NAME);
 
     private ApiGatewayHelper() {
         if (Utils.isBlank(AWS_REGION)) {

--- a/layers/apigw-helper/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/ApiGatewayHelper.java
+++ b/layers/apigw-helper/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/ApiGatewayHelper.java
@@ -84,10 +84,12 @@ public class ApiGatewayHelper {
 //        LOGGER.info(buffer.toString());
 
         LOGGER.info("Calling REST API " + apiExecuteRequest.httpRequest().getUri());
-        String responseBody = null;
+        BufferedReader responseReader = null;
+        String responseBody;
         try {
             HttpExecuteResponse apiResponse = HTTP_CLIENT.prepareRequest(apiExecuteRequest).call();
-            responseBody = new BufferedReader(new InputStreamReader(apiResponse.responseBody().get())).lines().collect(Collectors.joining());
+            responseReader = new BufferedReader(new InputStreamReader(apiResponse.responseBody().get(), StandardCharsets.UTF_8));
+            responseBody = responseReader.lines().collect(Collectors.joining());
             LOGGER.info(responseBody);
             if (!apiResponse.httpResponse().isSuccessful()) {
                 throw new Exception("{\"statusCode\":" + apiResponse.httpResponse().statusCode() + ", \"message\":\"" + apiResponse.httpResponse().statusText().get() + "\"}");
@@ -96,6 +98,10 @@ public class ApiGatewayHelper {
             LOGGER.error("HTTP Client error {}", ioe.getMessage());
             LOGGER.error(Utils.getFullStackTrace(ioe));
             throw new RuntimeException(ioe);
+        } finally {
+            if (responseReader != null) {
+                responseReader.close();
+            }
         }
 
         return responseBody;
@@ -163,7 +169,7 @@ public class ApiGatewayHelper {
                     .roleSessionName((Utils.isNotBlank(context)) ? context : SAAS_BOOST_ENV)
             );
 
-            AssumedRoleUser assumedUser = response.assumedRoleUser();
+            //AssumedRoleUser assumedUser = response.assumedRoleUser();
             //LOGGER.info("Assumed IAM User {}", assumedUser.arn());
             //LOGGER.info("Assumed IAM Role {}", assumedUser.assumedRoleId());
 

--- a/layers/pom.xml
+++ b/layers/pom.xml
@@ -24,6 +24,7 @@
         </license>
     </licenses>
     <build>
+        <defaultGoal>clean install</defaultGoal>
         <pluginManagement>
             <plugins>
                 <plugin>


### PR DESCRIPTION
- Update the layers modules pom to default to `clean install` instead of `clean package` so our shared libraries end up in the local maven cache.
- Update the installer to play nice with the new Boost parent pom.
- Remove old maven plugin from the ApiGatewayHelper pom.
- Cosmetic tweaks to lower the checkstyle count.
- Delete existing compiled react files from the web bucket before uploading a fresh build so you see your changes


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
