### PR TITLE
java.nio.file.Path uses OS dependent file separator character but we

### DIFF
--- a/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostArtifactsBucket.java
+++ b/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostArtifactsBucket.java
@@ -62,7 +62,10 @@ public class SaaSBoostArtifactsBucket {
             LOGGER.debug("Putting {} to Artifacts bucket: {}", localPath, this);
             s3.putObject(PutObjectRequest.builder()
                     .bucket(bucketName)
-                    .key(remotePath.toString())
+                    // java.nio.file.Path will use OS dependent file separators, so when we run the installer on
+                    // Windows, the S3 key will have back slashes instead of forward slashes. The CloudFormation
+                    // definitions of the Lambda functions will always use forward slashes for the S3Key property.
+                    .key(remotePath.toString().replace('\\', '/'))
                     .build(), RequestBody.fromFile(localPath)
             );
         } catch (SdkServiceException s3Error) {

--- a/installer/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostArtifactsBucketTest.java
+++ b/installer/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostArtifactsBucketTest.java
@@ -60,7 +60,7 @@ public class SaaSBoostArtifactsBucketTest {
         assertEquals("Put object to the wrong bucket.",
                 testBucket.getBucketName(), putObjectRequestArgumentCaptor.getValue().bucket());
         assertEquals("Put object to the wrong location.",
-                exampleRemotePath.toString(), putObjectRequestArgumentCaptor.getValue().key());
+                exampleRemotePath.toString().replace('\\', '/'), putObjectRequestArgumentCaptor.getValue().key());
         assertEquals("Put different length object to remote location. Wrong file?",
                 localPathToTestPut.toFile().length(), requestBodyArgumentCaptor.getValue().contentLength());
     }


### PR DESCRIPTION
java.nio.file.Path will use OS dependent file separators, so when we run the installer on Windows, the S3 key for objects uploaded to the SaaS Boost artifacts bucket will have back slashes `\` instead of forward slashes. The CloudFormation definitions of the Lambda functions will always use forward slashes for the S3Key property so the creation of the Lambda resources will fail on key not found.

This patch simply replaces all backslashes with forward slashes when putting objects to S3.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
