### PR TITLE
Add Tier UI and implement default tiers.

### DIFF
--- a/client/web/src/_nav.js
+++ b/client/web/src/_nav.js
@@ -80,6 +80,13 @@ const _nav = [
   },
   {
     component: CNavItem,
+    name: 'Tiers',
+    to: '/tiers',
+    icon: <CIcon icon={cilLayers} customClassName="nav-icon" />,
+    disabled: false,
+  },
+  {
+    component: CNavItem,
     name: 'Users',
     to: '/users',
     icon: <CIcon icon={cilPeople} customClassName="nav-icon" />,

--- a/client/web/src/dashboard/DashboardComponent.js
+++ b/client/web/src/dashboard/DashboardComponent.js
@@ -199,7 +199,7 @@ export const DashboardComponent = (props) => {
                 <Col xs={12} md={6} lg={6}>
                   <strong className="h4 mb-1">Tiers</strong>
                   {tiers.map((tier) => (
-                    <dl key={tier}>
+                    <dl key={tier.id}>
                       <dt className="mb-1">{tier.name}</dt>
                       <dd className="mb-3">
                         {isEmpty(tier.description)

--- a/client/web/src/onboarding/OnboardingFormComponent.js
+++ b/client/web/src/onboarding/OnboardingFormComponent.js
@@ -83,6 +83,7 @@ export default function OnboardingFormComponent(props) {
   }
 
   const getTiers = (tiers) => {
+    const defaultTier = tiers.filter((tier) => tier.defaultTier)[0]
     const options = tiers.map((tier) => {
       return (
         <option value={tier.name} key={tier.id}>
@@ -91,7 +92,7 @@ export default function OnboardingFormComponent(props) {
       )
     })
     return (
-      <SaasBoostSelect type="select" name="tier" label="Select Tier">
+      <SaasBoostSelect type="select" name="tier" label="Select Tier" value={defaultTier?.name}>
         {options}
       </SaasBoostSelect>
     )

--- a/client/web/src/routes.js
+++ b/client/web/src/routes.js
@@ -16,6 +16,7 @@
 
 import React from 'react'
 import { TenantRoutes } from './tenant'
+import { TierRoutes } from './tier'
 import { UserRoutes } from './users'
 import { OnboardingRoutes } from './onboarding'
 import { SettingsRoutes } from './settings'
@@ -26,6 +27,6 @@ const routes = [
   { path: '/', exact: true, name: 'Home' },
   { path: '/dashboard', exact: true, name: 'Dashboard', component: Dashboard },
   { path: '/summary', exact: true, name: 'Dashboard', component: Dashboard },
-].concat(TenantRoutes, UserRoutes, OnboardingRoutes, SettingsRoutes, MetricsRoutes)
+].concat(TenantRoutes, TierRoutes, UserRoutes, OnboardingRoutes, SettingsRoutes, MetricsRoutes)
 
 export default routes

--- a/client/web/src/settings/ApplicationComponent.js
+++ b/client/web/src/settings/ApplicationComponent.js
@@ -105,7 +105,7 @@ export function ApplicationComponent(props) {
     let uncleanedInitialTierValues = Object.assign({}, defaults, tierValuesCopy)
     return {
       ...uncleanedInitialTierValues,
-      provisionDb: !!uncleanedInitialTierValues.database,
+      provisionDb: !!tierValuesCopy.database,
       database: !!uncleanedInitialTierValues.database ? {
         ...uncleanedInitialTierValues.database,
         //This is frail, but try to see if the incoming password is base64d
@@ -116,10 +116,10 @@ export function ApplicationComponent(props) {
         ),
         encryptedPassword: uncleanedInitialTierValues?.database?.password,
       } : defaults.database,
-      provisionFS: !!uncleanedInitialTierValues.filesystem,
+      provisionFS: !!tierValuesCopy.filesystem,
       filesystem: !!uncleanedInitialTierValues.filesystem ? {
         ...uncleanedInitialTierValues.filesystem,
-        fsx: !!getFsx(uncleanedInitialTierValues?.filesystem?.fsx) || defaults.filesystem.fsx
+        fsx: getFsx(uncleanedInitialTierValues?.filesystem?.fsx) || defaults.filesystem.fsx
       } : defaults.filesystem,
     }
   }
@@ -156,13 +156,13 @@ export function ApplicationComponent(props) {
     let initialTierValues = {}
     for (var i = 0; i < tiers.length; i++) {
       var tierName = tiers[i].name
-      initialTierValues[tierName] = generateAppConfigOrDefaultInitialValuesForTier(thisService?.tiers[tierName], defaultTierValues, fileSystemType)
+      initialTierValues[tierName] = generateAppConfigOrDefaultInitialValuesForTier(Object.assign({}, thisService?.tiers[defaultTierName]), defaultTierValues, fileSystemType)
     }
     return {
       ...thisService,
       name: thisService?.name || serviceName,
       path: thisService?.path || '/*',
-      public: thisService?.public || false,
+      public: thisService?.public || true,
       healthCheckUrl: thisService?.healthCheckUrl || '/',
       containerPort: thisService?.containerPort || 0,
       containerTag: thisService?.containerTag || 'latest',

--- a/client/web/src/tier/TierCreateContainer.js
+++ b/client/web/src/tier/TierCreateContainer.js
@@ -1,0 +1,96 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { PropTypes } from 'prop-types'
+import React, { Component } from 'react'
+import TierForm from './TierFormComponent'
+import { connect } from 'react-redux'
+import { withRouter } from 'react-router'
+
+import { dismissError, createTierThunk } from './ducks'
+
+const mapDispatchToProps = {
+  createTierThunk,
+  dismissError,
+}
+
+const mapStateToProps = (state) => {
+  return { tiers: state.tiers }
+}
+
+class TierCreateContainer extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {}
+
+    this.saveTier = this.saveTier.bind(this)
+    this.handleError = this.handleError.bind(this)
+  }
+
+  async saveTier(values, { setSubmitting, resetForm }) {
+    const { createTierThunk, history } = this.props
+    const tier = values
+    const { id } = tier
+
+    try {
+      const createdResponse = await createTierThunk(tier)
+      if (!createdResponse.error) {
+        history.push(`/tiers/${createdResponse.payload.id}`)
+      } else {
+        setSubmitting(false)
+        resetForm({ values })
+      }
+    } catch (e) {
+      setSubmitting(false)
+      resetForm({ values })
+    }
+  }
+
+  handleCancel = () => {
+    const { history } = this.props
+    history.goBack()
+  }
+
+  handleError = () => {
+    const { dismissError } = this.props
+    dismissError()
+  }
+
+  render() {
+    const { error } = this.props.tiers
+    return (
+      <TierForm
+        handleCancel={this.handleCancel}
+        handleSubmit={this.saveTier}
+        error={error}
+        handleError={this.handleError}
+      />
+    )
+  }
+}
+
+TierCreateContainer.propTypes = {
+  createTierThunk: PropTypes.func,
+  history: PropTypes.object,
+  tiers: PropTypes.object,
+  dismissError: PropTypes.func,
+}
+
+export const TierCreateContainerWithRouter = connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(withRouter(TierCreateContainer))
+
+export default TierCreateContainerWithRouter

--- a/client/web/src/tier/TierFormComponent.js
+++ b/client/web/src/tier/TierFormComponent.js
@@ -1,0 +1,123 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { PropTypes } from 'prop-types'
+import React from 'react'
+import { Formik, Form } from 'formik'
+import * as Yup from 'yup'
+import { Row, Col, Card, Button, Alert } from 'react-bootstrap'
+import { SaasBoostInput, SaasBoostTextarea } from '../components/FormComponents'
+
+const initialTier = {
+  id: null,
+  name: '',
+  description: '',
+}
+
+const TierForm = (props) => {
+  const {
+    handleSubmit,
+    handleCancel,
+    tier = initialTier,
+    error,
+    dismissError,
+  } = props
+
+  const showError = (error, dismissError) => {
+    if (!!error) {
+      return (
+        <Row>
+          <Col md={6}>
+            <Alert
+              color="danger"
+              isOpen={!!error}
+              toggle={() => dismissError()}
+            >
+              <h4 className="alert-heading">Error</h4>
+              <p>{error}</p>
+            </Alert>
+          </Col>
+        </Row>
+      )
+    }
+    return undefined
+  }
+
+  return (
+    <Formik
+      initialValues={tier}
+      enableReinitialize={true}
+      validationSchema={Yup.object({
+        name: Yup.string()
+          .max(100, 'Must be 100 characters or less.')
+          .required('Required'),
+        description: Yup.string().max(100, 'Must be 100 characters or less.')
+      })}
+      onSubmit={handleSubmit}
+    >
+      {(formik) => (
+        <Form>
+          {tier.id && (
+            <input
+              type="hidden"
+              name="id"
+              id="id"
+              value={tier.id}
+            />
+          )}
+          <div className="animated fadeIn">
+            {showError(error, dismissError)}
+            <Row>
+              <Col lg={6}>
+                <Card>
+                  <Card.Header>Tier Details</Card.Header>
+                  <Card.Body>
+                    <SaasBoostInput label="Name" name="name" type="text" />
+                    <SaasBoostTextarea label="Description" name="description" type="text" />
+                  </Card.Body>
+                  <Card.Footer>
+                    <Button variant="danger" onClick={handleCancel}>
+                      Cancel
+                    </Button>
+                    <Button
+                      className="ml-2"
+                      variant="primary"
+                      type="Submit"
+                      disabled={formik.isSubmitting}
+                    >
+                      {formik.isSubmitting ? 'Saving...' : 'Submit'}
+                    </Button>
+                  </Card.Footer>
+                </Card>
+              </Col>
+            </Row>
+          </div>
+        </Form>
+      )}
+    </Formik>
+  )
+}
+
+TierForm.propTypes = {
+  handleSubmit: PropTypes.func,
+  handleCancel: PropTypes.func,
+  dismissError: PropTypes.func,
+  tier: PropTypes.object,
+  error: PropTypes.string,
+  config: PropTypes.object,
+  plans: PropTypes.array,
+}
+
+export default TierForm

--- a/client/web/src/tier/TierFormComponent.js
+++ b/client/web/src/tier/TierFormComponent.js
@@ -18,12 +18,13 @@ import React from 'react'
 import { Formik, Form } from 'formik'
 import * as Yup from 'yup'
 import { Row, Col, Card, Button, Alert } from 'react-bootstrap'
-import { SaasBoostInput, SaasBoostTextarea } from '../components/FormComponents'
+import { SaasBoostCheckbox, SaasBoostInput, SaasBoostTextarea } from '../components/FormComponents'
 
 const initialTier = {
   id: null,
   name: '',
   description: '',
+  defaultTier: false,
 }
 
 const TierForm = (props) => {
@@ -63,7 +64,8 @@ const TierForm = (props) => {
         name: Yup.string()
           .max(100, 'Must be 100 characters or less.')
           .required('Required'),
-        description: Yup.string().max(100, 'Must be 100 characters or less.')
+        description: Yup.string().max(100, 'Must be 100 characters or less.'),
+        defaultTier: Yup.boolean().required()
       })}
       onSubmit={handleSubmit}
     >
@@ -86,6 +88,7 @@ const TierForm = (props) => {
                   <Card.Body>
                     <SaasBoostInput label="Name" name="name" type="text" />
                     <SaasBoostTextarea label="Description" name="description" type="text" />
+                    <SaasBoostCheckbox label="Mark as Default" name="defaultTier" tooltip="If a non-default tier is missing any required application configuration, the default tier's application configuration will be used." />
                   </Card.Body>
                   <Card.Footer>
                     <Button variant="danger" onClick={handleCancel}>

--- a/client/web/src/tier/TierListComponent.js
+++ b/client/web/src/tier/TierListComponent.js
@@ -1,0 +1,162 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { PropTypes } from 'prop-types'
+import React from 'react'
+import CIcon from '@coreui/icons-react'
+import { cilReload, cilListRich, cilCheckCircle, cilXCircle } from '@coreui/icons'
+import {
+  Card,
+  CardBody,
+  CardHeader,
+  Table,
+  Button,
+  Row,
+  Col,
+  Spinner,
+  Alert,
+  Badge,
+  NavLink,
+} from 'reactstrap'
+
+TierListItem.propTypes = {
+  tier: PropTypes.object,
+  handleTierClick: PropTypes.func,
+}
+
+function TierListItem({ tier, handleTierClick }) {
+  return (
+    <tr
+      key={tier.id}
+      onClick={() => {
+        handleTierClick(tier.id)
+      }}
+      className="pointer"
+    >
+      <td>
+        <NavLink
+          href="#"
+          onClick={() => {
+            handleTierClick(tier.id)
+          }}
+          color="link"
+          className="pl-0 pt-0"
+        >
+          {tier.name}
+        </NavLink>
+      </td>
+      <td>{tier.description}</td>
+    </tr>
+  )
+}
+
+function showError(error, handleError) {
+  return (
+    <Alert color="danger" isOpen={!!error} toggle={() => handleError()}>
+      <h4 className="alert-heading">Error</h4>
+      <p>{error}</p>
+    </Alert>
+  )
+}
+
+TierList.propTypes = {
+  tiers: PropTypes.array,
+  loading: PropTypes.string,
+  error: PropTypes.string,
+  handleProvisionTier: PropTypes.func,
+  handleTierClick: PropTypes.func,
+  handleCreateTier: PropTypes.func,
+  handleRefresh: PropTypes.func,
+  handleError: PropTypes.func,
+}
+
+function TierList({
+  tiers,
+  loading,
+  error,
+  handleTierClick,
+  handleCreateTier,
+  handleRefresh,
+  handleError,
+}) {
+  const toRender = (
+    <Table responsive striped>
+      <thead>
+        <tr>
+          <th width="25%">Name</th>
+          <th width="75%">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        {loading === 'idle' &&
+          tiers.length !== 0 &&
+          tiers.map((tier) => (
+            <TierListItem tier={tier} key={tier.id} handleTierClick={handleTierClick} />
+          ))}
+        {tiers.length === 0 && loading === 'idle' && (
+          <tr>
+            <td colSpan="5" className="text-center">
+              <p className="font-weight-bold">No results</p>
+              <p>There are no Tiers to display.</p>
+            </td>
+          </tr>
+        )}
+        {loading === 'pending' && (
+          <tr>
+            <td colSpan="5" className="text-center">
+              <Spinner animation="border" role="status">
+                Loading...
+              </Spinner>
+            </td>
+          </tr>
+        )}
+      </tbody>
+    </Table>
+  )
+
+  return (
+    <div className="animated fadeIn">
+      <Row>
+        <Col>{error && showError(error, handleError)}</Col>
+      </Row>
+      <Row className="mb-3">
+        <Col>
+          <div className="float-right">
+            <Button color="secondary" className="mr-2" onClick={handleRefresh}>
+              <span>
+                <CIcon icon={cilReload} />
+              </span>
+            </Button>
+            <Button color="primary" onClick={handleCreateTier}>
+              Create Tier
+            </Button>
+          </div>
+        </Col>
+      </Row>
+      <Row>
+        <Col xs="12" lg="12">
+          <Card>
+            <CardHeader>
+              <CIcon icon={cilListRich} /> Tiers
+            </CardHeader>
+            <CardBody>{toRender}</CardBody>
+          </Card>
+        </Col>
+      </Row>
+    </div>
+  )
+}
+
+export default TierList

--- a/client/web/src/tier/TierListComponent.js
+++ b/client/web/src/tier/TierListComponent.js
@@ -30,6 +30,8 @@ import {
   Badge,
   NavLink,
 } from 'reactstrap'
+import Moment from 'react-moment'
+import Display from '../components/Display'
 
 TierListItem.propTypes = {
   tier: PropTypes.object,
@@ -61,6 +63,20 @@ function TierListItem({ tier, handleTierClick }) {
         {!!tier && tier.defaultTier
           ? (<CIcon icon={cilCheckCircle} className="text-success"/>)
           : (<CIcon icon={cilXCircle} className="text-danger"/>)}
+      </td>
+      <td>
+        <Display condition={!!tier}>
+          <Moment format="LLL">
+            {!!tier && new Date(tier.created)}
+          </Moment>
+        </Display>
+      </td>
+      <td>
+        <Display condition={!!tier}>
+          <Moment format="LLL">
+            {!!tier && new Date(tier.modified)}
+          </Moment>
+        </Display>
       </td>
       <td>{tier.description}</td>
     </tr>
@@ -100,9 +116,11 @@ function TierList({
     <Table responsive striped>
       <thead>
         <tr>
-          <th width="15%">Name</th>
-          <th width="10%">Default</th>
-          <th width="75%">Description</th>
+          <th width="10%">Name</th>
+          <th width="5%">Default</th>
+          <th width="10%">Created</th>
+          <th width="10%">Modified</th>
+          <th width="65%">Description</th>
         </tr>
       </thead>
       <tbody>

--- a/client/web/src/tier/TierListComponent.js
+++ b/client/web/src/tier/TierListComponent.js
@@ -57,6 +57,11 @@ function TierListItem({ tier, handleTierClick }) {
           {tier.name}
         </NavLink>
       </td>
+      <td>
+        {!!tier && tier.defaultTier
+          ? (<CIcon icon={cilCheckCircle} className="text-success"/>)
+          : (<CIcon icon={cilXCircle} className="text-danger"/>)}
+      </td>
       <td>{tier.description}</td>
     </tr>
   )
@@ -95,7 +100,8 @@ function TierList({
     <Table responsive striped>
       <thead>
         <tr>
-          <th width="25%">Name</th>
+          <th width="15%">Name</th>
+          <th width="10%">Default</th>
           <th width="75%">Description</th>
         </tr>
       </thead>

--- a/client/web/src/tier/TierListComponent.js
+++ b/client/web/src/tier/TierListComponent.js
@@ -48,6 +48,11 @@ function TierListItem({ tier, handleTierClick }) {
       className="pointer"
     >
       <td>
+        {!!tier && tier.defaultTier
+          ? (<CIcon icon={cilCheckCircle} className="text-success"/>)
+          : (<CIcon icon={cilXCircle} className="text-danger"/>)}
+      </td>
+      <td>
         <NavLink
           href="#"
           onClick={() => {
@@ -59,11 +64,7 @@ function TierListItem({ tier, handleTierClick }) {
           {tier.name}
         </NavLink>
       </td>
-      <td>
-        {!!tier && tier.defaultTier
-          ? (<CIcon icon={cilCheckCircle} className="text-success"/>)
-          : (<CIcon icon={cilXCircle} className="text-danger"/>)}
-      </td>
+      <td>{tier.description}</td>
       <td>
         <Display condition={!!tier}>
           <Moment format="LLL">
@@ -78,7 +79,6 @@ function TierListItem({ tier, handleTierClick }) {
           </Moment>
         </Display>
       </td>
-      <td>{tier.description}</td>
     </tr>
   )
 }
@@ -116,11 +116,11 @@ function TierList({
     <Table responsive striped>
       <thead>
         <tr>
-          <th width="10%">Name</th>
           <th width="5%">Default</th>
-          <th width="10%">Created</th>
-          <th width="10%">Modified</th>
-          <th width="65%">Description</th>
+          <th width="20%">Name</th>
+          <th width="40%">Description</th>
+          <th width="17.5%">Created</th>
+          <th width="17.5%">Modified</th>
         </tr>
       </thead>
       <tbody>

--- a/client/web/src/tier/TierListContainer.js
+++ b/client/web/src/tier/TierListContainer.js
@@ -1,0 +1,77 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useEffect, Fragment } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+
+import { fetchTiersThunk, selectAllTiers, dismissError } from './ducks'
+import TierListComponent from './TierListComponent'
+import { useHistory } from 'react-router-dom'
+import LoadingOverlay from '@ronchalant/react-loading-overlay'
+
+export default function TierListContainer() {
+  const dispatch = useDispatch()
+  const history = useHistory()
+  const tiers = useSelector(selectAllTiers)
+  const loading = useSelector((state) => state.tiers.loading)
+  const error = useSelector((state) => state.tiers.error)
+
+  const handleTierClick = (tierId) => {
+    history.push(`/tiers/${tierId}`)
+  }
+
+  const handleCreateTier = () => {
+    history.push(`/tiers/create`)
+  }
+
+  const handleRefresh = () => {
+    dispatch(fetchTiersThunk())
+  }
+
+  const handleError = () => {
+    dispatch(dismissError())
+  }
+
+  useEffect(() => {
+    const fetchTiers = dispatch(fetchTiersThunk())
+    return () => {
+      if (fetchTiers.PromiseStatus === 'pending') {
+        fetchTiers.abort()
+      }
+      dispatch(dismissError())
+    }
+  }, [dispatch]) //TODO: Follow up on the use of this dispatch function.
+
+  return (
+    <Fragment>
+      <LoadingOverlay
+          active={loading === 'pending'}
+          spinner
+          text="Loading tiers..."
+        >
+        <TierListComponent
+          tiers={tiers}
+          loading={loading}
+          error={error}
+          handleTierClick={handleTierClick}
+          handleCreateTier={handleCreateTier}
+          handleRefresh={handleRefresh}
+          handleError={handleError}
+        />
+      </LoadingOverlay>
+    </Fragment>
+  )
+}

--- a/client/web/src/tier/TierViewComponent.js
+++ b/client/web/src/tier/TierViewComponent.js
@@ -168,6 +168,17 @@ function TierViewComponent(props) {
                     sm={4}
                     className="border border border-top-0 border-bottom-0 border-left-0"
                   >
+                    <dt>Default</dt>
+                    <dd>
+                      {!!tier && tier.defaultTier
+                        ? (<CIcon icon={cilCheckCircle} className="text-success"/>)
+                        : (<CIcon icon={cilXCircle} className="text-danger"/>)}
+                    </dd>
+                  </Col>
+                  <Col
+                    sm={2}
+                    className="border border border-top-0 border-bottom-0 border-left-0"
+                  >
                     <dt>Name</dt>
                     <dd>
                       <Display>{!!tier && tier.name}</Display>

--- a/client/web/src/tier/TierViewComponent.js
+++ b/client/web/src/tier/TierViewComponent.js
@@ -1,0 +1,195 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { PropTypes } from 'prop-types'
+import React, { useState } from 'react'
+import CIcon from '@coreui/icons-react'
+import { cilCheckCircle, cilXCircle } from '@coreui/icons'
+import {
+  Alert,
+  Badge,
+  Button,
+  Card,
+  Col,
+  Dropdown,
+  Form,
+  FormGroup,
+  Modal,
+  NavLink,
+  Row,
+} from 'react-bootstrap'
+import Display from '../components/Display'
+import { MoonLoader } from 'react-spinners'
+
+TierViewComponent.propTypes = {
+  tier: PropTypes.object,
+  loading: PropTypes.string,
+  error: PropTypes.string,
+  handleError: PropTypes.func,
+  toggleEdit: PropTypes.func,
+  deleteTier: PropTypes.func,
+}
+
+function TierViewComponent(props) {
+  const banner = {
+    fontWeight: 600,
+    color: '#f6f6f6',
+    background: '#232f3e',
+    border: '1px solid orange',
+  }
+
+  const {
+    tier,
+    loading,
+    error,
+    handleError,
+    toggleEdit,
+    deleteTier,
+  } = props
+
+  const confirmDeleteTier = () => {
+    toggleShowModal(true)
+  }
+
+  const deleteTierDismissModal = () => {
+    toggleShowModal(false)
+    deleteTier()
+  }
+
+  const showError = (error, handleError) => {
+    return (
+      <Alert color="danger" isOpen={!!error} toggle={() => handleError()}>
+        <h4 className={'alert-heading'}>Error</h4>
+        <p>{error}</p>
+      </Alert>
+    )
+  }
+  const [showModal, toggleShowModal] = useState(false)
+  const [matches, setMatches] = useState(false)
+
+  const toggleModal = () => {
+    toggleShowModal((s) => !s)
+  }
+
+  const checkMatches = (event) => {
+    if (event.target.value === tier.id) {
+      setMatches(true)
+    }
+  }
+
+  return (
+    <>
+      <Modal size="lg" fade={"true"} show={showModal}>
+        <Modal.Header className="bg-primary">Confirm Delete</Modal.Header>
+        <Modal.Body>
+          <p>
+            Delete tier <code>{tier?.name}</code> (id: <code>{tier?.id}</code>)? Please type the ID
+            of the tier to confirm.
+          </p>
+          <Form>
+            <FormGroup>
+              <Form.Control
+                onChange={checkMatches}
+                type="text"
+                name="tierId"
+                id="tierId"
+                placeholder="Tier ID"
+              />
+            </FormGroup>
+          </Form>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button
+            disabled={!matches}
+            color="danger"
+            onClick={deleteTierDismissModal}
+          >
+            Yes, delete
+          </Button>
+          <Button color="primary" onClick={toggleModal}>
+            Cancel
+          </Button>
+        </Modal.Footer>
+      </Modal>
+      <div className="animated fadeIn">
+        <Row>
+          <Col>{error && showError(error, handleError)}</Col>
+        </Row>
+        <Row className="mb-3">
+          <Col className="justify-content-end">
+            <Dropdown
+              className="float-right"
+            >
+              <Dropdown.Toggle color="primary" disabled={loading === 'pending'}>
+                <MoonLoader
+                  size={15}
+                  className="d-inline-block"
+                  loading={loading === 'pending'}
+                />{' '}
+                <span>Actions</span>
+              </Dropdown.Toggle>
+              {loading === 'idle' && !!tier && (
+                <Dropdown.Menu end="true">
+                  <Dropdown.Item onClick={() => toggleEdit()}>
+                    Edit
+                  </Dropdown.Item>
+                  <Dropdown.Item
+                    onClick={confirmDeleteTier}
+                  >
+                    Delete
+                  </Dropdown.Item>
+                </Dropdown.Menu>
+              )}
+            </Dropdown>
+          </Col>
+        </Row>
+        <Row>
+          <Col xs={12}>
+            <Card>
+              <Card.Header>
+                <strong>{tier && tier.name}</strong> (Id:{' '}
+                {tier && tier.id})
+              </Card.Header>
+              <Card.Body>
+                <Row className="pt-3">
+                  <Col
+                    sm={4}
+                    className="border border border-top-0 border-bottom-0 border-left-0"
+                  >
+                    <dt>Name</dt>
+                    <dd>
+                      <Display>{!!tier && tier.name}</Display>
+                    </dd>
+                  </Col>
+                  <Col
+                    sm={8}
+                    className="border border border-top-0 border-bottom-0 border-left-0"
+                  >
+                    <dt>Description</dt>
+                    <dd>
+                      <Display>{!!tier && tier?.description}</Display>
+                    </dd>
+                  </Col>
+                </Row>
+              </Card.Body>
+            </Card>
+          </Col>
+        </Row>
+      </div>
+    </>
+  )
+}
+
+export default TierViewComponent

--- a/client/web/src/tier/TierViewComponent.js
+++ b/client/web/src/tier/TierViewComponent.js
@@ -165,7 +165,7 @@ function TierViewComponent(props) {
               <Card.Body>
                 <Row className="pt-3">
                   <Col
-                    sm={4}
+                    sm={1}
                     className="border border border-top-0 border-bottom-0 border-left-0"
                   >
                     <dt>Default</dt>
@@ -176,7 +176,7 @@ function TierViewComponent(props) {
                     </dd>
                   </Col>
                   <Col
-                    sm={2}
+                    sm={1}
                     className="border border border-top-0 border-bottom-0 border-left-0"
                   >
                     <dt>Name</dt>
@@ -185,7 +185,25 @@ function TierViewComponent(props) {
                     </dd>
                   </Col>
                   <Col
-                    sm={8}
+                    sm={2}
+                    className="border border border-top-0 border-bottom-0 border-left-0"
+                  >
+                    <dt>Created</dt>
+                    <dd>
+                      <Display>{!!tier && tier.created}</Display>
+                    </dd>
+                  </Col>
+                  <Col
+                    sm={2}
+                    className="border border border-top-0 border-bottom-0 border-left-0"
+                  >
+                    <dt>Modified</dt>
+                    <dd>
+                      <Display>{!!tier && tier.modified}</Display>
+                    </dd>
+                  </Col>
+                  <Col
+                    sm={6}
                     className="border border border-top-0 border-bottom-0 border-left-0"
                   >
                     <dt>Description</dt>

--- a/client/web/src/tier/TierViewComponent.js
+++ b/client/web/src/tier/TierViewComponent.js
@@ -31,6 +31,7 @@ import {
   Row,
 } from 'react-bootstrap'
 import Display from '../components/Display'
+import Moment from 'react-moment'
 import { MoonLoader } from 'react-spinners'
 
 TierViewComponent.propTypes = {
@@ -165,50 +166,50 @@ function TierViewComponent(props) {
               <Card.Body>
                 <Row className="pt-3">
                   <Col
-                    sm={1}
+                    sm={4}
                     className="border border border-top-0 border-bottom-0 border-left-0"
                   >
                     <dt>Default</dt>
                     <dd>
-                      {!!tier && tier.defaultTier
-                        ? (<CIcon icon={cilCheckCircle} className="text-success"/>)
-                        : (<CIcon icon={cilXCircle} className="text-danger"/>)}
+                      <Display condition={!!tier}>
+                        {!!tier && tier.defaultTier
+                          ? (<CIcon icon={cilCheckCircle} className="text-success"/>)
+                          : (<CIcon icon={cilXCircle} className="text-danger"/>)}
+                      </Display>
                     </dd>
-                  </Col>
-                  <Col
-                    sm={1}
-                    className="border border border-top-0 border-bottom-0 border-left-0"
-                  >
                     <dt>Name</dt>
                     <dd>
-                      <Display>{!!tier && tier.name}</Display>
+                      <Display condition={!!tier}>{!!tier && tier.name}</Display>
                     </dd>
                   </Col>
                   <Col
-                    sm={2}
+                    sm={4}
                     className="border border border-top-0 border-bottom-0 border-left-0"
                   >
                     <dt>Created</dt>
                     <dd>
-                      <Display>{!!tier && tier.created}</Display>
+                      <Display condition={!!tier}>
+                        <Moment format="LLL">
+                          {!!tier && new Date(tier.created)}
+                        </Moment>
+                      </Display>
                     </dd>
-                  </Col>
-                  <Col
-                    sm={2}
-                    className="border border border-top-0 border-bottom-0 border-left-0"
-                  >
                     <dt>Modified</dt>
                     <dd>
-                      <Display>{!!tier && tier.modified}</Display>
+                      <Display condition={!!tier}>
+                        <Moment format="LLL">
+                          {!!tier && new Date(tier.modified)}
+                        </Moment>
+                      </Display>
                     </dd>
                   </Col>
                   <Col
-                    sm={6}
+                    sm={4}
                     className="border border border-top-0 border-bottom-0 border-left-0"
                   >
                     <dt>Description</dt>
                     <dd>
-                      <Display>{!!tier && tier?.description}</Display>
+                      <Display condition={!!tier}>{!!tier && tier?.description}</Display>
                     </dd>
                   </Col>
                 </Row>

--- a/client/web/src/tier/TierViewContainer.js
+++ b/client/web/src/tier/TierViewContainer.js
@@ -1,0 +1,165 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { PropTypes } from 'prop-types'
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+import { unwrapResult } from '@reduxjs/toolkit'
+import { withRouter } from 'react-router'
+import LoadingOverlay from '@ronchalant/react-loading-overlay'
+
+import TierForm from './TierFormComponent'
+import {
+  fetchTiersThunk,
+  fetchTierThunk,
+  deleteTierThunk,
+  updateTierThunk,
+  dismissError,
+} from './ducks'
+import TierViewComponent from './TierViewComponent'
+
+const mapDispatchToProps = {
+  fetchTiersThunk,
+  fetchTierThunk,
+  dismissError,
+  updateTierThunk,
+  deleteTierThunk,
+}
+
+const mapStateToProps = (state, props) => {
+  const { tierId } = props.match.params
+  const { tiers } = state
+  const tier = !!tierId ? tiers.entities[tierId] : undefined
+
+  return {
+    tier: tier,
+    loading: tiers.loading,
+    error: tiers.error,
+  }
+}
+
+class TierContainer extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      tierId: null,
+      isEditing: false,
+    }
+    this.toggleEdit = this.toggleEdit.bind(this)
+    this.saveTier = this.saveTier.bind(this)
+    this.handleError = this.handleError.bind(this)
+    this.deleteTier = this.deleteTier.bind(this)
+  }
+
+  async componentDidMount() {
+    const { tierId } = this.props.match.params
+
+    if (tierId != null) {
+      try {
+        this.setState((state, props) => {
+          if (tierId === state.tierId) {
+            return state
+          }
+          return { tierId: tierId }
+        })
+      } catch (err) {
+        console.error('error when dispatching tier thunk.', err)
+      }
+    }
+  }
+
+  toggleEdit() {
+    const { error } = this.props
+    if (error) {
+      const { dismissError } = this.props
+      dismissError()
+    }
+    this.setState((state) => ({ isEditing: !state.isEditing }))
+  }
+
+  saveTier(values, { setSubmitting }) {
+    const dispatchResponse = this.props.updateTierThunk({ values: values })
+    dispatchResponse
+      .then(unwrapResult)
+      .then(() => {
+        setSubmitting(false)
+        this.toggleEdit()
+      })
+      .catch((e) => {
+        setSubmitting(false)
+      })
+  }
+
+  deleteTier() {
+    const valToSend = {
+      tierId: this.state.tierId,
+      history: this.props.history,
+    }
+    this.props.deleteTierThunk(valToSend)
+  }
+
+  handleError() {
+    this.props.dismissError()
+  }
+
+  render() {
+    const { tier, error, dismissError, loading } = this.props
+    const { tierId, isEditing } = this.state
+    return (
+      <div>
+        <LoadingOverlay
+          active={(loading === 'pending')}
+          spinner
+        >
+          {!isEditing && (
+            <TierViewComponent
+              tier={tier}
+              tierId={tierId}
+              loading={loading}
+              error={error}
+              handleError={this.handleError}
+              toggleEdit={this.toggleEdit}
+              deleteTier={this.deleteTier}
+            />
+          )}
+          {isEditing && (
+            <TierForm
+              tier={tier}
+              error={error}
+              handleCancel={this.toggleEdit}
+              handleSubmit={this.saveTier}
+              dismissError={dismissError}
+            />
+          )}
+        </LoadingOverlay>
+      </div>
+    )
+  }
+}
+
+TierContainer.propTypes = {
+  fetchTiersThunk: PropTypes.func,
+  fetchTierThunk: PropTypes.func,
+  dismissError: PropTypes.func,
+  updateTierThunk: PropTypes.func,
+  deleteTierThunk: PropTypes.func,
+}
+
+export const TierContainerWithRouter = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(withRouter(TierContainer))
+
+export default TierContainerWithRouter

--- a/client/web/src/tier/ducks/index.js
+++ b/client/web/src/tier/ducks/index.js
@@ -32,7 +32,6 @@ import {
   // Thunks
   export const fetchTiersThunk = createAsyncThunk('tiers/fetchAll', async (...[, thunkAPI]) => {
     const { signal } = thunkAPI
-    //since no value is passed to this async fn()
     try {
       const response = await tierAPI.fetchAll({ signal })
       // Normalize the data so reducers can load a predicatable payload, like:
@@ -79,11 +78,11 @@ import {
   
   export const updateTierThunk = createAsyncThunk(
     'tiers/update', 
-    async (tierData, thunkAPI) => {
+    async ({ values }, thunkAPI) => {
       const { signal } = thunkAPI
   
       try {
-        return await tierAPI.update(tierData, { signal })
+        return await tierAPI.update(values, { signal })
       } catch (err) {
         if (tierAPI.isCancel(err)) {
           console.log('api cancelled request')
@@ -98,11 +97,11 @@ import {
   
   export const deleteTierThunk = createAsyncThunk(
     'tiers/delete', 
-    async (tierId, thunkAPI) => {
+    async (values, thunkAPI) => {
       const { signal } = thunkAPI
   
       try {
-        return await tierAPI.delete(tierId, { signal })
+        return await tierAPI.delete(values, { signal })
       } catch (err) {
         if (tierAPI.isCancel(err)) {
           console.log('api cancelled request')
@@ -209,7 +208,6 @@ import {
 
       [deleteTierThunk.fulfilled]: (state, action) => {
         console.log(action)
-        tiersAdapter.upsertOne(state, action.payload)
         state.loading = 'idle'
         state.error = null
         return state

--- a/client/web/src/tier/index.js
+++ b/client/web/src/tier/index.js
@@ -16,20 +16,27 @@
 
 import React from 'react'
 
-// const TierListContainer = React.lazy(() => import('./TierListContainer'))
-// const TierViewContainer = React.lazy(() => import('./TierViewContainer'))
+const TierListContainer = React.lazy(() => import('./TierListContainer'))
+const TierViewContainer = React.lazy(() => import('./TierViewContainer'))
+const TierCreateContainer = React.lazy(() => import('./TierCreateContainer'))
 
-// export const TierRoutes = [
-//   {
-//     path: '/tiers',
-//     exact: true,
-//     name: 'Tiers',
-//     component: TierListContainer,
-//   },
-//   {
-//     path: '/tiers/:tierId',
-//     exact: true,
-//     name: 'Tier Detail',
-//     component: TierViewContainer,
-//   },
-// ]
+export const TierRoutes = [
+  {
+    path: '/tiers',
+    exact: true,
+    name: 'Tiers',
+    component: TierListContainer,
+  },
+  {
+    path: '/tiers/create',
+    exact: true,
+    name: 'Create a new Tier',
+    component: TierCreateContainer,
+  },
+  {
+    path: '/tiers/:tierId',
+    exact: true,
+    name: 'Tier Detail',
+    component: TierViewContainer,
+  },
+]

--- a/resources/saas-boost-public-api.yaml
+++ b/resources/saas-boost-public-api.yaml
@@ -1280,7 +1280,7 @@ Resources:
             ResponseTemplates: { application/json: '' }
             ResponseParameters:
               method.response.header.Access-Control-Allow-Headers: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'"
-              method.response.header.Access-Control-Allow-Methods: "'OPTIONS,PATCH'"
+              method.response.header.Access-Control-Allow-Methods: "'OPTIONS,POST'"
               method.response.header.Access-Control-Allow-Origin: "'*'"
               method.response.header.Access-Control-Max-Age: "'3600'"
               method.response.header.X-Requested-With: "'*'"
@@ -1316,7 +1316,7 @@ Resources:
             ResponseTemplates: { application/json: '' }
             ResponseParameters:
               method.response.header.Access-Control-Allow-Headers: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'"
-              method.response.header.Access-Control-Allow-Methods: "'OPTIONS,PATCH'"
+              method.response.header.Access-Control-Allow-Methods: "'OPTIONS,PUT,DELETE'"
               method.response.header.Access-Control-Allow-Origin: "'*'"
               method.response.header.Access-Control-Max-Age: "'3600'"
               method.response.header.X-Requested-With: "'*'"

--- a/resources/saas-boost-public-api.yaml
+++ b/resources/saas-boost-public-api.yaml
@@ -1280,7 +1280,7 @@ Resources:
             ResponseTemplates: { application/json: '' }
             ResponseParameters:
               method.response.header.Access-Control-Allow-Headers: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'"
-              method.response.header.Access-Control-Allow-Methods: "'OPTIONS,POST'"
+              method.response.header.Access-Control-Allow-Methods: "'GET,OPTIONS,POST'"
               method.response.header.Access-Control-Allow-Origin: "'*'"
               method.response.header.Access-Control-Max-Age: "'3600'"
               method.response.header.X-Requested-With: "'*'"
@@ -1316,7 +1316,7 @@ Resources:
             ResponseTemplates: { application/json: '' }
             ResponseParameters:
               method.response.header.Access-Control-Allow-Headers: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'"
-              method.response.header.Access-Control-Allow-Methods: "'OPTIONS,PUT,DELETE'"
+              method.response.header.Access-Control-Allow-Methods: "'GET,OPTIONS,PUT,DELETE'"
               method.response.header.Access-Control-Allow-Origin: "'*'"
               method.response.header.Access-Control-Max-Age: "'3600'"
               method.response.header.X-Requested-With: "'*'"

--- a/resources/saas-boost-svc-tier.yaml
+++ b/resources/saas-boost-svc-tier.yaml
@@ -104,7 +104,7 @@ Resources:
         - !Ref SaaSBoostUtilsLayer
       Environment:
         Variables:
-          TABLE_NAME: !Ref TiersTable
+          TIERS_TABLE: !Ref TiersTable
           JAVA_TOOL_OPTIONS: '-XX:+TieredCompilation -XX:TieredStopAtLevel=1'
       Tags:
         - Key: "Application"
@@ -134,7 +134,7 @@ Resources:
         - !Ref SaaSBoostUtilsLayer
       Environment:
         Variables:
-          TABLE_NAME: !Ref TiersTable
+          TIERS_TABLE: !Ref TiersTable
           JAVA_TOOL_OPTIONS: '-XX:+TieredCompilation -XX:TieredStopAtLevel=1'
       Tags:
         - Key: "Application"
@@ -164,7 +164,7 @@ Resources:
         - !Ref SaaSBoostUtilsLayer
       Environment:
         Variables:
-          TABLE_NAME: !Ref TiersTable
+          TIERS_TABLE: !Ref TiersTable
           JAVA_TOOL_OPTIONS: '-XX:+TieredCompilation -XX:TieredStopAtLevel=1'
       Tags:
         - Key: "Application"
@@ -194,7 +194,7 @@ Resources:
         - !Ref SaaSBoostUtilsLayer
       Environment:
         Variables:
-          TABLE_NAME: !Ref TiersTable
+          TIERS_TABLE: !Ref TiersTable
           JAVA_TOOL_OPTIONS: '-XX:+TieredCompilation -XX:TieredStopAtLevel=1'
       Tags:
         - Key: "Application"
@@ -224,7 +224,7 @@ Resources:
         - !Ref SaaSBoostUtilsLayer
       Environment:
         Variables:
-          TABLE_NAME: !Ref TiersTable
+          TIERS_TABLE: !Ref TiersTable
           JAVA_TOOL_OPTIONS: '-XX:+TieredCompilation -XX:TieredStopAtLevel=1'
       Tags:
         - Key: "Application"

--- a/services/tier-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/TierService.java
+++ b/services/tier-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/TierService.java
@@ -160,6 +160,7 @@ public class TierService implements RequestHandler<Map<String, Object>, APIGatew
         Tier updatedTier = providedTier;
         try {
             Tier oldTier = store.getTier(providedTier.getId());
+            // TODO validate that user isn't trying to update fields that should not be updated, e.g. created, id
             updatedTier = store.updateTier(providedTier);
             // handling default cases:
             //   - we are now default

--- a/services/tier-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/TierService.java
+++ b/services/tier-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/TierService.java
@@ -29,35 +29,15 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class TierService implements RequestHandler<Map<String, Object>, APIGatewayProxyResponseEvent> {
     private static final Logger LOGGER = LoggerFactory.getLogger(TierService.class);
     private static final String TABLE_NAME = System.getenv("TABLE_NAME");
     private static final Map<String, String> CORS = Map.of("Access-Control-Allow-Origin", "*");
-    // private static final String DATASTORE_IMPL = System.getenv("DATASTORE_IMPL");
-
-    // private static final String API_GATEWAY_HOST = System.getenv("API_GATEWAY_HOST");
-    // private static final String API_GATEWAY_STAGE = System.getenv("API_GATEWAY_STAGE");
-    // private static final String API_TRUST_ROLE = System.getenv("API_TRUST_ROLE");
-    // private static final String SYSTEM_API_CALL_DETAIL_TYPE = "System API Call";
-    // private static final String SYSTEM_API_CALL_SOURCE = "saas-boost";
 
     private final TierDataStore store;
 
-    // TODO EventBridge will eventually be needed to send tier definition change events
-    // private final EventBridgeClient eventBridge;
-
-    /*
-     * getTiers, getTier, createTier, updateTier, deleteTier
-     * each requires access to the backing DDB datastore
-     *
-     * DDB table needs to be passed as environment variable
-     *
-     * getTiers, getTier, createTier, updateTier, deleteTier
-     * are all kind of ONLY DDB datastore actions
-     * except maybe update.
-     * either way, we should have a Tier object. JSON serializable. and DDB serializable.
-     */
     public TierService() {
         final long startTimeMillis = System.currentTimeMillis();
         if (Utils.isEmpty(TABLE_NAME)) {
@@ -65,24 +45,20 @@ public class TierService implements RequestHandler<Map<String, Object>, APIGatew
         }
         LOGGER.info("Version Info: {}", Utils.version(this.getClass()));
 
-        // this.store = TierDataStoreFactory.getInstance(DATASTORE_IMPL); // creates required clients in factory method
         this.store = new DynamoTierDataStore(
                 Utils.sdkClient(DynamoDbClient.builder(), DynamoDbClient.SERVICE_NAME),
                 TABLE_NAME);
 
-        // this.eventBridge = Utils.sdkClient(EventBridgeClient.builder(), EventBridgeClient.SERVICE_NAME);
         LOGGER.info("Constructor init: {}", System.currentTimeMillis() - startTimeMillis);
     }
 
     @Override
     public APIGatewayProxyResponseEvent handleRequest(Map<String, Object> event, Context context) {
-        //Utils.logRequestEvent(event);
         return new APIGatewayProxyResponseEvent().withHeaders(CORS).withStatusCode(200);
     }
 
     public APIGatewayProxyResponseEvent getTiers(Map<String, Object> event, Context context) {
         if (Utils.warmup(event)) {
-            //LOGGER.info("Warming up");
             return new APIGatewayProxyResponseEvent().withHeaders(CORS).withStatusCode(200);
         }
 
@@ -91,7 +67,14 @@ public class TierService implements RequestHandler<Map<String, Object>, APIGatew
         List<Tier> tiers = store.listTiers();
         if (tiers.isEmpty()) {
             // we want to ensure there is always at least a default tier.
-            tiers.add(store.createTier(Tier.builder().name("default").description("Default Tier").build()));
+            tiers.add(
+                    store.createTier(Tier.builder()
+                            .name("default")
+                            .description("Default Tier")
+                            .defaultTier(true)
+                            .build()
+                    )
+            );
         }
         long totalTimeMillis = System.currentTimeMillis() - startTimeMillis;
         LOGGER.info("TierService::getTiers exec " + totalTimeMillis);
@@ -103,7 +86,6 @@ public class TierService implements RequestHandler<Map<String, Object>, APIGatew
 
     public APIGatewayProxyResponseEvent getTier(Map<String, Object> event, Context context) {
         if (Utils.warmup(event)) {
-            //LOGGER.info("Warming up");
             return new APIGatewayProxyResponseEvent().withHeaders(CORS).withStatusCode(200);
         }
 
@@ -176,7 +158,33 @@ public class TierService implements RequestHandler<Map<String, Object>, APIGatew
                     .withBody("{\"message\":\"Tier IDs are immutable: body Tier ID must match path parameter.\"}");
         }
         try {
-            store.updateTier(updatedTier);
+            Tier oldTier = store.updateTier(updatedTier);
+            // handling default cases:
+            //   - we are now default
+            //     | because we enforce only one default, we must unset all other default tiers
+            //   - we are no longer default
+            //     | if we enforce there is always a default Tier we need to decide
+            //     | which is now default. otherwise we have no extra action to take
+            //   - default didn't change (no action)
+            if (!oldTier.defaultTier() && updatedTier.defaultTier()) {
+                // we weren't default but now we are, this means all other default
+                // Tiers should be updated to no longer be default,
+                // as we need to enforce only one default Tier at a given time
+                List<Tier> defaultTiers = store.listTiers().stream()
+                        .filter(tier -> tier.defaultTier())
+                        .collect(Collectors.toList());
+                for (Tier t : defaultTiers) {
+                    if (!t.getId().equals(updatedTier.getId())) {
+                        try {
+                            store.updateTier(Tier.builder(t).defaultTier(false).build());
+                        } catch (TierNotFoundException tnfe) {
+                            // race condition between the list we just pulled and the update
+                            LOGGER.error("Could not enforce a single default tier."
+                                    + " Found {} default tiers but {} does not exist.", defaultTiers, t);
+                        }
+                    }
+                }
+            }
         } catch (TierNotFoundException tnfe) {
             return new APIGatewayProxyResponseEvent()
                     .withHeaders(CORS)
@@ -187,7 +195,8 @@ public class TierService implements RequestHandler<Map<String, Object>, APIGatew
         LOGGER.info("TierService::updateTier exec " + totalTimeMillis);
         return new APIGatewayProxyResponseEvent()
                 .withHeaders(CORS)
-                .withStatusCode(200);
+                .withStatusCode(200)
+                .withBody(Utils.toJson(updatedTier));
     }
 
     public APIGatewayProxyResponseEvent deleteTier(Map<String, Object> event, Context context) {

--- a/services/tier-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/dal/TierDataStore.java
+++ b/services/tier-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/dal/TierDataStore.java
@@ -29,20 +29,20 @@ import java.util.List;
  * convert between the model definition of {@link Tier} and the datastore required definition.
  */
 public interface TierDataStore {
-    Tier getTier(String id) throws TierNotFoundException;
+    Tier getTier(String id);
 
     List<Tier> listTiers();
 
     Tier createTier(Tier tier);
 
-    void deleteTier(String id) throws TierNotFoundException;
+    void deleteTier(String id);
 
     /**
      * Updates the {@link Tier} with the same id as the provided Tier.
      *
      * @param newTier the Tier to update and the new data to supplant the old data
-     * @returns the Tier as it was before being updated
+     * @returns the updated Tier
      * @throws TierNotFoundException if there is no Tier with that id
      */
-    Tier updateTier(Tier newTier) throws TierNotFoundException;
+    Tier updateTier(Tier newTier);
 }

--- a/services/tier-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/dal/TierDataStore.java
+++ b/services/tier-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/dal/TierDataStore.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.amazon.aws.partners.saasfactory.saasboost.dal;
 
 import com.amazon.aws.partners.saasfactory.saasboost.TierService;
@@ -25,7 +41,8 @@ public interface TierDataStore {
      * Updates the {@link Tier} with the same id as the provided Tier.
      *
      * @param newTier the Tier to update and the new data to supplant the old data
+     * @returns the Tier as it was before being updated
      * @throws TierNotFoundException if there is no Tier with that id
      */
-    void updateTier(Tier newTier) throws TierNotFoundException;
+    Tier updateTier(Tier newTier) throws TierNotFoundException;
 }

--- a/services/tier-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/dal/ddb/DynamoTier.java
+++ b/services/tier-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/dal/ddb/DynamoTier.java
@@ -29,12 +29,12 @@ import java.util.Map;
 
 public class DynamoTier {
     private static final Logger LOGGER = LoggerFactory.getLogger(DynamoTier.class);
-    private static final TierAttribute PRIMARY_KEY = TierAttribute.id;
+    private static final DynamoTierAttribute PRIMARY_KEY = DynamoTierAttribute.id;
     public final Map<String, AttributeValue> attributes;
 
     private DynamoTier(Tier tier) {
         attributes = new HashMap<>();
-        for (TierAttribute tierAttribute : TierAttribute.values()) {
+        for (DynamoTierAttribute tierAttribute : DynamoTierAttribute.values()) {
             attributes.put(tierAttribute.name(), tierAttribute.fromTier(tier));
         }
         LOGGER.debug("Created DynamoTier: {}", attributes);
@@ -87,7 +87,7 @@ public class DynamoTier {
 
     public static Tier fromAttributes(Map<String, AttributeValue> attributes) {
         Tier.Builder tierBuilderInProgress = Tier.builder();
-        for (TierAttribute tierAttribute : TierAttribute.values()) {
+        for (DynamoTierAttribute tierAttribute : DynamoTierAttribute.values()) {
             tierAttribute.toTier(tierBuilderInProgress, attributes.get(tierAttribute.name()));
         }
         return tierBuilderInProgress.build();

--- a/services/tier-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/dal/ddb/DynamoTier.java
+++ b/services/tier-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/dal/ddb/DynamoTier.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.amazon.aws.partners.saasfactory.saasboost.dal.ddb;
 
 import com.amazon.aws.partners.saasfactory.saasboost.model.Tier;

--- a/services/tier-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/dal/ddb/DynamoTier.java
+++ b/services/tier-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/dal/ddb/DynamoTier.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -77,11 +78,11 @@ public class DynamoTier {
     }
 
     public Map<String, AttributeValue> primaryKey() {
-        return Map.of(PRIMARY_KEY.name(), attributes.get(PRIMARY_KEY.name()));
+        return Collections.singletonMap(PRIMARY_KEY.name(), attributes.get(PRIMARY_KEY.name()));
     }
 
     public static Map<String, AttributeValue> primaryKey(String id) {
-        return Map.of(PRIMARY_KEY.name(), AttributeValue.builder().s(id).build());
+        return Collections.singletonMap(PRIMARY_KEY.name(), AttributeValue.builder().s(id).build());
     }
 
     public static Tier fromAttributes(Map<String, AttributeValue> attributes) {

--- a/services/tier-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/dal/ddb/DynamoTierDataStore.java
+++ b/services/tier-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/dal/ddb/DynamoTierDataStore.java
@@ -107,6 +107,9 @@ public class DynamoTierDataStore implements TierDataStore {
 
     @Override
     public Tier updateTier(Tier tier) {
+        // updating the Tier modifies it, so update the modified field
+        tier = Tier.builder(tier).modified(LocalDateTime.now()).build();
+
         // TODO this doesn't do any ddb error checking
         DynamoTier dynamoTier = DynamoTier.fromTier(tier);
 

--- a/services/tier-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/dal/ddb/DynamoTierDataStore.java
+++ b/services/tier-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/dal/ddb/DynamoTierDataStore.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.amazon.aws.partners.saasfactory.saasboost.dal.ddb;
 
 import com.amazon.aws.partners.saasfactory.saasboost.dal.TierDataStore;
@@ -74,7 +90,7 @@ public class DynamoTierDataStore implements TierDataStore {
     }
 
     @Override
-    public void updateTier(Tier tier) throws TierNotFoundException {
+    public Tier updateTier(Tier tier) throws TierNotFoundException {
         // TODO this doesn't do any ddb error checking
         DynamoTier dynamoTier = DynamoTier.fromTier(tier);
 
@@ -85,8 +101,10 @@ public class DynamoTierDataStore implements TierDataStore {
                 .updateExpression(dynamoTier.updateExpression())
                 .expressionAttributeValues(dynamoTier.updateAttributes())
                 .expressionAttributeNames(dynamoTier.updateAttributeNames())
+                .returnValues(ReturnValue.ALL_OLD)
                 .build();
         LOGGER.debug("{}", updateItemRequest);
-        ddb.updateItem(updateItemRequest);
+        UpdateItemResponse updateItemResponse = ddb.updateItem(updateItemRequest);
+        return DynamoTier.fromAttributes(updateItemResponse.attributes());
     }
 }

--- a/services/tier-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/dal/ddb/TierAttribute.java
+++ b/services/tier-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/dal/ddb/TierAttribute.java
@@ -20,19 +20,31 @@ import com.amazon.aws.partners.saasfactory.saasboost.Utils;
 import com.amazon.aws.partners.saasfactory.saasboost.model.Tier;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.function.*;
 
 public enum TierAttribute {
     id(tier -> AttributeValue.builder().s(tier.getId()).build(),
             attributeValue -> !Utils.isEmpty(attributeValue.s()),
             (tierBuilder, attributeValue) -> tierBuilder.id(attributeValue.s())),
+    created(tier -> AttributeValue.builder().s(
+            tier.getCreated().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)).build(),
+            attributeValue -> !Utils.isEmpty(attributeValue.s()),
+            (tierBuilder, attributeValue) -> tierBuilder.created(
+                LocalDateTime.parse(attributeValue.s(), DateTimeFormatter.ISO_DATE_TIME))),
+    modified(tier -> AttributeValue.builder().s(
+            tier.getModified().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)).build(),
+            attributeValue -> !Utils.isEmpty(attributeValue.s()),
+            (tierBuilder, attributeValue) -> tierBuilder.modified(
+                LocalDateTime.parse(attributeValue.s(), DateTimeFormatter.ISO_DATE_TIME))),
     name(tier -> AttributeValue.builder().s(tier.getName()).build(),
             attributeValue -> !Utils.isEmpty(attributeValue.s()),
             (tierBuilder, attributeValue) -> tierBuilder.name(attributeValue.s())),
     description(tier -> AttributeValue.builder().s(tier.getDescription()).build(),
             attributeValue -> !Utils.isEmpty(attributeValue.s()),
             (tierBuilder, attributeValue) -> tierBuilder.description(attributeValue.s())),
-    defaultTier(tier -> AttributeValue.builder().bool(tier.defaultTier()).build(),
+    default_tier(tier -> AttributeValue.builder().bool(tier.defaultTier()).build(),
             attributeValue -> true,
             (tierBuilder, attributeValue) -> tierBuilder.defaultTier(attributeValue.bool()));
 

--- a/services/tier-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/dal/ddb/TierAttribute.java
+++ b/services/tier-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/dal/ddb/TierAttribute.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.amazon.aws.partners.saasfactory.saasboost.dal.ddb;
 
 import com.amazon.aws.partners.saasfactory.saasboost.Utils;
@@ -15,7 +31,10 @@ public enum TierAttribute {
             (tierBuilder, attributeValue) -> tierBuilder.name(attributeValue.s())),
     description(tier -> AttributeValue.builder().s(tier.getDescription()).build(),
             attributeValue -> !Utils.isEmpty(attributeValue.s()),
-            (tierBuilder, attributeValue) -> tierBuilder.description(attributeValue.s()));
+            (tierBuilder, attributeValue) -> tierBuilder.description(attributeValue.s())),
+    defaultTier(tier -> AttributeValue.builder().bool(tier.defaultTier()).build(),
+            attributeValue -> true,
+            (tierBuilder, attributeValue) -> tierBuilder.defaultTier(attributeValue.bool()));
 
     // used to convert the Attribute from a Tier to a DDB AttributeValue
     private final Function<Tier, AttributeValue> fromTierFunction;

--- a/services/tier-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/dal/exception/TierNotFoundException.java
+++ b/services/tier-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/dal/exception/TierNotFoundException.java
@@ -16,7 +16,7 @@
 
 package com.amazon.aws.partners.saasfactory.saasboost.dal.exception;
 
-public class TierNotFoundException extends Exception {
+public class TierNotFoundException extends RuntimeException {
     public TierNotFoundException(String message) {
         super(message);
     }

--- a/services/tier-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/dal/exception/TierNotFoundException.java
+++ b/services/tier-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/dal/exception/TierNotFoundException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.amazon.aws.partners.saasfactory.saasboost.dal.exception;
 
 public class TierNotFoundException extends Exception {

--- a/services/tier-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/model/Tier.java
+++ b/services/tier-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/model/Tier.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.amazon.aws.partners.saasfactory.saasboost.model;
 
 import com.amazon.aws.partners.saasfactory.saasboost.Utils;
@@ -12,11 +28,13 @@ public final class Tier {
     private final String id;
     private final String name;
     private final String description;
+    private final Boolean defaultTier;
 
     private Tier(Tier.Builder builder) {
         this.id = builder.id;
         this.name = builder.name;
         this.description = builder.description;
+        this.defaultTier = builder.defaultTier;
     }
 
     public String getId() {
@@ -31,6 +49,10 @@ public final class Tier {
         return this.description;
     }
 
+    public Boolean defaultTier() {
+        return this.defaultTier;
+    }
+
     @Override
     public boolean equals(Object other) {
         if (!(other instanceof Tier)) {
@@ -39,7 +61,8 @@ public final class Tier {
         Tier otherTier = (Tier)other;
         return this.getId().equals(otherTier.getId())
                 && this.getName().equals(otherTier.getName())
-                && this.getDescription().equals(otherTier.getDescription());
+                && this.getDescription().equals(otherTier.getDescription())
+                && this.defaultTier().equals(otherTier.defaultTier());
     }
 
     @Override
@@ -51,7 +74,8 @@ public final class Tier {
         return builder()
                 .id(tier.getId())
                 .description(tier.getDescription())
-                .name(tier.getName());
+                .name(tier.getName())
+                .defaultTier(tier.defaultTier());
     }
 
     public static Tier.Builder builder() {
@@ -63,6 +87,7 @@ public final class Tier {
         private String id;
         private String name;
         private String description;
+        private Boolean defaultTier = false;
 
         private Builder() {
 
@@ -80,6 +105,11 @@ public final class Tier {
 
         public Builder description(String description) {
             this.description = description;
+            return this;
+        }
+
+        public Builder defaultTier(Boolean defaultTier) {
+            this.defaultTier = defaultTier;
             return this;
         }
 

--- a/services/tier-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/model/Tier.java
+++ b/services/tier-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/model/Tier.java
@@ -20,18 +20,22 @@ import com.amazon.aws.partners.saasfactory.saasboost.Utils;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
+import java.time.LocalDateTime;
 import java.util.Objects;
-import java.util.UUID;
 
 @JsonDeserialize(builder = Tier.Builder.class)
 public final class Tier {
     private final String id;
+    private final LocalDateTime created;
+    private final LocalDateTime modified;
     private final String name;
     private final String description;
     private final Boolean defaultTier;
 
     private Tier(Tier.Builder builder) {
         this.id = builder.id;
+        this.created = builder.created;
+        this.modified = builder.modified;
         this.name = builder.name;
         this.description = builder.description;
         this.defaultTier = builder.defaultTier;
@@ -39,6 +43,14 @@ public final class Tier {
 
     public String getId() {
         return this.id;
+    }
+
+    public LocalDateTime getCreated() {
+        return this.created;
+    }
+
+    public LocalDateTime getModified() {
+        return this.modified;
     }
 
     public String getName() {
@@ -60,6 +72,8 @@ public final class Tier {
         }
         Tier otherTier = (Tier)other;
         return this.getId().equals(otherTier.getId())
+                && this.getCreated().equals(otherTier.getCreated())
+                && this.getModified().equals(otherTier.getModified())
                 && this.getName().equals(otherTier.getName())
                 && this.getDescription().equals(otherTier.getDescription())
                 && this.defaultTier().equals(otherTier.defaultTier());
@@ -67,12 +81,14 @@ public final class Tier {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, description);
+        return Objects.hash(id, created, modified, name, description, defaultTier);
     }
 
     public static Tier.Builder builder(Tier tier) {
         return builder()
                 .id(tier.getId())
+                .created(tier.getCreated())
+                .modified(tier.getModified())
                 .description(tier.getDescription())
                 .name(tier.getName())
                 .defaultTier(tier.defaultTier());
@@ -85,6 +101,8 @@ public final class Tier {
     @JsonPOJOBuilder(withPrefix = "") // setters aren't named with[Property]
     public static final class Builder {
         private String id;
+        private LocalDateTime created;
+        private LocalDateTime modified;
         private String name;
         private String description;
         private Boolean defaultTier = false;
@@ -95,6 +113,16 @@ public final class Tier {
 
         public Builder id(String id) {
             this.id = id;
+            return this;
+        }
+
+        public Builder created(LocalDateTime created) {
+            this.created = created;
+            return this;
+        }
+
+        public Builder modified(LocalDateTime modified) {
+            this.modified = modified;
             return this;
         }
 
@@ -116,10 +144,6 @@ public final class Tier {
         public Tier build() {
             if (Utils.isEmpty(name)) {
                 throw new IllegalArgumentException("Tier must include a non-null, non-empty name.");
-            }
-            if (Utils.isEmpty(id)) {
-                // if no ID was supplied, generate a new one.
-                id = UUID.randomUUID().toString();
             }
             return new Tier(this);
         }

--- a/services/tier-service/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/dal/ddb/DynamoTierAttributeTest.java
+++ b/services/tier-service/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/dal/ddb/DynamoTierAttributeTest.java
@@ -1,0 +1,261 @@
+package com.amazon.aws.partners.saasfactory.saasboost.dal.ddb;
+
+import static org.junit.Assert.assertEquals;
+
+import com.amazon.aws.partners.saasfactory.saasboost.model.Tier;
+import org.junit.Test;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import java.util.UUID;
+
+public class DynamoTierAttributeTest {
+    // TODO migrate to ParameterizedTest in JUnit5
+    private static final String VALID_ID = UUID.randomUUID().toString();
+    private static final String VALID_NAME = "Ultra-Platinum";
+    private static final String VALID_DESC = "The best tier, wow!";
+    private static final LocalDateTime VALID_DATETIME = LocalDateTime.now();
+    private static final Boolean VALID_ISDEFAULT = Boolean.TRUE;
+    private static final Tier VALID_TIER = Tier.builder()
+            .created(VALID_DATETIME)
+            .defaultTier(VALID_ISDEFAULT)
+            .description(VALID_DESC)
+            .id(VALID_ID)
+            .modified(VALID_DATETIME)
+            .name(VALID_NAME)
+            .build();
+    private static final Map<String, AttributeValue> VALID_ATTRIBUTES = Map.of(
+        DynamoTierAttribute.id.name(), AttributeValue.builder().s(VALID_ID).build(),
+        DynamoTierAttribute.created.name(), AttributeValue.builder().s(VALID_DATETIME.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)).build(),
+        DynamoTierAttribute.modified.name(), AttributeValue.builder().s(VALID_DATETIME.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)).build(),
+        DynamoTierAttribute.name.name(), AttributeValue.builder().s(VALID_NAME).build(),
+        DynamoTierAttribute.description.name(), AttributeValue.builder().s(VALID_DESC).build(),
+        DynamoTierAttribute.default_tier.name(), AttributeValue.builder().bool(VALID_ISDEFAULT).build()
+    );
+
+    // Test fromTier for all DynamoTierAttributes
+
+    @Test
+    public void id_fromTier() {
+        assertEquals(VALID_ATTRIBUTES.get(DynamoTierAttribute.id.name()), DynamoTierAttribute.id.fromTier(VALID_TIER));
+    }
+
+    @Test
+    public void id_fromTier_null() {
+        Tier nullIdTier = Tier.builder(VALID_TIER).id(null).build();
+        AttributeValue nullIdAttributeValue = AttributeValue.builder().s(null).build();
+        assertEquals(nullIdAttributeValue, DynamoTierAttribute.id.fromTier(nullIdTier));
+    }
+
+    @Test
+    public void id_fromTier_empty() {
+        Tier emptyIdTier = Tier.builder(VALID_TIER).id("").build();
+        AttributeValue emptyIdAttributeValue = AttributeValue.builder().s("").build();
+        assertEquals(emptyIdAttributeValue, DynamoTierAttribute.id.fromTier(emptyIdTier));
+    }
+
+    @Test
+    public void created_fromTier() {
+        assertEquals(VALID_ATTRIBUTES.get(DynamoTierAttribute.created.name()), DynamoTierAttribute.created.fromTier(VALID_TIER));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void created_fromTier_null() {
+        Tier nullCreatedTier = Tier.builder(VALID_TIER).created(null).build();
+        AttributeValue nullCreatedAttributeValue = AttributeValue.builder().s(null).build();
+        assertEquals(nullCreatedAttributeValue, DynamoTierAttribute.created.fromTier(nullCreatedTier));
+    }
+
+    @Test
+    public void modified_fromTier() {
+        assertEquals(VALID_ATTRIBUTES.get(DynamoTierAttribute.modified.name()), DynamoTierAttribute.modified.fromTier(VALID_TIER));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void modified_fromTier_null() {
+        Tier nullModifiedTier = Tier.builder(VALID_TIER).modified(null).build();
+        AttributeValue nullModifiedAttributeValue = AttributeValue.builder().s(null).build();
+        assertEquals(nullModifiedAttributeValue, DynamoTierAttribute.modified.fromTier(nullModifiedTier));
+    }
+
+    @Test
+    public void name_fromTier() {
+        assertEquals(VALID_ATTRIBUTES.get(DynamoTierAttribute.name.name()), DynamoTierAttribute.name.fromTier(VALID_TIER));
+    }
+
+    // Tier Builder disallows a null and empty names
+
+    @Test
+    public void description_fromTier() {
+        assertEquals(VALID_ATTRIBUTES.get(DynamoTierAttribute.description.name()), DynamoTierAttribute.description.fromTier(VALID_TIER));
+    }
+
+    @Test
+    public void description_fromTier_null() {
+        Tier nullDescriptionTier = Tier.builder(VALID_TIER).description(null).build();
+        AttributeValue nullDescriptionAttributeValue = AttributeValue.builder().s(null).build();
+        assertEquals(nullDescriptionAttributeValue, DynamoTierAttribute.description.fromTier(nullDescriptionTier));
+    }
+
+    @Test
+    public void description_fromTier_empty() {
+        Tier emptyDescriptionTier = Tier.builder(VALID_TIER).description("").build();
+        AttributeValue emptyDescriptionAttributeValue = AttributeValue.builder().s("").build();
+        assertEquals(emptyDescriptionAttributeValue, DynamoTierAttribute.description.fromTier(emptyDescriptionTier));
+    }
+
+    @Test
+    public void defaultTier_fromTier() {
+        assertEquals(VALID_ATTRIBUTES.get(DynamoTierAttribute.default_tier.name()), DynamoTierAttribute.default_tier.fromTier(VALID_TIER));
+    }
+
+    @Test
+    public void defaultTier_fromTier_null() {
+        Tier nullDefaultTier = Tier.builder(VALID_TIER).defaultTier(null).build();
+        AttributeValue nullDefaultAttributeValue = AttributeValue.builder().s(null).build();
+        assertEquals(nullDefaultAttributeValue, DynamoTierAttribute.default_tier.fromTier(nullDefaultTier));
+    }
+
+    // Test toTier for all DynamoTierAttributes
+
+    @Test
+    public void id_toTier_valid() {
+        assertEquals(VALID_ID.toString(), toTierTest(
+                DynamoTierAttribute.id, VALID_ATTRIBUTES.get(DynamoTierAttribute.id.name()))
+            .getId());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void id_toTier_null() {
+        toTierTest(DynamoTierAttribute.id, AttributeValue.builder().s(null).build());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void id_toTier_empty() {
+        toTierTest(DynamoTierAttribute.id, AttributeValue.builder().s("").build());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void id_toTier_nonexistent() {
+        toTierTest(DynamoTierAttribute.id, AttributeValue.builder().build());
+    }
+
+    @Test
+    public void created_toTier_valid() {
+        assertEquals(VALID_DATETIME.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME), toTierTest(
+                DynamoTierAttribute.created, VALID_ATTRIBUTES.get(DynamoTierAttribute.created.name()))
+            .getCreated().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void created_toTier_null() {
+        toTierTest(DynamoTierAttribute.created, AttributeValue.builder().s(null).build());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void created_toTier_empty() {
+        toTierTest(DynamoTierAttribute.created, AttributeValue.builder().s("").build());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void created_toTier_nonexistent() {
+        toTierTest(DynamoTierAttribute.created, AttributeValue.builder().build());
+    }
+
+    @Test
+    public void modified_toTier_valid() {
+        assertEquals(VALID_DATETIME.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME), toTierTest(
+                DynamoTierAttribute.modified, VALID_ATTRIBUTES.get(DynamoTierAttribute.modified.name()))
+            .getModified().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void modified_toTier_null() {
+        toTierTest(DynamoTierAttribute.modified, AttributeValue.builder().s(null).build());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void modified_toTier_empty() {
+        toTierTest(DynamoTierAttribute.modified, AttributeValue.builder().s("").build());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void modified_toTier_nonexistent() {
+        toTierTest(DynamoTierAttribute.modified, AttributeValue.builder().build());
+    }
+
+    @Test
+    public void name_toTier_valid() {
+        assertEquals(VALID_NAME, toTierTest(
+                DynamoTierAttribute.name, VALID_ATTRIBUTES.get(DynamoTierAttribute.name.name()))
+            .getName());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void name_toTier_null() {
+        toTierTest(DynamoTierAttribute.name, AttributeValue.builder().s(null).build());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void name_toTier_empty() {
+        toTierTest(DynamoTierAttribute.name, AttributeValue.builder().s("").build());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void name_toTier_nonexistent() {
+        toTierTest(DynamoTierAttribute.name, AttributeValue.builder().build());
+    }
+
+    @Test
+    public void description_toTier_valid() {
+        assertEquals(VALID_DESC, toTierTest(
+                DynamoTierAttribute.description, VALID_ATTRIBUTES.get(DynamoTierAttribute.description.name()))
+            .getDescription());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void description_toTier_null() {
+        toTierTest(DynamoTierAttribute.description, AttributeValue.builder().s(null).build());
+    }
+
+    public void description_toTier_empty() {
+        assertEquals("", toTierTest(
+                DynamoTierAttribute.description, AttributeValue.builder().s("").build())
+            .getDescription());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void description_toTier_nonexistent() {
+        toTierTest(DynamoTierAttribute.description, AttributeValue.builder().build());
+    }
+
+    @Test
+    public void defaultTier_toTier_valid() {
+        assertEquals(VALID_ISDEFAULT, toTierTest(
+                DynamoTierAttribute.default_tier, VALID_ATTRIBUTES.get(DynamoTierAttribute.default_tier.name()))
+            .defaultTier());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void defaultTier_toTier_null() {
+        toTierTest(DynamoTierAttribute.default_tier, AttributeValue.builder().bool(null).build());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void defaultTier_toTier_nonexistent() {
+        toTierTest(DynamoTierAttribute.default_tier, AttributeValue.builder().build());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void defaultTier_toTier_invalid() {
+        toTierTest(DynamoTierAttribute.default_tier, AttributeValue.builder().s("").build());
+    }
+
+    private Tier toTierTest(DynamoTierAttribute testedAttribute, AttributeValue testAttributeValue) {
+        Tier.Builder testBuilder = Tier.builder(VALID_TIER);
+        testedAttribute.toTier(testBuilder, testAttributeValue);
+        return testBuilder.build();
+    }
+}

--- a/services/tier-service/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/dal/ddb/DynamoTierDataStoreCreateTierTest.java
+++ b/services/tier-service/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/dal/ddb/DynamoTierDataStoreCreateTierTest.java
@@ -64,10 +64,24 @@ public class DynamoTierDataStoreCreateTierTest {
         assertTrue(capturedRequest.hasItem());
         assertTrue("Put item attributes must contain ID.",
                 capturedRequest.item().containsKey(TierAttribute.id.name()));
+        assertTrue("Put item attributes must contain Created.",
+                capturedRequest.item().containsKey(TierAttribute.created.name()));
+        assertTrue("Put item attributes must contain Modified.",
+                capturedRequest.item().containsKey(TierAttribute.modified.name()));
+
+        // we might need to modify expectedAttributes, and it might be unmodifiable. so make a quick copy.
+        expectedAttributes = new HashMap<>(expectedAttributes);
         if (!expectedAttributes.containsKey(TierAttribute.id.name())) {
             // we aren't expecting any ID in particular, so just set the expected ID to be the actual
-            expectedAttributes = new HashMap<>(expectedAttributes);
             expectedAttributes.put(TierAttribute.id.name(), capturedRequest.item().get(TierAttribute.id.name()));
+        }
+        if (!expectedAttributes.containsKey(TierAttribute.created.name())) {
+            // it's unreasonable to expect an exact create time, so just set the expected to be the actual
+            expectedAttributes.put(TierAttribute.created.name(), capturedRequest.item().get(TierAttribute.created.name()));
+        }
+        if (!expectedAttributes.containsKey(TierAttribute.modified.name())) {
+            // it's unreasonable to expect an exact modified time, so just set the expected to be the actual
+            expectedAttributes.put(TierAttribute.modified.name(), capturedRequest.item().get(TierAttribute.modified.name()));
         }
         assertEquals("Put item attributes should match expected.",
                 expectedAttributes,
@@ -80,7 +94,7 @@ public class DynamoTierDataStoreCreateTierTest {
         verifyPutItemRequest(Map.of(
                 TierAttribute.description.name(), AttributeValue.builder().s(VALID_DESC).build(),
                 TierAttribute.name.name(), AttributeValue.builder().s(VALID_NAME).build(),
-                TierAttribute.defaultTier.name(), AttributeValue.builder().bool(false).build()
+                TierAttribute.default_tier.name(), AttributeValue.builder().bool(false).build()
         ));
     }
 
@@ -91,7 +105,7 @@ public class DynamoTierDataStoreCreateTierTest {
                 TierAttribute.description.name(), AttributeValue.builder().s(VALID_DESC).build(),
                 TierAttribute.name.name(), AttributeValue.builder().s(VALID_NAME).build(),
                 TierAttribute.id.name(), AttributeValue.builder().s(VALID_ID).build(),
-                TierAttribute.defaultTier.name(), AttributeValue.builder().bool(false).build()
+                TierAttribute.default_tier.name(), AttributeValue.builder().bool(false).build()
         ));
     }
 

--- a/services/tier-service/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/dal/ddb/DynamoTierDataStoreCreateTierTest.java
+++ b/services/tier-service/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/dal/ddb/DynamoTierDataStoreCreateTierTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.amazon.aws.partners.saasfactory.saasboost.dal.ddb;
 
 import com.amazon.aws.partners.saasfactory.saasboost.model.Tier;
@@ -20,9 +36,9 @@ public class DynamoTierDataStoreCreateTierTest {
     private static final String VALID_DESC = "gold tier description\n123";
     private static final String VALID_NAME = "gold-tier";
     private static final Tier TIER_WITH_ID = Tier.builder()
-            .name(VALID_NAME).id(VALID_ID).description(VALID_DESC).build();
+            .name(VALID_NAME).id(VALID_ID).description(VALID_DESC).defaultTier(false).build();
     private static final Tier TIER_NO_ID = Tier.builder()
-            .name(VALID_NAME).description(VALID_DESC).build();
+            .name(VALID_NAME).description(VALID_DESC).defaultTier(false).build();
 
     private DynamoDbClient mockDdb;
     private DynamoTierDataStore dynamoTierDataStore;
@@ -63,7 +79,8 @@ public class DynamoTierDataStoreCreateTierTest {
         dynamoTierDataStore.createTier(TIER_NO_ID);
         verifyPutItemRequest(Map.of(
                 TierAttribute.description.name(), AttributeValue.builder().s(VALID_DESC).build(),
-                TierAttribute.name.name(), AttributeValue.builder().s(VALID_NAME).build()
+                TierAttribute.name.name(), AttributeValue.builder().s(VALID_NAME).build(),
+                TierAttribute.defaultTier.name(), AttributeValue.builder().bool(false).build()
         ));
     }
 
@@ -73,7 +90,8 @@ public class DynamoTierDataStoreCreateTierTest {
         verifyPutItemRequest(Map.of(
                 TierAttribute.description.name(), AttributeValue.builder().s(VALID_DESC).build(),
                 TierAttribute.name.name(), AttributeValue.builder().s(VALID_NAME).build(),
-                TierAttribute.id.name(), AttributeValue.builder().s(VALID_ID).build()
+                TierAttribute.id.name(), AttributeValue.builder().s(VALID_ID).build(),
+                TierAttribute.defaultTier.name(), AttributeValue.builder().bool(false).build()
         ));
     }
 

--- a/services/tier-service/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/dal/ddb/DynamoTierDataStoreCreateTierTest.java
+++ b/services/tier-service/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/dal/ddb/DynamoTierDataStoreCreateTierTest.java
@@ -63,25 +63,25 @@ public class DynamoTierDataStoreCreateTierTest {
                 TABLE_NAME, capturedRequest.tableName());
         assertTrue(capturedRequest.hasItem());
         assertTrue("Put item attributes must contain ID.",
-                capturedRequest.item().containsKey(TierAttribute.id.name()));
+                capturedRequest.item().containsKey(DynamoTierAttribute.id.name()));
         assertTrue("Put item attributes must contain Created.",
-                capturedRequest.item().containsKey(TierAttribute.created.name()));
+                capturedRequest.item().containsKey(DynamoTierAttribute.created.name()));
         assertTrue("Put item attributes must contain Modified.",
-                capturedRequest.item().containsKey(TierAttribute.modified.name()));
+                capturedRequest.item().containsKey(DynamoTierAttribute.modified.name()));
 
         // we might need to modify expectedAttributes, and it might be unmodifiable. so make a quick copy.
         expectedAttributes = new HashMap<>(expectedAttributes);
-        if (!expectedAttributes.containsKey(TierAttribute.id.name())) {
+        if (!expectedAttributes.containsKey(DynamoTierAttribute.id.name())) {
             // we aren't expecting any ID in particular, so just set the expected ID to be the actual
-            expectedAttributes.put(TierAttribute.id.name(), capturedRequest.item().get(TierAttribute.id.name()));
+            expectedAttributes.put(DynamoTierAttribute.id.name(), capturedRequest.item().get(DynamoTierAttribute.id.name()));
         }
-        if (!expectedAttributes.containsKey(TierAttribute.created.name())) {
+        if (!expectedAttributes.containsKey(DynamoTierAttribute.created.name())) {
             // it's unreasonable to expect an exact create time, so just set the expected to be the actual
-            expectedAttributes.put(TierAttribute.created.name(), capturedRequest.item().get(TierAttribute.created.name()));
+            expectedAttributes.put(DynamoTierAttribute.created.name(), capturedRequest.item().get(DynamoTierAttribute.created.name()));
         }
-        if (!expectedAttributes.containsKey(TierAttribute.modified.name())) {
+        if (!expectedAttributes.containsKey(DynamoTierAttribute.modified.name())) {
             // it's unreasonable to expect an exact modified time, so just set the expected to be the actual
-            expectedAttributes.put(TierAttribute.modified.name(), capturedRequest.item().get(TierAttribute.modified.name()));
+            expectedAttributes.put(DynamoTierAttribute.modified.name(), capturedRequest.item().get(DynamoTierAttribute.modified.name()));
         }
         assertEquals("Put item attributes should match expected.",
                 expectedAttributes,
@@ -92,9 +92,9 @@ public class DynamoTierDataStoreCreateTierTest {
     public void withoutId() {
         dynamoTierDataStore.createTier(TIER_NO_ID);
         verifyPutItemRequest(Map.of(
-                TierAttribute.description.name(), AttributeValue.builder().s(VALID_DESC).build(),
-                TierAttribute.name.name(), AttributeValue.builder().s(VALID_NAME).build(),
-                TierAttribute.default_tier.name(), AttributeValue.builder().bool(false).build()
+                DynamoTierAttribute.description.name(), AttributeValue.builder().s(VALID_DESC).build(),
+                DynamoTierAttribute.name.name(), AttributeValue.builder().s(VALID_NAME).build(),
+                DynamoTierAttribute.default_tier.name(), AttributeValue.builder().bool(false).build()
         ));
     }
 
@@ -102,10 +102,10 @@ public class DynamoTierDataStoreCreateTierTest {
     public void withId() {
         dynamoTierDataStore.createTier(TIER_WITH_ID);
         verifyPutItemRequest(Map.of(
-                TierAttribute.description.name(), AttributeValue.builder().s(VALID_DESC).build(),
-                TierAttribute.name.name(), AttributeValue.builder().s(VALID_NAME).build(),
-                TierAttribute.id.name(), AttributeValue.builder().s(VALID_ID).build(),
-                TierAttribute.default_tier.name(), AttributeValue.builder().bool(false).build()
+                DynamoTierAttribute.description.name(), AttributeValue.builder().s(VALID_DESC).build(),
+                DynamoTierAttribute.name.name(), AttributeValue.builder().s(VALID_NAME).build(),
+                DynamoTierAttribute.id.name(), AttributeValue.builder().s(VALID_ID).build(),
+                DynamoTierAttribute.default_tier.name(), AttributeValue.builder().bool(false).build()
         ));
     }
 

--- a/services/tier-service/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/dal/ddb/DynamoTierDataStoreGetTierTest.java
+++ b/services/tier-service/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/dal/ddb/DynamoTierDataStoreGetTierTest.java
@@ -52,7 +52,7 @@ public class DynamoTierDataStoreGetTierTest {
             .build();
     private static final ArgumentMatcher<GetItemRequest> VALID_REQUEST =
             getItemRequest -> getItemRequest != null && getItemRequest.hasKey()
-                    && VALID_ID.equals(getItemRequest.key().get(TierAttribute.id.name()).s());
+                    && VALID_ID.equals(getItemRequest.key().get(DynamoTierAttribute.id.name()).s());
     private static final ArgumentMatcher<GetItemRequest> INVALID_REQUEST =
             getItemRequest -> !VALID_REQUEST.matches(getItemRequest);
 
@@ -65,12 +65,12 @@ public class DynamoTierDataStoreGetTierTest {
         mockDdb = mock(DynamoDbClient.class);
         final GetItemResponse validResponse = GetItemResponse.builder()
                 .item(Map.of(
-                        TierAttribute.id.name(), AttributeValue.builder().s(VALID_ID).build(),
-                        TierAttribute.created.name(), AttributeValue.builder().s(VALID_TIME).build(),
-                        TierAttribute.modified.name(), AttributeValue.builder().s(VALID_TIME).build(),
-                        TierAttribute.description.name(), AttributeValue.builder().s(VALID_DESC).build(),
-                        TierAttribute.name.name(), AttributeValue.builder().s(VALID_NAME).build(),
-                        TierAttribute.default_tier.name(), AttributeValue.builder().bool(false).build()))
+                        DynamoTierAttribute.id.name(), AttributeValue.builder().s(VALID_ID).build(),
+                        DynamoTierAttribute.created.name(), AttributeValue.builder().s(VALID_TIME).build(),
+                        DynamoTierAttribute.modified.name(), AttributeValue.builder().s(VALID_TIME).build(),
+                        DynamoTierAttribute.description.name(), AttributeValue.builder().s(VALID_DESC).build(),
+                        DynamoTierAttribute.name.name(), AttributeValue.builder().s(VALID_NAME).build(),
+                        DynamoTierAttribute.default_tier.name(), AttributeValue.builder().bool(false).build()))
                 .build();
         final GetItemResponse invalidResponse = GetItemResponse.builder().build();
         when(mockDdb.getItem(ArgumentMatchers.argThat(VALID_REQUEST))).thenReturn(validResponse);
@@ -89,7 +89,7 @@ public class DynamoTierDataStoreGetTierTest {
                 TABLE_NAME, capturedRequest.tableName());
         assertTrue(capturedRequest.hasKey());
         assertEquals("Requested primary key should be id:configuredId.",
-                Map.of(TierAttribute.id.name(), AttributeValue.builder().s(expectedId).build()),
+                Map.of(DynamoTierAttribute.id.name(), AttributeValue.builder().s(expectedId).build()),
                 capturedRequest.key());
         assertTrue("GetItem should use Consistent Reads", capturedRequest.consistentRead());
     }

--- a/services/tier-service/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/dal/ddb/DynamoTierDataStoreGetTierTest.java
+++ b/services/tier-service/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/dal/ddb/DynamoTierDataStoreGetTierTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.amazon.aws.partners.saasfactory.saasboost.dal.ddb;
 
 import com.amazon.aws.partners.saasfactory.saasboost.dal.exception.TierNotFoundException;
@@ -23,7 +39,7 @@ public class DynamoTierDataStoreGetTierTest {
     private static final String VALID_DESC = "gold tier description\n123";
     private static final String VALID_NAME = "gold-tier";
     private static final Tier VALID_TIER = Tier.builder()
-            .name(VALID_NAME).id(VALID_ID).description(VALID_DESC).build();
+            .name(VALID_NAME).id(VALID_ID).description(VALID_DESC).defaultTier(false).build();
     private static final ArgumentMatcher<GetItemRequest> VALID_REQUEST =
             getItemRequest -> getItemRequest != null && getItemRequest.hasKey()
                     && VALID_ID.equals(getItemRequest.key().get(TierAttribute.id.name()).s());
@@ -41,7 +57,8 @@ public class DynamoTierDataStoreGetTierTest {
                 .item(Map.of(
                         TierAttribute.id.name(), AttributeValue.builder().s(VALID_ID).build(),
                         TierAttribute.description.name(), AttributeValue.builder().s(VALID_DESC).build(),
-                        TierAttribute.name.name(), AttributeValue.builder().s(VALID_NAME).build()))
+                        TierAttribute.name.name(), AttributeValue.builder().s(VALID_NAME).build(),
+                        TierAttribute.defaultTier.name(), AttributeValue.builder().bool(false).build()))
                 .build();
         final GetItemResponse invalidResponse = GetItemResponse.builder().build();
         when(mockDdb.getItem(ArgumentMatchers.argThat(VALID_REQUEST))).thenReturn(validResponse);


### PR DESCRIPTION
This PR adds a new page to the Admin UI allowing SaaS Boost admins the ability to easily create, modify, and delete tiers. 

This PR also adds a "default tier" functionality as a convenience to users when adding tiers. A newly created tier will initialize with the saved AppConfig configurations of the default tier, if those configurations exist.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
