### PR TITLE
Fix credentials tests when using a non-default profile. Fixes #148

### DIFF
--- a/installer/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/clients/RefreshingProfileDefaultCredentialsProviderTest.java
+++ b/installer/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/clients/RefreshingProfileDefaultCredentialsProviderTest.java
@@ -100,6 +100,9 @@ public class RefreshingProfileDefaultCredentialsProviderTest {
         System.setProperty(
                 ProfileFileSystemSetting.AWS_SHARED_CREDENTIALS_FILE.property(),
                 fakeProfileFilename);
+        System.setProperty(
+                ProfileFileSystemSetting.AWS_PROFILE.property(),
+                ProfileFileSystemSetting.AWS_PROFILE.defaultValue());
         DefaultCredentialsProvider defaultCredentialsProvider = DefaultCredentialsProvider.create();
         runUpdatingCredentialsProviderTest(defaultCredentialsProvider, false);
     }
@@ -113,6 +116,7 @@ public class RefreshingProfileDefaultCredentialsProviderTest {
                 TEST_CREDENTIALS[0]);
         RefreshingProfileDefaultCredentialsProvider refreshingCredentialsProvider = RefreshingProfileDefaultCredentialsProvider.builder()
                 .profileFilename(fakeProfileFilename)
+                .profileName(ProfileFileSystemSetting.AWS_PROFILE.defaultValue())
                 .build();
         runUpdatingCredentialsProviderTest(refreshingCredentialsProvider, true);
     }
@@ -174,7 +178,9 @@ public class RefreshingProfileDefaultCredentialsProviderTest {
                 SdkSystemSetting.AWS_SESSION_TOKEN.property(),
                 SdkSystemSetting.AWS_ROLE_SESSION_NAME.property(),
                 SdkSystemSetting.AWS_ROLE_ARN.property(),
-                SdkSystemSetting.AWS_WEB_IDENTITY_TOKEN_FILE.property()
+                SdkSystemSetting.AWS_WEB_IDENTITY_TOKEN_FILE.property(),
+                ProfileFileSystemSetting.AWS_SHARED_CREDENTIALS_FILE.property(),
+                ProfileFileSystemSetting.AWS_PROFILE.property()
         };
 
         private final Map<String,String> hiddenProperties;


### PR DESCRIPTION
The original test I wrote in https://github.com/awslabs/aws-saas-boost/commit/0380a1220dcd071f140b3e079e7ccf4f4c1f63a9 assumed you had the default profile name (or no profile name) configured. This commit fixes that by explicitly configuring the default profile in the test and resetting the configuration once the test is done.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
