### PR TITLE
Resolve OS dependent path separators in S3 keys for web app files

### DIFF
--- a/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostInstall.java
+++ b/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostInstall.java
@@ -1796,7 +1796,10 @@ public class SaaSBoostInstall {
                     LOGGER.info("Uploading to S3 " + fileToUpload.toString() + " -> " + key);
                     s3.putObject(PutObjectRequest.builder()
                             .bucket(webBucket)
-                            .key(key)
+                            // java.nio.file.Path will use OS dependent file separators, so when we run the installer on
+                            // Windows, the S3 key will have back slashes instead of forward slashes. The CloudFormation
+                            // definitions of the Lambda functions will always use forward slashes for the S3Key property.
+                            .key(key.replace('\\', '/'))
                             .metadata(metadata)
                             .build(), RequestBody.fromFile(fileToUpload)
                     );

--- a/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostInstall.java
+++ b/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostInstall.java
@@ -1798,7 +1798,7 @@ public class SaaSBoostInstall {
                             .bucket(webBucket)
                             // java.nio.file.Path will use OS dependent file separators, so when we run the installer on
                             // Windows, the S3 key will have back slashes instead of forward slashes. The CloudFormation
-                            // definitions of the Lambda functions will always use forward slashes for the S3Key property.
+                            // definitions of Lambda functions will always use forward slashes for the S3Key property.
                             .key(key.replace('\\', '/'))
                             .metadata(metadata)
                             .build(), RequestBody.fromFile(fileToUpload)


### PR DESCRIPTION
Same fix as 3c700cce1460b329ef805840f0ef293add62f453 this time for the web bucket file uploads

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
