### PR TITLE
Fill SSL Certificate options from ACM in Admin UI AppConfig.

### DIFF
--- a/client/web/src/options/ducks/index.js
+++ b/client/web/src/options/ducks/index.js
@@ -71,6 +71,8 @@ export const selectDbOptions = (state) => state.options?.data?.dbOptions
 
 export const selectOsOptions = (state) => state.options?.data?.osOptions
 
+export const selectCertOptions = (state) => state.options?.data?.acmOptions
+
 export const selectOSLabel = (state, os) => {
   return isEmpty(os) || isEmpty(state.options?.data?.osOptions)
     ? ''

--- a/client/web/src/settings/AppSettingsSubform.js
+++ b/client/web/src/settings/AppSettingsSubform.js
@@ -55,11 +55,11 @@ export default class AppSettingsSubform extends React.Component {
                       type="select"
                       name="sslCertificate"
                       id="sslCertificate"
-                      label="ACM SSL Certificate"
+                      label={(<a href={this.props.acmConsoleLink} target="new">SSL Certificate</a>)}
                       key="sslCertificate"
                       disabled={this.props.isLocked || this.props.options?.length == 0}
                     >
-                      <option value="">{this.props.certOptions?.length == 0 ? "No Certificates in ACM!" : "Select One..."}</option>
+                      <option value="">{this.props.certOptions?.length == 0 ? "No Valid Certificates" : "Select One..."}</option>
                       {this.props.certOptions?.map((option) => (
                         <option
                           value={option.certificateArn}

--- a/client/web/src/settings/AppSettingsSubform.js
+++ b/client/web/src/settings/AppSettingsSubform.js
@@ -17,9 +17,15 @@ import { PropTypes } from 'prop-types'
 import React, { Fragment } from 'react'
 import { Row, Col, Card, CardBody, CardHeader } from 'reactstrap'
 
-import { SaasBoostInput } from '../components/FormComponents'
+import { SaasBoostInput, SaasBoostSelect } from '../components/FormComponents'
 
 export default class AppSettingsSubform extends React.Component {
+
+  certificateIdFromArn(arn) {
+    let arnParts = arn.split('/')
+    return arnParts[arnParts.length - 1]
+  }
+
   render() {
     return (
       <Fragment>
@@ -45,13 +51,24 @@ export default class AppSettingsSubform extends React.Component {
                       type="text"
                       disabled={this.props.isLocked}
                     />
-                    <SaasBoostInput
-                      key="sslCertificate"
-                      label="SSL Certificate ARN"
+                    <SaasBoostSelect
+                      type="select"
                       name="sslCertificate"
-                      type="text"
-                      disabled={this.props.isLocked}
-                    />
+                      id="sslCertificate"
+                      label="ACM SSL Certificate"
+                      key="sslCertificate"
+                      disabled={this.props.isLocked || this.props.options?.length == 0}
+                    >
+                      <option value="">{this.props.certOptions?.length == 0 ? "No Certificates in ACM!" : "Select One..."}</option>
+                      {this.props.certOptions?.map((option) => (
+                        <option
+                          value={option.certificateArn}
+                          key={option.certificateArn}
+                        >
+                          {option.domainName} (ACM id: {this.certificateIdFromArn(option.certificateArn)})
+                        </option>
+                      ))}
+                    </SaasBoostSelect>
                   </Col>
                 </Row>
               </CardBody>
@@ -65,4 +82,5 @@ export default class AppSettingsSubform extends React.Component {
 
 AppSettingsSubform.propTypes = {
   isLocked: PropTypes.bool,
+  certOptions: PropTypes.array,
 }

--- a/client/web/src/settings/ApplicationComponent.js
+++ b/client/web/src/settings/ApplicationComponent.js
@@ -22,7 +22,7 @@ import { PropTypes } from 'prop-types'
 import * as Yup from 'yup'
 import { Button, Row, Col, Card, Alert } from 'react-bootstrap'
 import LoadingOverlay from '@ronchalant/react-loading-overlay'
-
+import globalConfig from '../config/appConfig'
 import AppSettingsSubform from './AppSettingsSubform'
 import BillingSubform from './BillingSubform'
 import ServicesComponent from './ServicesComponent'
@@ -62,6 +62,8 @@ export function ApplicationComponent(props) {
   const WINDOWS = 'WINDOWS'
   const FSX = 'FSX'
   const EFS = 'EFS'
+  const awsRegion = globalConfig.region
+  const acmConsoleLink = `https://${awsRegion}.console.aws.amazon.com/acm/home?region=${awsRegion}#/certificates/list`
 
   const updateConfig = (values) => {
     updateConfiguration(values)
@@ -464,6 +466,7 @@ export function ApplicationComponent(props) {
                   <AppSettingsSubform
                     isLocked={hasTenants}
                     certOptions={certOptions}
+                    acmConsoleLink={acmConsoleLink}
                   ></AppSettingsSubform>
                   <ServicesComponent
                     formik={formik}

--- a/client/web/src/settings/ApplicationComponent.js
+++ b/client/web/src/settings/ApplicationComponent.js
@@ -34,6 +34,7 @@ ApplicationComponent.propTypes = {
   dbOptions: PropTypes.array,
   hasTenants: PropTypes.bool,
   loading: PropTypes.string,
+  certOptions: PropTypes.array,
   error: PropTypes.bool,
   message: PropTypes.string,
   osOptions: PropTypes.object,
@@ -50,6 +51,7 @@ export function ApplicationComponent(props) {
     hasTenants,
     loading,
     error,
+    certOptions,
     message,
     osOptions,
     updateConfiguration,
@@ -461,6 +463,7 @@ export function ApplicationComponent(props) {
                 <Form>
                   <AppSettingsSubform
                     isLocked={hasTenants}
+                    certOptions={certOptions}
                   ></AppSettingsSubform>
                   <ServicesComponent
                     formik={formik}

--- a/client/web/src/settings/ApplicationContainer.js
+++ b/client/web/src/settings/ApplicationContainer.js
@@ -36,7 +36,7 @@ import {
 
 import { ApplicationComponent } from './ApplicationComponent'
 import { ConfirmModal } from './ConfirmModal'
-import { selectDbOptions, selectOsOptions } from '../options/ducks'
+import { selectDbOptions, selectOsOptions, selectCertOptions } from '../options/ducks'
 import { fetchTenantsThunk, selectAllTenants } from '../tenant/ducks'
 import { fetchTiersThunk, selectAllTiers } from '../tier/ducks'
 
@@ -53,6 +53,7 @@ export function ApplicationContainer(props) {
   const dbOptions = useSelector(selectDbOptions)
   const loading = useSelector(selectLoading)
   const osOptions = useSelector(selectOsOptions)
+  const certOptions = useSelector(selectCertOptions)
   const serviceToS3BucketMap = useSelector(selectServiceToS3BucketMap)
   const settings = useSelector(selectAllSettings)
 
@@ -272,6 +273,7 @@ export function ApplicationContainer(props) {
               hasTenants={hasTenants}
               onFileSelected={handleFileSelected}
               osOptions={osOptions}
+              certOptions={certOptions}
               settings={settings}
               settingsObj={settingsObj}
               error={configError}

--- a/resources/saas-boost-svc-settings.yaml
+++ b/resources/saas-boost-svc-settings.yaml
@@ -199,6 +199,10 @@ Resources:
                 Action:
                   - sts:AssumeRole
                 Resource: !Sub '{{resolve:ssm:/saas-boost/${Environment}/PRIVATE_API_TRUST_ROLE}}'
+              - Effect: Allow
+                Action:
+                  - acm:ListCertificates
+                Resource: '*'
   SettingsServiceGetAllLogs:
     Type: AWS::Logs::LogGroup
     Properties:

--- a/services/settings-service/pom.xml
+++ b/services/settings-service/pom.xml
@@ -138,6 +138,21 @@ limitations under the License.
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
+            <artifactId>acm</artifactId>
+            <version>${aws.java.sdk.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>apache-client</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
             <artifactId>dynamodb</artifactId>
             <version>${aws.java.sdk.version}</version>
             <exclusions>

--- a/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SettingsService.java
+++ b/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SettingsService.java
@@ -24,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.acm.AcmClient;
 import software.amazon.awssdk.services.eventbridge.EventBridgeClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.*;
@@ -293,6 +294,7 @@ public class SettingsService implements RequestHandler<Map<String, Object>, APIG
                         Collectors.toMap(OperatingSystem::name, OperatingSystem::getDescription)
                 ));
         options.put("dbOptions", dal.rdsOptions());
+        options.put("acmOptions", dal.acmCertificateOptions());
 
         APIGatewayProxyResponseEvent response = new APIGatewayProxyResponseEvent()
                 .withStatusCode(200)


### PR DESCRIPTION
This commit switches the SSL Certificate option on the AppConfig page in the Admin UI from a pure text box expecting an ACM ARN to a dropdown that is automatically filled from ACM by the Settings Service. This dropdown displays the main domain configured with the ACM certificate as well as the ARN ID in case there are multiple certificates configured with the same domain name. Currently only PENDING_VALIDATION or ISSUED certificates are displayed.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
