### PR TITLE
Upgrade aws-lambda-java-log4j2 to 1.5.0 to upgrade log4j2 to 2.17.0

### DIFF
--- a/functions/alb-update/pom.xml
+++ b/functions/alb-update/pom.xml
@@ -116,11 +116,6 @@ limitations under the License.
             <artifactId>aws-lambda-java-log4j2</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.16.0</version>
-        </dependency>
-        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>elasticloadbalancingv2</artifactId>
             <version>2.14.26</version>

--- a/functions/alb-update/pom.xml
+++ b/functions/alb-update/pom.xml
@@ -114,7 +114,6 @@ limitations under the License.
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-log4j2</artifactId>
-            <version>1.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/functions/ecs-deploy/pom.xml
+++ b/functions/ecs-deploy/pom.xml
@@ -114,7 +114,6 @@ limitations under the License.
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-log4j2</artifactId>
-            <version>1.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/functions/ecs-deploy/pom.xml
+++ b/functions/ecs-deploy/pom.xml
@@ -116,11 +116,6 @@ limitations under the License.
             <artifactId>aws-lambda-java-log4j2</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.16.0</version>
-        </dependency>
-        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>s3</artifactId>
             <version>2.14.26</version>

--- a/functions/ecs-service-update/pom.xml
+++ b/functions/ecs-service-update/pom.xml
@@ -109,11 +109,6 @@ limitations under the License.
             <artifactId>aws-lambda-java-log4j2</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.16.0</version>
-        </dependency>
-        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>ecs</artifactId>
             <version>2.14.26</version>

--- a/functions/ecs-service-update/pom.xml
+++ b/functions/ecs-service-update/pom.xml
@@ -107,7 +107,6 @@ limitations under the License.
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-log4j2</artifactId>
-            <version>1.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/functions/ecs-shutdown-services/pom.xml
+++ b/functions/ecs-shutdown-services/pom.xml
@@ -114,7 +114,6 @@ limitations under the License.
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-log4j2</artifactId>
-            <version>1.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/functions/ecs-shutdown-services/pom.xml
+++ b/functions/ecs-shutdown-services/pom.xml
@@ -116,11 +116,6 @@ limitations under the License.
             <artifactId>aws-lambda-java-log4j2</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.16.0</version>
-        </dependency>
-        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>ecs</artifactId>
             <version>2.14.26</version>

--- a/functions/ecs-startup-services/pom.xml
+++ b/functions/ecs-startup-services/pom.xml
@@ -114,7 +114,6 @@ limitations under the License.
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-log4j2</artifactId>
-            <version>1.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/functions/ecs-startup-services/pom.xml
+++ b/functions/ecs-startup-services/pom.xml
@@ -116,11 +116,6 @@ limitations under the License.
             <artifactId>aws-lambda-java-log4j2</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.16.0</version>
-        </dependency>
-        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>ecs</artifactId>
             <version>2.14.26</version>

--- a/functions/onboarding-notification/pom.xml
+++ b/functions/onboarding-notification/pom.xml
@@ -109,11 +109,6 @@ limitations under the License.
             <artifactId>aws-lambda-java-log4j2</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.16.0</version>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-joda</artifactId>
             <version>2.11.0</version>

--- a/functions/onboarding-notification/pom.xml
+++ b/functions/onboarding-notification/pom.xml
@@ -107,7 +107,6 @@ limitations under the License.
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-log4j2</artifactId>
-            <version>1.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/functions/system-rest-api-client/pom.xml
+++ b/functions/system-rest-api-client/pom.xml
@@ -114,7 +114,6 @@ limitations under the License.
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-log4j2</artifactId>
-            <version>1.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/functions/system-rest-api-client/pom.xml
+++ b/functions/system-rest-api-client/pom.xml
@@ -115,10 +115,5 @@ limitations under the License.
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-log4j2</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.16.0</version>
-        </dependency>
     </dependencies>
 </project>

