### PR TITLE
Fix API Gateway throttling in installer update

### DIFF
--- a/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/clients/AwsClientBuilderFactory.java
+++ b/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/clients/AwsClientBuilderFactory.java
@@ -18,10 +18,14 @@ package com.amazon.aws.partners.saasfactory.saasboost.clients;
 
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import software.amazon.awssdk.awscore.retry.AwsRetryPolicy;
 import software.amazon.awssdk.core.SdkClient;
+import software.amazon.awssdk.core.retry.RetryPolicy;
+import software.amazon.awssdk.core.retry.RetryUtils;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.apigateway.ApiGatewayClient;
 import software.amazon.awssdk.services.apigateway.ApiGatewayClientBuilder;
+import software.amazon.awssdk.services.apigateway.model.CreateDeploymentRequest;
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
 import software.amazon.awssdk.services.cloudformation.CloudFormationClientBuilder;
 import software.amazon.awssdk.services.ecr.EcrClient;
@@ -38,6 +42,8 @@ import software.amazon.awssdk.services.ssm.SsmClient;
 import software.amazon.awssdk.services.ssm.SsmClientBuilder;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.StsClientBuilder;
+
+import java.time.Duration;
 
 public class AwsClientBuilderFactory {
 
@@ -64,7 +70,16 @@ public class AwsClientBuilderFactory {
     }
 
     public ApiGatewayClientBuilder apiGatewayBuilder() {
-        return decorateBuilderWithDefaults(ApiGatewayClient.builder());
+        // override throttling policy to wait 5 seconds if we're throttled on CreateDeployment
+        // https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html
+        return decorateBuilderWithDefaults(ApiGatewayClient.builder())
+                .overrideConfiguration(config -> config.retryPolicy(AwsRetryPolicy.addRetryConditions(
+                        RetryPolicy.builder().throttlingBackoffStrategy(retryPolicyContext -> {
+                            if (retryPolicyContext.originalRequest() instanceof CreateDeploymentRequest) {
+                                return Duration.ofSeconds(5);
+                            }
+                            return null;
+                        }).build())));
     }
 
     public CloudFormationClientBuilder cloudFormationBuilder() {

--- a/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/clients/AwsClientBuilderFactory.java
+++ b/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/clients/AwsClientBuilderFactory.java
@@ -21,7 +21,6 @@ import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
 import software.amazon.awssdk.awscore.retry.AwsRetryPolicy;
 import software.amazon.awssdk.core.SdkClient;
 import software.amazon.awssdk.core.retry.RetryPolicy;
-import software.amazon.awssdk.core.retry.RetryUtils;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.apigateway.ApiGatewayClient;
 import software.amazon.awssdk.services.apigateway.ApiGatewayClientBuilder;


### PR DESCRIPTION
This commit adds a custom ThrottlingBackoffStrategy to explicitly wait 5
seconds if the installer is throttled on createDeployment, because the
current limit for that API is 1 request per 5 seconds per account.

This commit fixes #167 .

These throttles are happening because the API Gateway limits for `createDeployment` are 1 request every 5 seconds, but in the installer we're calling `createDeployment` one immediately after the other.

This is a regression introduced by https://github.com/awslabs/aws-saas-boost/commit/0380a1220dcd071f140b3e079e7ccf4f4c1f63a9, which removed the explicitly set `RetryPolicy` for the APIGatewayClient. However, the original solution only partially solved the problem by incorrectly setting the `maxRetries` to one more than it should have been, leading to a significantly higher likelihood of passing the 5 second wait period inside of the allowed retries, although not guaranteeing success: 
```
default throttled base delay: 500ms
default max retries: 3
max retries before regression: 4

exponential delay function: wait (baseDelay * (1 << numberRetries))
jitter function: wait rand(0.5*exponentialDelay, 1.5*exponentialDelay)
|--------------------------------------------------------|
|             Num Retries              |   3    |   4    |
|--------------------------------------|--------|--------|
| Min ms from first request to failure | 1750ms | 3750ms |
|--------------------------------------|--------|--------|
| Max ms from first request to failure | 3750ms | 11250ms|
|--------------------------------------|--------|--------|
```
Reference:
* [Default delay and attempts](https://github.com/aws/aws-sdk-java-v2/blob/master/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/retry/SdkDefaultRetrySetting.java)
* [Default retry mode](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/core/retry/RetryMode.html)
* [Default backoff strategy is EqualJitter](https://github.com/aws/aws-sdk-java-v2/blob/master/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/backoff/BackoffStrategy.java#L65)
* [Exponential delay function](https://github.com/aws/aws-sdk-java-v2/blob/master/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/backoff/BackoffStrategy.java#L42-L45)
* [Equal Jitter function](https://github.com/aws/aws-sdk-java-v2/blob/master/core/sdk-core/src/main/java/software/amazon/awssdk/core/retry/backoff/EqualJitterBackoffStrategy.java#L65-L69)

The real fix here is to add a custom `ThrottlingBackoffStrategy` which will explicitly wait 5 seconds whenever the installer is throttled on a `CreateDeploymentRequest` call, ensuring that
1. we don't use more bandwidth than we need to
2. we make our second call only when we know it will succeed, avoiding unnecessary wait time and avoiding failures
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
