### PR TITLE
Load base stack details if creating metrics and analytics stack during install

### DIFF
--- a/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostInstall.java
+++ b/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostInstall.java
@@ -362,6 +362,9 @@ public class SaaSBoostInstall {
 
         if (useAnalyticsModule) {
             LOGGER.info("Install metrics and analytics module");
+            // The analytics module stack reads baseStackDetails for its CloudFormation template parameters
+            // because we're not yet creating the analytics resources as a nested child stack of the main stack
+            this.baseStackDetails = getExistingSaaSBoostStackDetails();
             installAnalyticsModule();
         }
 


### PR DESCRIPTION
The metrics and analytics stack is currently not a nested stack for SaaS Boost like the other modules are. The metrics and analytics stack requires parameter values from the result of the main SaaS Boost stack. When we run the installer for an update or other non-install purpose, we load the existing SaaS Boost environment data. We do not do this for the install action. If we are installing the metrics and analytics stack as part of a clean/initial installation of SaaS Boost, we need to pull the main stack details from CloudFormation when it completes prior to running the metrics and analytics stack.

Resolves issue #144 

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
