### PR TITLE
Fix unit test to be OS platform independent. Clean up PowerShell script

### DIFF
--- a/installer/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostInstallTest.java
+++ b/installer/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostInstallTest.java
@@ -93,7 +93,7 @@ public class SaaSBoostInstallTest {
         input.put("NumericParameter", "1"); // Let's pretend that we overwrote the default the first time around
 
         // Fill up standard input with a response for the Keyboard class
-        System.setIn(new ByteArrayInputStream("keyboard input\n".getBytes(StandardCharsets.UTF_8)));
+        System.setIn(new ByteArrayInputStream(("keyboard input" + System.lineSeparator()).getBytes(StandardCharsets.UTF_8)));
 
         Path cloudFormationTemplate = Path.of(this.getClass().getClassLoader().getResource("template.yaml").toURI());
         Map<String, String> actual = SaaSBoostInstall.getCloudFormationParameterMap(cloudFormationTemplate, input);


### PR DESCRIPTION
Resolves #151. The keyboard input reader class breaks standard input into tokens based on the operating system's default line ending character(s), but one of our unit tests was explicitly adding a `\n` newline instead of using `System.lineSeparator()`. This caused the unit test to fail when executed on Windows.

Also cleaned up the PowerShell script for the installer to match the latest from the Bash script version.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
