### PR TITLE
[Fixes #128] Only apply LocationConstraint to S3 bucket in non-us-east-1

### DIFF
--- a/installer/pom.xml
+++ b/installer/pom.xml
@@ -115,6 +115,12 @@ limitations under the License.
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.12.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
             <version>2.13.3</version>

--- a/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostArtifactsBucket.java
+++ b/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostArtifactsBucket.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.amazon.aws.partners.saasfactory.saasboost;
 
 import org.slf4j.Logger;

--- a/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostArtifactsBucket.java
+++ b/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostArtifactsBucket.java
@@ -127,4 +127,8 @@ public class SaaSBoostArtifactsBucket {
         }
         return new SaaSBoostArtifactsBucket(s3, s3ArtifactBucketName, awsRegion);
     }
+
+    public String toString() {
+        return bucketName;
+    }
 }

--- a/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostArtifactsBucket.java
+++ b/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostArtifactsBucket.java
@@ -1,0 +1,114 @@
+package com.amazon.aws.partners.saasfactory.saasboost;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.BucketLocationConstraint;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
+
+import java.nio.file.Path;
+import java.util.UUID;
+
+import static com.amazon.aws.partners.saasfactory.saasboost.SaaSBoostInstall.getFullStackTrace;
+
+public class SaaSBoostArtifactsBucket {
+
+    private static Logger LOGGER = LoggerFactory.getLogger(SaaSBoostArtifactsBucket.class);
+
+    private final S3Client s3;
+    private final String bucketName;
+    private final Region region;
+
+    public SaaSBoostArtifactsBucket(S3Client s3, String bucketName, Region region) {
+        this.s3 = s3;
+        this.bucketName = bucketName;
+        this.region = region;
+    }
+
+    public String getBucketName() {
+        return bucketName;
+    }
+
+    /**
+     *
+     * @see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-bucket-intro.html">S3 Documentation</a>
+     * @return
+     */
+    public String getBucketUrl() {
+        return String.format("https://%s.s3.%s.amazonaws.com/", bucketName, region);
+    }
+
+    public void putFile(Path localPath, Path remotePath) {
+        try {
+            s3.putObject(PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(remotePath.toString())
+                    .build(), RequestBody.fromFile(localPath)
+            );
+        } catch (SdkServiceException s3Error) {
+            LOGGER.error("s3:PutObject error {}", s3Error.getMessage());
+            LOGGER.error(getFullStackTrace(s3Error));
+            throw s3Error;
+        }
+    }
+
+    protected static SaaSBoostArtifactsBucket createS3ArtifactBucket(S3Client s3, String envName, Region awsRegion) {
+        UUID uniqueId = UUID.randomUUID();
+        String[] parts = uniqueId.toString().split("-");  //UUID 29219402-d9e2-4727-afec-2cd61f54fa8f
+
+        String s3ArtifactBucketName = "sb-" + envName + "-artifacts-" + parts[0] + "-" + parts[1];
+        LOGGER.info("Creating S3 Artifact Bucket {}", s3ArtifactBucketName);
+        try {
+            CreateBucketRequest.Builder createBucketRequestBuilder = CreateBucketRequest.builder();
+            if (!(awsRegion.equals(Region.AWS_GLOBAL) || awsRegion.equals(Region.US_EAST_1))) {
+                createBucketRequestBuilder.createBucketConfiguration(config ->
+                        config.locationConstraint(BucketLocationConstraint.fromValue(awsRegion.id())));
+            }
+            createBucketRequestBuilder.bucket(s3ArtifactBucketName);
+            s3.createBucket(createBucketRequestBuilder.build());
+            s3.putBucketEncryption(request -> request
+                    .serverSideEncryptionConfiguration(
+                            config -> config.rules(rules -> rules
+                                    .applyServerSideEncryptionByDefault(encrypt -> encrypt
+                                            .sseAlgorithm(ServerSideEncryption.AES256)
+                                    )
+                            )
+                    )
+                    .bucket(s3ArtifactBucketName)
+            );
+            s3.putBucketPolicy(request -> request
+                    .policy("{\n" +
+                            "    \"Version\": \"2012-10-17\",\n" +
+                            "    \"Statement\": [\n" +
+                            "        {\n" +
+                            "            \"Sid\": \"DenyNonHttps\",\n" +
+                            "            \"Effect\": \"Deny\",\n" +
+                            "            \"Principal\": \"*\",\n" +
+                            "            \"Action\": \"s3:*\",\n" +
+                            "            \"Resource\": [\n" +
+                            "                \"arn:aws:s3:::" + s3ArtifactBucketName + "/*\",\n" +
+                            "                \"arn:aws:s3:::" + s3ArtifactBucketName + "\"\n" +
+                            "            ],\n" +
+                            "            \"Condition\": {\n" +
+                            "                \"Bool\": {\n" +
+                            "                    \"aws:SecureTransport\": \"false\"\n" +
+                            "                }\n" +
+                            "            }\n" +
+                            "        }\n" +
+                            "    ]\n" +
+                            "}")
+                    .bucket(s3ArtifactBucketName)
+            );
+        } catch (SdkServiceException s3Error) {
+            LOGGER.error("s3 error {}", s3Error.getMessage());
+            LOGGER.error(getFullStackTrace(s3Error));
+            throw s3Error;
+        }
+        return new SaaSBoostArtifactsBucket(s3, s3ArtifactBucketName, awsRegion);
+    }
+}