--- a/installer/pom.xml
+++ b/installer/pom.xml
@@ -120,21 +120,6 @@ limitations under the License.
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>2.17.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <version>2.17.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.16.0</version>
-        </dependency>
-        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>cloudformation</artifactId>
             <version>${aws.java.sdk.version}</version>

--- a/layers/pom.xml
+++ b/layers/pom.xml
@@ -40,4 +40,12 @@
             </plugins>
         </pluginManagement>
     </build>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>${log4j.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/layers/utils/pom.xml
+++ b/layers/utils/pom.xml
@@ -57,11 +57,6 @@ limitations under the License.
 
     <dependencies>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.30</version>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <version>2.11.0</version>

--- a/metering-billing/lambdas/pom.xml
+++ b/metering-billing/lambdas/pom.xml
@@ -115,7 +115,6 @@ limitations under the License.
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-log4j2</artifactId>
-            <version>1.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/metering-billing/lambdas/pom.xml
+++ b/metering-billing/lambdas/pom.xml
@@ -117,11 +117,6 @@ limitations under the License.
             <artifactId>aws-lambda-java-log4j2</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.16.0</version>
-        </dependency>
-        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>lambda</artifactId>
             <version>2.14.26</version>

--- a/metrics-analytics/metrics-java-sdk/pom.xml
+++ b/metrics-analytics/metrics-java-sdk/pom.xml
@@ -68,12 +68,6 @@ limitations under the License.
         </dependency>
 
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.30</version>
-        </dependency>
-
-        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>1.2.3</version>

--- a/pom.xml
+++ b/pom.xml
@@ -35,9 +35,9 @@
         <surefire.version>2.22.2</surefire.version>
         <!-- dependency versions -->
         <!-- aws-lambda-java-log4j2 and log4j versions should be upgraded in tandem -->
-        <aws-lambda-java-log4j2.version>1.5.0</aws-lambda-java-log4j2.version>
+        <aws-lambda-java-log4j2.version>1.5.1</aws-lambda-java-log4j2.version>
         <aws.java.sdk.version>2.17.70</aws.java.sdk.version>
-        <log4j.version>2.17.0</log4j.version>
+        <log4j.version>2.17.1</log4j.version>
         <junit.version>4.13.2</junit.version>
     </properties>
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -34,10 +34,10 @@
         <!-- TODO upgrade to surefire 3 on release? -->
         <surefire.version>2.22.2</surefire.version>
         <!-- dependency versions -->
+        <!-- aws-lambda-java-log4j2 and log4j versions should be upgraded in tandem -->
         <aws-lambda-java-log4j2.version>1.5.0</aws-lambda-java-log4j2.version>
-        <slf4j-api.version>1.7.21</slf4j-api.version>
-        <slf4j-log4j12.version>1.7.21</slf4j-log4j12.version>
         <aws.java.sdk.version>2.17.70</aws.java.sdk.version>
+        <log4j.version>2.17.0</log4j.version>
         <junit.version>4.13.2</junit.version>
     </properties>
     <dependencyManagement>
@@ -55,6 +55,25 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+    <dependencies>
+        <!-- predefine all log4j versions for centralized logging management -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+        <!-- log4j-slf4j-impl brings in its own version of the slf4j-api -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+    </dependencies>
     <build>
         <defaultGoal>clean package</defaultGoal>
         <!-- this defines default plugin configuration when referenced by all inheriting modules -->

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
         <!-- TODO upgrade to surefire 3 on release? -->
         <surefire.version>2.22.2</surefire.version>
         <!-- dependency versions -->
+        <aws-lambda-java-log4j2.version>1.5.0</aws-lambda-java-log4j2.version>
         <slf4j-api.version>1.7.21</slf4j-api.version>
         <slf4j-log4j12.version>1.7.21</slf4j-log4j12.version>
         <aws.java.sdk.version>2.17.70</aws.java.sdk.version>
@@ -46,6 +47,11 @@
                 <artifactId>junit</artifactId>
                 <version>${junit.version}</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-lambda-java-log4j2</artifactId>
+                <version>${aws-lambda-java-log4j2.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -52,21 +52,20 @@
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-lambda-java-log4j2</artifactId>
                 <version>${aws-lambda-java-log4j2.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>
-        <!-- predefine all log4j versions for centralized logging management -->
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>${log4j.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <version>${log4j.version}</version>
-        </dependency>
         <!-- log4j-slf4j-impl brings in its own version of the slf4j-api -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/resources/custom-resources/cidr-dynamodb/pom.xml
+++ b/resources/custom-resources/cidr-dynamodb/pom.xml
@@ -106,7 +106,6 @@ limitations under the License.
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-log4j2</artifactId>
-            <version>1.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/resources/custom-resources/cidr-dynamodb/pom.xml
+++ b/resources/custom-resources/cidr-dynamodb/pom.xml
@@ -108,11 +108,6 @@ limitations under the License.
             <artifactId>aws-lambda-java-log4j2</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.16.0</version>
-        </dependency>
-        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>dynamodb</artifactId>
             <version>2.13.76</version>

--- a/resources/custom-resources/clear-s3-bucket/pom.xml
+++ b/resources/custom-resources/clear-s3-bucket/pom.xml
@@ -104,11 +104,6 @@ limitations under the License.
             <artifactId>aws-lambda-java-log4j2</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.16.0</version>
-        </dependency>
-        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>s3</artifactId>
             <version>2.13.76</version>

--- a/resources/custom-resources/clear-s3-bucket/pom.xml
+++ b/resources/custom-resources/clear-s3-bucket/pom.xml
@@ -102,7 +102,6 @@ limitations under the License.
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-log4j2</artifactId>
-            <version>1.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/resources/custom-resources/disable-instance-protection/pom.xml
+++ b/resources/custom-resources/disable-instance-protection/pom.xml
@@ -106,7 +106,6 @@ limitations under the License.
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-log4j2</artifactId>
-            <version>1.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/resources/custom-resources/disable-instance-protection/pom.xml
+++ b/resources/custom-resources/disable-instance-protection/pom.xml
@@ -108,11 +108,6 @@ limitations under the License.
             <artifactId>aws-lambda-java-log4j2</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.16.0</version>
-        </dependency>
-        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>autoscaling</artifactId>
             <version>2.13.76</version>

--- a/resources/custom-resources/fsx-dns-name/pom.xml
+++ b/resources/custom-resources/fsx-dns-name/pom.xml
@@ -106,7 +106,6 @@ limitations under the License.
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-log4j2</artifactId>
-            <version>1.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/resources/custom-resources/fsx-dns-name/pom.xml
+++ b/resources/custom-resources/fsx-dns-name/pom.xml
@@ -108,11 +108,6 @@ limitations under the License.
             <artifactId>aws-lambda-java-log4j2</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.16.0</version>
-        </dependency>
-        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>fsx</artifactId>
             <version>2.13.76</version>

--- a/resources/custom-resources/rds-bootstrap/pom.xml
+++ b/resources/custom-resources/rds-bootstrap/pom.xml
@@ -99,7 +99,6 @@ limitations under the License.
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-log4j2</artifactId>
-            <version>1.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/resources/custom-resources/rds-bootstrap/pom.xml
+++ b/resources/custom-resources/rds-bootstrap/pom.xml
@@ -101,11 +101,6 @@ limitations under the License.
             <artifactId>aws-lambda-java-log4j2</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.16.0</version>
-        </dependency>
-        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>url-connection-client</artifactId>
             <version>2.13.76</version>

--- a/resources/custom-resources/rds-options/pom.xml
+++ b/resources/custom-resources/rds-options/pom.xml
@@ -102,7 +102,6 @@ limitations under the License.
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-log4j2</artifactId>
-            <version>1.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/resources/custom-resources/rds-options/pom.xml
+++ b/resources/custom-resources/rds-options/pom.xml
@@ -104,11 +104,6 @@ limitations under the License.
             <artifactId>aws-lambda-java-log4j2</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.16.0</version>
-        </dependency>
-        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>url-connection-client</artifactId>
             <version>2.13.76</version>

--- a/resources/custom-resources/redshift-table/pom.xml
+++ b/resources/custom-resources/redshift-table/pom.xml
@@ -102,7 +102,6 @@ limitations under the License.
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-log4j2</artifactId>
-            <version>1.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/resources/custom-resources/redshift-table/pom.xml
+++ b/resources/custom-resources/redshift-table/pom.xml
@@ -103,11 +103,6 @@ limitations under the License.
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-log4j2</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.16.0</version>
-        </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazon.redshift/redshift-jdbc42 -->
         <dependency>
             <groupId>com.amazon.redshift</groupId>

--- a/services/metric-service/pom.xml
+++ b/services/metric-service/pom.xml
@@ -116,11 +116,6 @@ limitations under the License.
             <artifactId>aws-lambda-java-log4j2</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.16.0</version>
-        </dependency>
-        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>cloudwatch</artifactId>
             <version>2.14.26</version>

--- a/services/metric-service/pom.xml
+++ b/services/metric-service/pom.xml
@@ -114,7 +114,6 @@ limitations under the License.
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-log4j2</artifactId>
-            <version>1.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/services/onboarding-service/pom.xml
+++ b/services/onboarding-service/pom.xml
@@ -114,7 +114,6 @@ limitations under the License.
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-log4j2</artifactId>
-            <version>1.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/services/onboarding-service/pom.xml
+++ b/services/onboarding-service/pom.xml
@@ -116,11 +116,6 @@ limitations under the License.
             <artifactId>aws-lambda-java-log4j2</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.16.0</version>
-        </dependency>
-        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>dynamodb</artifactId>
             <version>2.14.26</version>

--- a/services/quotas-service/pom.xml
+++ b/services/quotas-service/pom.xml
@@ -107,7 +107,6 @@ limitations under the License.
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-log4j2</artifactId>
-            <version>1.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/services/quotas-service/pom.xml
+++ b/services/quotas-service/pom.xml
@@ -109,11 +109,6 @@ limitations under the License.
             <artifactId>aws-lambda-java-log4j2</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.16.0</version>
-        </dependency>
-        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>servicequotas</artifactId>
             <version>2.14.26</version>

--- a/services/settings-service/pom.xml
+++ b/services/settings-service/pom.xml
@@ -139,7 +139,6 @@ limitations under the License.
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-log4j2</artifactId>
-            <version>1.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/services/settings-service/pom.xml
+++ b/services/settings-service/pom.xml
@@ -141,11 +141,6 @@ limitations under the License.
             <artifactId>aws-lambda-java-log4j2</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.16.0</version>
-        </dependency>
-        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>ssm</artifactId>
             <version>2.14.26</version>

--- a/services/tenant-service/pom.xml
+++ b/services/tenant-service/pom.xml
@@ -109,11 +109,6 @@ limitations under the License.
             <artifactId>aws-lambda-java-log4j2</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.16.0</version>
-        </dependency>
-        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>dynamodb</artifactId>
             <version>2.14.26</version>

--- a/services/tenant-service/pom.xml
+++ b/services/tenant-service/pom.xml
@@ -107,7 +107,6 @@ limitations under the License.
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-log4j2</artifactId>
-            <version>1.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/services/user-service/pom.xml
+++ b/services/user-service/pom.xml
@@ -107,7 +107,6 @@ limitations under the License.
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-log4j2</artifactId>
-            <version>1.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/services/user-service/pom.xml
+++ b/services/user-service/pom.xml
@@ -109,11 +109,6 @@ limitations under the License.
             <artifactId>aws-lambda-java-log4j2</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.16.0</version>
-        </dependency>
-        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>cognitoidentityprovider</artifactId>
             <version>2.14.26</version>


### PR DESCRIPTION
This commit bumps us up so all transitive dependencies use log4j2 2.17.0 to address the DOS vulnerability in 2.16.0.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
