### PR TITLE
Enabling SQS encryption at rest using the default KMS key

### DIFF
--- a/resources/saas-boost-svc-onboarding.yaml
+++ b/resources/saas-boost-svc-onboarding.yaml
@@ -86,10 +86,14 @@ Resources:
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt OnboardingValidationDLQ.Arn
         maxReceiveCount: 10
+      KmsMasterKeyId: alias/aws/sqs
+      KmsDataKeyReusePeriodSeconds: 86400
   OnboardingValidationDLQ:
     Type: AWS::SQS::Queue
     Properties:
       QueueName: !Sub sb-${Environment}-onboarding-validation-dlq
+      KmsMasterKeyId: alias/aws/sqs
+      KmsDataKeyReusePeriodSeconds: 86400
   OnboardingTenantConfigQueue:
     Type: AWS::SQS::Queue
     Properties:
@@ -98,10 +102,14 @@ Resources:
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt OnboardingTenantConfigDLQ.Arn
         maxReceiveCount: 10
+      KmsMasterKeyId: alias/aws/sqs
+      KmsDataKeyReusePeriodSeconds: 86400
   OnboardingTenantConfigDLQ:
     Type: AWS::SQS::Queue
     Properties:
       QueueName: !Sub sb-${Environment}-onboarding-tenant-config-dlq
+      KmsMasterKeyId: alias/aws/sqs
+      KmsDataKeyReusePeriodSeconds: 86400
   OnboardingTenantConfigQueuePolicy:
     Type: AWS::SQS::QueuePolicy
     Properties:


### PR DESCRIPTION
SQS encrypts all data in transit by default. We can also encrypt data at rest on the SQS hosts while waiting to be pulled.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