--- a/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostInstall.java
+++ b/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostInstall.java
@@ -1178,7 +1178,7 @@ public class SaaSBoostInstall {
             outputMessage("Uploading " + cloudFormationTemplates.size() + " CloudFormation templates to S3");
             for (Path cloudFormationTemplate : cloudFormationTemplates) {
                 LOGGER.info("Uploading CloudFormation template to S3 " + cloudFormationTemplate.toString() + " -> " + cloudFormationTemplate.getFileName().toString());
-                saasBoostArtifactsBucket.putFile(cloudFormationTemplate, cloudFormationTemplate.getFileName());
+                saasBoostArtifactsBucket.putFile(s3, cloudFormationTemplate, cloudFormationTemplate.getFileName());
             }
         } catch (IOException ioe) {
             LOGGER.error("Error listing resources directory", ioe);
@@ -1306,7 +1306,7 @@ public class SaaSBoostInstall {
             throw ssmError;
         }
         LOGGER.info("Loaded artifacts bucket {}", artifactsBucket);
-        return new SaaSBoostArtifactsBucket(s3, artifactsBucket, AWS_REGION);
+        return new SaaSBoostArtifactsBucket(artifactsBucket, AWS_REGION);
     }
 
     protected String getExistingSaaSBoostStackName() {
@@ -1456,7 +1456,7 @@ public class SaaSBoostInstall {
                                 .collect(Collectors.toSet());
                         for (Path zipFile : lambdaSourcePackage) {
                             LOGGER.info("Uploading Lambda source package to S3 " + zipFile.toString() + " -> " + this.lambdaSourceFolder + "/" + zipFile.getFileName().toString());
-                            saasBoostArtifactsBucket.putFile(zipFile,
+                            saasBoostArtifactsBucket.putFile(s3, zipFile,
                                     Path.of(this.lambdaSourceFolder, zipFile.getFileName().toString()));
                         }
                     }

--- a/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostInstall.java
+++ b/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostInstall.java
@@ -84,7 +84,7 @@ public class SaaSBoostInstall {
     private final String accountId;
     private String envName;
     private Path workingDir;
-    private String s3ArtifactBucket;
+    private SaaSBoostArtifactsBucket saasBoostArtifactsBucket;
     private String lambdaSourceFolder = "lambdas";
     private String stackName;
     private Map<String, String> baseStackDetails = new HashMap<>();
@@ -347,7 +347,8 @@ public class SaaSBoostInstall {
 
         // Create the S3 artifacts bucket
         outputMessage("Creating S3 artifacts bucket");
-        createS3ArtifactBucket();
+        saasBoostArtifactsBucket = SaaSBoostArtifactsBucket.createS3ArtifactBucket(s3, envName, AWS_REGION);
+        outputMessage("Created S3 artifacts bucket: " + saasBoostArtifactsBucket.getBucketName());
 
         // Copy the CloudFormation templates
         outputMessage("Uploading CloudFormation templates to S3 artifacts bucket");
@@ -396,7 +397,7 @@ public class SaaSBoostInstall {
         }
 
         outputMessage("Check the admin email box for the temporary password.");
-        outputMessage("AWS SaaS Boost Artifacts Bucket: " + s3ArtifactBucket);
+        outputMessage("AWS SaaS Boost Artifacts Bucket: " + saasBoostArtifactsBucket.getBucketName());
         outputMessage("AWS SaaS Boost Console URL is: " + webUrl);
     }
 
@@ -415,7 +416,7 @@ public class SaaSBoostInstall {
         }
 
         // First, upload the (potentially) modified CloudFormation templates up to S3
-        outputMessage("Copy CloudFormation template files to S3 artifacts bucket " + this.s3ArtifactBucket);
+        outputMessage("Copy CloudFormation template files to S3 artifacts bucket " + saasBoostArtifactsBucket.getBucketName());
         copyTemplateFilesToS3();
 
         // Grab the current Lambda folder. We are going to upload the (potentially) modified Lambda functions to a
@@ -488,7 +489,7 @@ public class SaaSBoostInstall {
 
         // Delete the old lambdas zip files
         outputMessage("Delete files from previous Lambda folder: " + existingLambdaSourceFolder);
-        cleanUpS3(s3ArtifactBucket, existingLambdaSourceFolder);
+        cleanUpS3(saasBoostArtifactsBucket.getBucketName(), existingLambdaSourceFolder);
 
         outputMessage("Update of SaaS Boost environment " + this.envName + " complete.");
     }
@@ -565,9 +566,9 @@ public class SaaSBoostInstall {
         deleteCloudFormationStack(this.stackName);
 
         // Finally, remove the S3 artifacts bucket that this installer created outside of CloudFormation
-        LOGGER.info("Clean up s3 bucket: " + this.s3ArtifactBucket);
-        cleanUpS3(this.s3ArtifactBucket, null);
-        s3.deleteBucket(r -> r.bucket(this.s3ArtifactBucket));
+        LOGGER.info("Clean up s3 bucket: " + saasBoostArtifactsBucket.getBucketName());
+        cleanUpS3(saasBoostArtifactsBucket.getBucketName(), null);
+        s3.deleteBucket(r -> r.bucket(saasBoostArtifactsBucket.getBucketName()));
 
         outputMessage("Delete of SaaS Boost environment " + this.envName + " complete.");
     }
@@ -1177,17 +1178,7 @@ public class SaaSBoostInstall {
             outputMessage("Uploading " + cloudFormationTemplates.size() + " CloudFormation templates to S3");
             for (Path cloudFormationTemplate : cloudFormationTemplates) {
                 LOGGER.info("Uploading CloudFormation template to S3 " + cloudFormationTemplate.toString() + " -> " + cloudFormationTemplate.getFileName().toString());
-                try {
-                    s3.putObject(PutObjectRequest.builder()
-                            .bucket(this.s3ArtifactBucket)
-                            .key(cloudFormationTemplate.getFileName().toString())
-                            .build(), RequestBody.fromFile(cloudFormationTemplate)
-                    );
-                } catch (SdkServiceException s3Error) {
-                    LOGGER.error("s3:PutObject error {}", s3Error.getMessage());
-                    LOGGER.error(getFullStackTrace(s3Error));
-                    throw s3Error;
-                }
+                saasBoostArtifactsBucket.putFile(cloudFormationTemplate, cloudFormationTemplate.getFileName());
             }
         } catch (IOException ioe) {
             LOGGER.error("Error listing resources directory", ioe);
@@ -1246,7 +1237,7 @@ public class SaaSBoostInstall {
 
     protected void loadExistingSaaSBoostEnvironment() {
         this.envName = getExistingSaaSBoostEnvironment();
-        this.s3ArtifactBucket = getExistingSaaSBoostArtifactBucket();
+        this.saasBoostArtifactsBucket = getExistingSaaSBoostArtifactBucket();
         this.lambdaSourceFolder = getExistingSaaSBoostLambdasFolder();
         this.stackName = getExistingSaaSBoostStackName();
         this.baseStackDetails = getExistingSaaSBoostStackDetails();
@@ -1298,7 +1289,7 @@ public class SaaSBoostInstall {
 //        return valid;
 //    }
 
-    protected String getExistingSaaSBoostArtifactBucket() {
+    protected SaaSBoostArtifactsBucket getExistingSaaSBoostArtifactBucket() {
         LOGGER.info("Getting existing SaaS Boost artifact bucket name from Parameter Store");
         String artifactsBucket = null;
         if (isBlank(this.envName)) {
@@ -1315,7 +1306,7 @@ public class SaaSBoostInstall {
             throw ssmError;
         }
         LOGGER.info("Loaded artifacts bucket {}", artifactsBucket);
-        return artifactsBucket;
+        return new SaaSBoostArtifactsBucket(s3, artifactsBucket, AWS_REGION);
     }
 
     protected String getExistingSaaSBoostStackName() {
@@ -1465,17 +1456,8 @@ public class SaaSBoostInstall {
                                 .collect(Collectors.toSet());
                         for (Path zipFile : lambdaSourcePackage) {
                             LOGGER.info("Uploading Lambda source package to S3 " + zipFile.toString() + " -> " + this.lambdaSourceFolder + "/" + zipFile.getFileName().toString());
-                            try {
-                                s3.putObject(PutObjectRequest.builder()
-                                        .bucket(this.s3ArtifactBucket)
-                                        .key(this.lambdaSourceFolder + "/" + zipFile.getFileName().toString())
-                                        .build(), RequestBody.fromFile(zipFile)
-                                );
-                            } catch (SdkServiceException s3Error) {
-                                LOGGER.error("s3:PutObject error {}", s3Error.getMessage());
-                                LOGGER.error(getFullStackTrace(s3Error));
-                                throw s3Error;
-                            }
+                            saasBoostArtifactsBucket.putFile(zipFile,
+                                    Path.of(this.lambdaSourceFolder, zipFile.getFileName().toString()));
                         }
                     }
                 } else {
@@ -1494,7 +1476,7 @@ public class SaaSBoostInstall {
         List<Parameter> templateParameters = new ArrayList<>();
         templateParameters.add(Parameter.builder().parameterKey("Environment").parameterValue(envName).build());
         templateParameters.add(Parameter.builder().parameterKey("AdminEmailAddress").parameterValue(adminEmail).build());
-        templateParameters.add(Parameter.builder().parameterKey("SaaSBoostBucket").parameterValue(s3ArtifactBucket).build());
+        templateParameters.add(Parameter.builder().parameterKey("SaaSBoostBucket").parameterValue(saasBoostArtifactsBucket.getBucketName()).build());
         templateParameters.add(Parameter.builder().parameterKey("Version").parameterValue(VERSION).build());
         templateParameters.add(Parameter.builder().parameterKey("DeployActiveDirectory").parameterValue(useActiveDirectory.toString()).build());
         templateParameters.add(Parameter.builder().parameterKey("ADPasswordParam").parameterValue(activeDirectoryPasswordParam).build());
@@ -1507,7 +1489,7 @@ public class SaaSBoostInstall {
                             //.onFailure("DO_NOTHING") // TODO bug on roll back?
                             //.timeoutInMinutes(90)
                             .capabilitiesWithStrings("CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND")
-                            .templateURL("https://" + this.s3ArtifactBucket + ".s3.amazonaws.com/saas-boost.yaml")
+                            .templateURL(saasBoostArtifactsBucket.getBucketUrl() + "saas-boost.yaml")
                             .parameters(templateParameters)
                             .build()
             );
@@ -1554,7 +1536,7 @@ public class SaaSBoostInstall {
             UpdateStackResponse updateStackResponse = cfn.updateStack(UpdateStackRequest.builder()
                     .stackName(stackName)
                     .capabilitiesWithStrings("CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND")
-                    .templateURL("https://" + this.s3ArtifactBucket + ".s3.amazonaws.com/" + yamlFile)
+                    .templateURL(saasBoostArtifactsBucket.getBucketUrl() + yamlFile)
                     .parameters(templateParameters)
                     .build()
             );
@@ -1600,7 +1582,7 @@ public class SaaSBoostInstall {
         templateParameters.add(Parameter.builder().parameterKey("Environment").parameterValue(this.envName).build());
         templateParameters.add(Parameter.builder().parameterKey("LambdaSourceFolder").parameterValue(this.lambdaSourceFolder).build());
         templateParameters.add(Parameter.builder().parameterKey("MetricUserPasswordSSMParameter").parameterValue(dbPasswordSSMParameter).build());
-        templateParameters.add(Parameter.builder().parameterKey("SaaSBoostBucket").parameterValue(this.s3ArtifactBucket).build());
+        templateParameters.add(Parameter.builder().parameterKey("SaaSBoostBucket").parameterValue(saasBoostArtifactsBucket.getBucketName()).build());
         templateParameters.add(Parameter.builder().parameterKey("LoggingBucket").parameterValue(baseStackDetails.get("LoggingBucket")).build());
         templateParameters.add(Parameter.builder().parameterKey("DatabaseName").parameterValue(databaseName).build());
         templateParameters.add(Parameter.builder().parameterKey("PublicSubnet1").parameterValue(baseStackDetails.get("PublicSubnet1")).build());
@@ -1619,7 +1601,7 @@ public class SaaSBoostInstall {
                     //.onFailure("DO_NOTHING") // TODO bug on roll back?
                     //.timeoutInMinutes(90)
                     .capabilitiesWithStrings("CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND")
-                    .templateURL("https://" + this.s3ArtifactBucket + ".s3.amazonaws.com/saas-boost-metrics-analytics.yaml")
+                    .templateURL(saasBoostArtifactsBucket.getBucketUrl() + "saas-boost-metrics-analytics.yaml")
                     .parameters(templateParameters)
                     .build()
             );
@@ -1730,62 +1712,6 @@ public class SaaSBoostInstall {
             }
         }
         return exists;
-    }
-
-    protected void createS3ArtifactBucket() {
-        UUID uniqueId = UUID.randomUUID();
-        String[] parts = uniqueId.toString().split("-");  //UUID 29219402-d9e2-4727-afec-2cd61f54fa8f
-
-        this.s3ArtifactBucket = "sb-" + this.envName + "-artifacts-" + parts[0] + "-" + parts[1];
-        LOGGER.info("Make S3 Artifact Bucket {}", this.s3ArtifactBucket);
-        try {
-            CreateBucketRequest.Builder createBucketRequestBuilder = CreateBucketRequest.builder();
-            if (!(AWS_REGION.equals(Region.AWS_GLOBAL) || AWS_REGION.equals(Region.US_EAST_1))) {
-                createBucketRequestBuilder.createBucketConfiguration(config ->
-                        config.locationConstraint(BucketLocationConstraint.fromValue(AWS_REGION.id())));
-            }
-            createBucketRequestBuilder.bucket(this.s3ArtifactBucket);
-            s3.createBucket(createBucketRequestBuilder.build());
-            s3.putBucketEncryption(request -> request
-                    .serverSideEncryptionConfiguration(
-                            config -> config.rules(rules -> rules
-                                    .applyServerSideEncryptionByDefault(encrypt -> encrypt
-                                            .sseAlgorithm(ServerSideEncryption.AES256)
-                                    )
-                            )
-                    )
-                    .bucket(this.s3ArtifactBucket)
-            );
-            s3.putBucketPolicy(request -> request
-                    .policy("{\n" +
-                            "    \"Version\": \"2012-10-17\",\n" +
-                            "    \"Statement\": [\n" +
-                            "        {\n" +
-                            "            \"Sid\": \"DenyNonHttps\",\n" +
-                            "            \"Effect\": \"Deny\",\n" +
-                            "            \"Principal\": \"*\",\n" +
-                            "            \"Action\": \"s3:*\",\n" +
-                            "            \"Resource\": [\n" +
-                            "                \"arn:aws:s3:::" + this.s3ArtifactBucket + "/*\",\n" +
-                            "                \"arn:aws:s3:::" + this.s3ArtifactBucket + "\"\n" +
-                            "            ],\n" +
-                            "            \"Condition\": {\n" +
-                            "                \"Bool\": {\n" +
-                            "                    \"aws:SecureTransport\": \"false\"\n" +
-                            "                }\n" +
-                            "            }\n" +
-                            "        }\n" +
-                            "    ]\n" +
-                            "}")
-                    .bucket(this.s3ArtifactBucket)
-            );
-        } catch (SdkServiceException s3Error) {
-            LOGGER.error("s3 error {}", s3Error.getMessage());
-            LOGGER.error(getFullStackTrace(s3Error));
-            throw s3Error;
-        }
-
-        outputMessage("Created S3 artifacts bucket: " + this.s3ArtifactBucket);
     }
 
     protected String buildAndCopyWebApp() {

--- a/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostInstall.java
+++ b/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostInstall.java
@@ -348,7 +348,7 @@ public class SaaSBoostInstall {
         // Create the S3 artifacts bucket
         outputMessage("Creating S3 artifacts bucket");
         saasBoostArtifactsBucket = SaaSBoostArtifactsBucket.createS3ArtifactBucket(s3, envName, AWS_REGION);
-        outputMessage("Created S3 artifacts bucket: " + saasBoostArtifactsBucket.getBucketName());
+        outputMessage("Created S3 artifacts bucket: " + saasBoostArtifactsBucket);
 
         // Copy the CloudFormation templates
         outputMessage("Uploading CloudFormation templates to S3 artifacts bucket");
@@ -397,7 +397,7 @@ public class SaaSBoostInstall {
         }
 
         outputMessage("Check the admin email box for the temporary password.");
-        outputMessage("AWS SaaS Boost Artifacts Bucket: " + saasBoostArtifactsBucket.getBucketName());
+        outputMessage("AWS SaaS Boost Artifacts Bucket: " + saasBoostArtifactsBucket);
         outputMessage("AWS SaaS Boost Console URL is: " + webUrl);
     }
 
@@ -416,7 +416,7 @@ public class SaaSBoostInstall {
         }
 
         // First, upload the (potentially) modified CloudFormation templates up to S3
-        outputMessage("Copy CloudFormation template files to S3 artifacts bucket " + saasBoostArtifactsBucket.getBucketName());
+        outputMessage("Copy CloudFormation template files to S3 artifacts bucket " + saasBoostArtifactsBucket);
         copyTemplateFilesToS3();
 
         // Grab the current Lambda folder. We are going to upload the (potentially) modified Lambda functions to a
@@ -566,7 +566,7 @@ public class SaaSBoostInstall {
         deleteCloudFormationStack(this.stackName);
 
         // Finally, remove the S3 artifacts bucket that this installer created outside of CloudFormation
-        LOGGER.info("Clean up s3 bucket: " + saasBoostArtifactsBucket.getBucketName());
+        LOGGER.info("Clean up s3 bucket: " + saasBoostArtifactsBucket);
         cleanUpS3(saasBoostArtifactsBucket.getBucketName(), null);
         s3.deleteBucket(r -> r.bucket(saasBoostArtifactsBucket.getBucketName()));
 

--- a/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostInstall.java
+++ b/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostInstall.java
@@ -1739,12 +1739,13 @@ public class SaaSBoostInstall {
         this.s3ArtifactBucket = "sb-" + this.envName + "-artifacts-" + parts[0] + "-" + parts[1];
         LOGGER.info("Make S3 Artifact Bucket {}", this.s3ArtifactBucket);
         try {
-            s3.createBucket(request -> request
-                    .createBucketConfiguration(
-                            config -> config.locationConstraint(BucketLocationConstraint.fromValue(AWS_REGION.id()))
-                    )
-                    .bucket(this.s3ArtifactBucket)
-            );
+            CreateBucketRequest.Builder createBucketRequestBuilder = CreateBucketRequest.builder();
+            if (!(AWS_REGION.equals(Region.AWS_GLOBAL) || AWS_REGION.equals(Region.US_EAST_1))) {
+                createBucketRequestBuilder.createBucketConfiguration(config ->
+                        config.locationConstraint(BucketLocationConstraint.fromValue(AWS_REGION.id())));
+            }
+            createBucketRequestBuilder.bucket(this.s3ArtifactBucket);
+            s3.createBucket(createBucketRequestBuilder.build());
             s3.putBucketEncryption(request -> request
                     .serverSideEncryptionConfiguration(
                             config -> config.rules(rules -> rules

--- a/installer/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostArtifactsBucketTest.java
+++ b/installer/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostArtifactsBucketTest.java
@@ -1,0 +1,127 @@
+package com.amazon.aws.partners.saasfactory.saasboost;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
+
+import java.nio.file.Path;
+
+import static org.junit.Assert.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SaaSBoostArtifactsBucketTest {
+
+    private static final String ENV_NAME = "env-name";
+
+    @Mock
+    S3Client mockS3;
+
+    @Before
+    public void reset() {
+        Mockito.reset(mockS3);
+    }
+
+    @Test
+    public void putFileTest() throws Exception {
+        ArgumentCaptor<PutObjectRequest> putObjectRequestArgumentCaptor =
+                ArgumentCaptor.forClass(PutObjectRequest.class);
+        ArgumentCaptor<RequestBody> requestBodyArgumentCaptor = ArgumentCaptor.forClass(RequestBody.class);
+
+        SaaSBoostArtifactsBucket testBucket =
+                SaaSBoostArtifactsBucket.createS3ArtifactBucket(mockS3, ENV_NAME, Region.US_EAST_1);
+        Path localPathToTestPut = Path.of(this.getClass().getClassLoader().getResource("template.yaml").toURI());
+        Path exampleRemotePath = Path.of("dir", "dir2");
+        testBucket.putFile(mockS3, localPathToTestPut, exampleRemotePath);
+        Mockito.verify(mockS3).putObject(putObjectRequestArgumentCaptor.capture(), requestBodyArgumentCaptor.capture());
+        assertEquals("Put object to the wrong bucket.",
+                testBucket.getBucketName(), putObjectRequestArgumentCaptor.getValue().bucket());
+        assertEquals("Put object to the wrong location.",
+                exampleRemotePath.toString(), putObjectRequestArgumentCaptor.getValue().key());
+        assertEquals("Put different length object to remote location. Wrong file?",
+                localPathToTestPut.toFile().length(), requestBodyArgumentCaptor.getValue().contentLength());
+    }
+
+    @Test
+    public void createBucketLocationConstraintTest() {
+        ArgumentCaptor<CreateBucketRequest> createBucketRequestArgumentCaptor =
+                ArgumentCaptor.forClass(CreateBucketRequest.class);
+
+        SaaSBoostArtifactsBucket.createS3ArtifactBucket(mockS3, ENV_NAME, Region.US_EAST_1);
+        Mockito.verify(mockS3).createBucket(createBucketRequestArgumentCaptor.capture());
+        // expected, actual
+        CreateBucketRequest capturedCreateBucketRequest = createBucketRequestArgumentCaptor.getValue();
+        if (capturedCreateBucketRequest.createBucketConfiguration() != null) {
+            // if no createBucketConfiguration is passed in the createBucketRequest,
+            // there is implicitly no location constraint (because constraint must be part of the config)
+            assertNull("No location constraint should be provided for buckets in us-east-1",
+                    createBucketRequestArgumentCaptor.getValue().createBucketConfiguration().locationConstraint());
+        }
+        Mockito.reset(mockS3);
+
+        SaaSBoostArtifactsBucket.createS3ArtifactBucket(mockS3, ENV_NAME, Region.US_WEST_2);
+        Mockito.verify(mockS3).createBucket(createBucketRequestArgumentCaptor.capture());
+        assertEquals("Location constraint should be provided for buckets in us-west-2",
+                BucketLocationConstraint.US_WEST_2,
+                createBucketRequestArgumentCaptor.getValue().createBucketConfiguration().locationConstraint());
+    }
+
+    @Test
+    public void createBucketServerSideEncryptionTest() {
+        ArgumentCaptor<PutBucketEncryptionRequest> putBucketEncryptionRequestArgumentCaptor =
+                ArgumentCaptor.forClass(PutBucketEncryptionRequest.class);
+        SaaSBoostArtifactsBucket createdBucket =
+                SaaSBoostArtifactsBucket.createS3ArtifactBucket(mockS3, ENV_NAME, Region.US_EAST_1);
+        Mockito.verify(mockS3).putBucketEncryption(putBucketEncryptionRequestArgumentCaptor.capture());
+        PutBucketEncryptionRequest capturedPutBucketEncryptionRequest =
+                putBucketEncryptionRequestArgumentCaptor.getValue();
+        assertEquals("Put encryption to the wrong bucket.",
+                createdBucket.getBucketName(), capturedPutBucketEncryptionRequest.bucket());
+        assertNotNull(capturedPutBucketEncryptionRequest.serverSideEncryptionConfiguration());
+        assertNotNull(capturedPutBucketEncryptionRequest.serverSideEncryptionConfiguration().rules());
+        assertTrue(capturedPutBucketEncryptionRequest.serverSideEncryptionConfiguration().rules().contains(
+                ServerSideEncryptionRule.builder().applyServerSideEncryptionByDefault(
+                        ServerSideEncryptionByDefault.builder().sseAlgorithm(ServerSideEncryption.AES256).build()
+                ).build()));
+    }
+
+    @Test
+    public void createBucketBucketPolicyTest() {
+        ArgumentCaptor<PutBucketPolicyRequest> putBucketPolicyArgumentCaptor =
+                ArgumentCaptor.forClass(PutBucketPolicyRequest.class);
+        SaaSBoostArtifactsBucket createdBucket =
+                SaaSBoostArtifactsBucket.createS3ArtifactBucket(mockS3, ENV_NAME, Region.US_EAST_1);
+        Mockito.verify(mockS3).putBucketPolicy(putBucketPolicyArgumentCaptor.capture());
+        PutBucketPolicyRequest capturedPutBucketPolicyRequest = putBucketPolicyArgumentCaptor.getValue();
+        assertEquals("Put bucket policy to the wrong bucket.",
+                createdBucket.getBucketName(), capturedPutBucketPolicyRequest.bucket());
+        assertNotNull(capturedPutBucketPolicyRequest.policy());
+        assertEquals("{\n" +
+                "    \"Version\": \"2012-10-17\",\n" +
+                "    \"Statement\": [\n" +
+                "        {\n" +
+                "            \"Sid\": \"DenyNonHttps\",\n" +
+                "            \"Effect\": \"Deny\",\n" +
+                "            \"Principal\": \"*\",\n" +
+                "            \"Action\": \"s3:*\",\n" +
+                "            \"Resource\": [\n" +
+                "                \"arn:aws:s3:::" + createdBucket.getBucketName() + "/*\",\n" +
+                "                \"arn:aws:s3:::" + createdBucket.getBucketName() + "\"\n" +
+                "            ],\n" +
+                "            \"Condition\": {\n" +
+                "                \"Bool\": {\n" +
+                "                    \"aws:SecureTransport\": \"false\"\n" +
+                "                }\n" +
+                "            }\n" +
+                "        }\n" +
+                "    ]\n" +
+                "}", capturedPutBucketPolicyRequest.policy());
+    }
+}

--- a/installer/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostInstallTest.java
+++ b/installer/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostInstallTest.java
@@ -83,8 +83,6 @@ public class SaaSBoostInstallTest {
 
     @Test
     public void testGetCloudFormationParameterMap() throws Exception {
-        System.out.println("testGetCloudFormationParameterMap");
-
         // The input map represents the existing CloudFormation parameter values.
         // These will either be the template defaults, or they will be the parameter
         // values read from a created stack with the describeStacks call.


### PR DESCRIPTION
This PR changes how the `LocationConstraint` parameter is handled when creating the artifacts bucket in the SaaS Boost installer: only applying it to the created bucket when the region is *not* us-east-1, as [LocationConstraint is not valid in us-east-1](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/model/BucketLocationConstraint.html)

Additionally, this PR introduces a little refactoring to more easily test the artifact bucket creation logic in the SaaS Boost Installer and adds unit tests for the same. Each of the functions in the new `SaaSBoostArtifactsBucket` class is copied from the old Installer to hopefully make reviewing easier.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
