### PR TITLE
Fix Java sample app dependency clashes. Don't use deprecated Spring

### DIFF
--- a/resources/tenant-onboarding.yaml
+++ b/resources/tenant-onboarding.yaml
@@ -722,8 +722,8 @@ Resources:
         !If
           - ProvisionEFS
           - - Name: !GetAtt efs.Outputs.FileSystemId
-              EfsVolumeConfiguration:
-                FileSystemId: !GetAtt efs.Outputs.FileSystemId
+              EFSVolumeConfiguration:
+                FilesystemId: !GetAtt efs.Outputs.FileSystemId
           - !If
             - ProvisionFsx
             - - Name: !GetAtt fsx.Outputs.FSxFileSystemID

--- a/samples/java/Dockerfile
+++ b/samples/java/Dockerfile
@@ -11,10 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM amazoncorretto:11-alpine-jdk AS build
-RUN ["/usr/lib/jvm/default-jvm/bin/jlink", "--compress=2", "--module-path", "/usr/lib/jvm/default-jvm/jmods", "--add-modules", "java.base,java.logging,java.xml,jdk.unsupported,java.sql,java.naming,java.desktop,java.management,java.security.jgss,java.instrument", "--output", "/jdk-mini"]
+FROM amazoncorretto:11-alpine AS build
+RUN ["/usr/lib/jvm/default-jvm/bin/jlink", "--compress=2", "--no-man-pages", "--module-path", "/usr/lib/jvm/default-jvm/jmods", "--add-modules", "java.base,java.logging,java.xml,jdk.unsupported,java.sql,java.naming,java.desktop,java.management,java.security.jgss,java.instrument,java.net.http", "--output", "/jdk-mini"]
 
-FROM alpine
+FROM public.ecr.aws/docker/library/alpine:latest
 COPY --from=build /jdk-mini /opt/jdk/
 VOLUME /mnt
 ENV PATH=$PATH:/opt/jdk/bin

--- a/samples/java/pom.xml
+++ b/samples/java/pom.xml
@@ -40,6 +40,7 @@ limitations under the License.
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>2.6.1</version>
                 <configuration>
                     <mainClass>com.amazon.aws.partners.saasfactory.HelloWorld</mainClass>
                     <layout>WAR</layout>
@@ -95,7 +96,7 @@ limitations under the License.
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-jasper</artifactId>
-            <version>9.0.35</version>
+            <version>9.0.55</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -141,12 +142,12 @@ limitations under the License.
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.11.0</version>
+            <version>2.13.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.11.0</version>
+            <version>2.13.0</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/samples/java/src/main/java/com/amazon/aws/partners/saasfactory/repository/CategoryDaoImpl.java
+++ b/samples/java/src/main/java/com/amazon/aws/partners/saasfactory/repository/CategoryDaoImpl.java
@@ -44,13 +44,13 @@ public class CategoryDaoImpl implements CategoryDao {
     @Override
     public Category getCategory(Integer categoryId) {
         LOGGER.info("CategoryDao::getCategory " + categoryId);
-        return jdbc.queryForObject("SELECT category_id, category FROM category WHERE category_id = ?", new Object[]{categoryId}, new CategoryRowMapper());
+        return jdbc.queryForObject("SELECT category_id, category FROM category WHERE category_id = ?", new CategoryRowMapper(), categoryId);
     }
 
     @Override
     public Category getCategoryByName(String name) {
         LOGGER.info("CategoryDao::getCategoryByName " + name);
-        return jdbc.queryForObject("SELECT category_id, category FROM category WHERE category = ?", new Object[]{name}, new CategoryRowMapper());
+        return jdbc.queryForObject("SELECT category_id, category FROM category WHERE category = ?", new CategoryRowMapper(), name);
     }
 
     @Override

--- a/samples/java/src/main/java/com/amazon/aws/partners/saasfactory/repository/OrderDaoImpl.java
+++ b/samples/java/src/main/java/com/amazon/aws/partners/saasfactory/repository/OrderDaoImpl.java
@@ -62,7 +62,7 @@ public class OrderDaoImpl implements OrderDao {
     @Override
     public Order getOrder(Integer orderId) throws Exception {
         String sql = SELECT_ORDER_SQL.concat(" WHERE order_fulfillment_id = ?");
-        return jdbc.queryForObject(sql, new Object[]{orderId}, new OrderRowMapper());
+        return jdbc.queryForObject(sql, new OrderRowMapper(), orderId);
     }
 
     @Override
@@ -222,7 +222,7 @@ public class OrderDaoImpl implements OrderDao {
         LOGGER.info("OrderDao::deleteOrder " + order);
 
         deleteOrderLineItems(order.getId());
-        int affectedRows = jdbc.update(DELETE_ORDER_SQL, new Object[]{order.getId()});
+        int affectedRows = jdbc.update(DELETE_ORDER_SQL, order.getId());
         if (affectedRows != 1) {
             throw new RuntimeException("Delete failed for order " + order.getId());
         }
@@ -232,7 +232,7 @@ public class OrderDaoImpl implements OrderDao {
     private List<OrderLineItem> getOrderLineItems(Integer orderId) throws Exception {
         String sql = "SELECT order_line_item_id, order_fulfillment_id, product_id, quantity, unit_purchase_price " +
                 "FROM order_line_item WHERE order_fulfillment_id = ?";
-        List<OrderLineItem> lineItems = jdbc.query(sql, new Object[]{orderId}, new OrderLineItemRowMapper());
+        List<OrderLineItem> lineItems = jdbc.query(sql, new OrderLineItemRowMapper(), orderId);
         return lineItems;
     }
 

--- a/samples/java/src/main/java/com/amazon/aws/partners/saasfactory/repository/ProductDaoImpl.java
+++ b/samples/java/src/main/java/com/amazon/aws/partners/saasfactory/repository/ProductDaoImpl.java
@@ -55,7 +55,7 @@ public class ProductDaoImpl implements ProductDao {
     public Product getProduct(Integer productId) {
         LOGGER.info("ProductDao::getProduct " + productId);
         String sql = SELECT_PRODUCT_SQL.concat(" WHERE p.product_id = ?");
-        return jdbc.query(sql, new Object[]{productId}, new ProductMapper());
+        return jdbc.query(sql, new ProductMapper(), productId);
     }
 
     @Override
@@ -126,17 +126,17 @@ public class ProductDaoImpl implements ProductDao {
                 category = categoryDao.saveCategory(category);
             }
         }
-        jdbc.update(UPDATE_PRODUCT_SQL, new Object[]{product.getSku(), product.getName(), product.getPrice(), product.getImageName(), product.getId()});
+        jdbc.update(UPDATE_PRODUCT_SQL, product.getSku(), product.getName(), product.getPrice(), product.getImageName(), product.getId());
         updateProductCategories(product);
         return product;
     }
 
     private void updateProductCategories(Product product) {
-        jdbc.update("DELETE FROM product_categories WHERE product_id = ?", new Object[]{product.getId()});
+        jdbc.update("DELETE FROM product_categories WHERE product_id = ?", product.getId());
         if (!product.getCategories().isEmpty()) {
             // replace this
             for (Category category : product.getCategories()) {
-                jdbc.update("INSERT INTO product_categories (product_id, category_id) VALUES (?, ?)", new Object[]{product.getId(), category.getId()});
+                jdbc.update("INSERT INTO product_categories (product_id, category_id) VALUES (?, ?)", product.getId(), category.getId());
             }
         }
     }
@@ -144,7 +144,7 @@ public class ProductDaoImpl implements ProductDao {
     @Override
     public Product deleteProduct(Product product) {
         LOGGER.info("ProductDao::deleteProduct " + product);
-        int affectedRows = jdbc.update(DELETE_PRODUCT_SQL, new Object[]{product.getId()});
+        int affectedRows = jdbc.update(DELETE_PRODUCT_SQL, product.getId());
         if (affectedRows != 1) {
             throw new RuntimeException("Delete failed for product " + product.getId());
         }


### PR DESCRIPTION
Resolves issue #182.

When we updated the Spring Boot dependencies for the sample app to upgrade log4j it pulled in some incompatible duplicate dependencies on the Tag Library Descriptors (TLD) utilities from Apache and the Jackson JSON library core.

This patch also updates the data access classes to not use the newly deprecated methods from Spring JDBC.

Resolves issue #179  (that I can't reproduce). As best as I can tell, those messages are warnings not errors. CloudFormation properly creates an ECS Task Definition with a functioning Docker volumes config even if the capitalization of the properties in the CloudFormation template do not match what's in the latest documentation. This patch matches the EFS volume definition capitalization with the latest CloudFormation documentation.

In our attempt to use the ECR Public Gallery for docker base images to avoid throttling by Docker in CI/CD scenarios, we moved to a base Amazon Corretto image that was incompatible with running the sample app under Alpine Linux. This patch reverts to using the Amazon Corretto docker image from Docker Hub to make Alpine work.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
