### PR TITLE
Move database configuration to services, performance characteristics (instanceClass) to tier.

### DIFF
--- a/client/web/src/settings/ApplicationComponent.js
+++ b/client/web/src/settings/ApplicationComponent.js
@@ -73,8 +73,8 @@ export function ApplicationComponent(props) {
   const generateAppConfigOrDefaultInitialValuesForTier = (tierValues, defaultValues, fileSystemType) => {
     let tierValuesCopy = Object.assign({}, tierValues)
     let defaults = Object.assign({
-      min: 1,
-      max: 1,
+      min: 0,
+      max: 0,
       computeSize: '',
       filesystem: {
         fileSystemType: fileSystemType,

--- a/client/web/src/settings/ApplicationComponent.js
+++ b/client/web/src/settings/ApplicationComponent.js
@@ -92,34 +92,11 @@ export function ApplicationComponent(props) {
           weeklyMaintenanceDay: '1',
           windowsMountDrive: 'G:',
         }
-      },
-      database: {
-        engine: '',
-        family: '',
-        version: '',
-        instance: '',
-        username: '',
-        password: '',
-        hasEncryptedPassword: false,
-        encryptedPassword: '',
-        database: '',
-        bootstrapFilename: '',
       }
     }, defaultValues)
     let uncleanedInitialTierValues = Object.assign({}, defaults, tierValuesCopy)
     return {
       ...uncleanedInitialTierValues,
-      provisionDb: !!tierValuesCopy.database,
-      database: !!uncleanedInitialTierValues.database ? {
-        ...uncleanedInitialTierValues.database,
-        //This is frail, but try to see if the incoming password is base64d
-        //If so, assume it's encrypted
-        //Also store a copy in the encryptedPassword field
-        hasEncryptedPassword: uncleanedInitialTierValues?.database?.password.match(
-          /^[A-Za-z0-9=+/\s ]+$/
-        ),
-        encryptedPassword: uncleanedInitialTierValues?.database?.password,
-      } : defaults.database,
       provisionFS: !!tierValuesCopy.filesystem,
       filesystem: !!uncleanedInitialTierValues.filesystem ? {
         ...uncleanedInitialTierValues.filesystem,
@@ -154,6 +131,29 @@ export function ApplicationComponent(props) {
         : WINDOWS
       : ''
     const fileSystemType = (os !== LINUX ? FSX : EFS)
+    const db = !!thisService?.database
+        ? {
+            ...thisService.database,
+            //This is frail, but try to see if the incoming password is base64d
+            //If so, assume it's encrypted
+            //Also store a copy in the encryptedPassword field
+            hasEncryptedPassword: !!thisService.database.password.match(
+              /^[A-Za-z0-9=+/\s ]+$/
+            ),
+            encryptedPassword: thisService.database.password,
+          }
+        : {
+            engine: '',
+            family: '',
+            version: '',
+            username: '',
+            password: '',
+            hasEncryptedPassword: false,
+            encryptedPassword: '',
+            database: '',
+            bootstrapFilename: '',
+            tiers: {},
+          }
     const windowsVersion = os === WINDOWS ? thisService.operatingSystem : ''
     let defaultTierName = tiers.filter(t => t.defaultTier)[0].name
     let defaultTierValues = generateAppConfigOrDefaultInitialValuesForTier(Object.assign({}, thisService?.tiers[defaultTierName]), {}, fileSystemType)
@@ -172,7 +172,8 @@ export function ApplicationComponent(props) {
       containerTag: thisService?.containerTag || 'latest',
       description: thisService?.description || '',
       operatingSystem: os,
-      filesystem: { fileSystemType: fileSystemType },
+      database: db,
+      provisionDb: !!thisService?.database,
       windowsVersion: windowsVersion,
       tiers: initialTierValues,
       tombstone: false,
@@ -277,28 +278,6 @@ export function ApplicationComponent(props) {
         Yup.string(),
         'Compute size is a required field.'
       ),
-      database: Yup.object().when('provisionDb', {
-        is: true,
-        then: Yup.object({
-          engine: Yup.string().required('Engine is required'),
-          version: Yup.string().required('Version is required'),
-          instance: Yup.string().required('Instance is required'),
-          username: Yup.string()
-            .matches('^[a-zA-Z]+[a-zA-Z0-9_$]*$', 'Username is not valid')
-            .required('Username is required'),
-          password: Yup.string()
-            .when('hasEncryptedPassword', {
-              is: false,
-              then: Yup.string().matches(
-                '^[a-zA-Z0-9/@"\' ]{8,}$',
-                'Password must be longer than 8 characters and can only contain alphanumberic characters or / @ " \' and spaces'
-              ),
-            })
-            .required('Password is required'),
-          database: Yup.string(),
-        }),
-        otherwise: Yup.object(),
-      }),
       filesystem: Yup.object().when('provisionFS', {
         is: true,
         then: filesystemSpec,
@@ -312,6 +291,21 @@ export function ApplicationComponent(props) {
     for (var i = 0; i < tiers.length; i++) {
       var tierName = tiers[i].name
       allTiers[tierName] = singleTierValidationSpec(tombstone, operatingSystem)
+    }
+    return Yup.object(allTiers)
+  }
+
+  const allTiersDatabaseValidationSpec = (tombstone) => {
+    let allTiers = {}
+    for (var i = 0; i < tiers.length; i++) {
+      var tierName = tiers[i].name
+      allTiers[tierName] = Yup.object({
+        instance: requiredIfNotTombstoned(
+          tombstone,
+          Yup.string(),
+          'Database instance is required.'
+        )
+      })
     }
     return Yup.object(allTiers)
   }
@@ -376,6 +370,30 @@ export function ApplicationComponent(props) {
           otherwise: Yup.string().nullable(),
         }),
         provisionDb: Yup.boolean(),
+        database: Yup.object().when('provisionDb', {
+          is: true,
+          then: Yup.object({
+            engine: Yup.string().required('Engine is required'),
+            version: Yup.string().required('Version is required'),
+            tiers: Yup.object().when('tombstone', (tombstone, schema) => {
+              return allTiersDatabaseValidationSpec(tombstone)
+            }),
+            username: Yup.string()
+              .matches('^[a-zA-Z]+[a-zA-Z0-9_$]*$', 'Username is not valid')
+              .required('Username is required'),
+            password: Yup.string()
+              .when('hasEncryptedPassword', {
+                is: false,
+                then: Yup.string().matches(
+                  '^[a-zA-Z0-9/@"\' ]{8,}$',
+                  'Password must be longer than 8 characters and can only contain alphanumberic characters or / @ " \' and spaces'
+                ),
+              })
+              .required('Password is required'),
+            database: Yup.string(),
+          }),
+          otherwise: Yup.object(),
+        }),
         provisionFS: Yup.boolean(),
         tiers: Yup.object().when(
           ['tombstone', 'operatingSystem'],

--- a/client/web/src/settings/DatabaseSubform.js
+++ b/client/web/src/settings/DatabaseSubform.js
@@ -144,10 +144,7 @@ export default class DatabaseSubform extends React.Component {
                           />
                           <SaasBoostFileUpload
                             fileMask=".sql"
-                            disabled={
-                              !this.props.values?.database ||
-                              this.props.isLocked
-                            }
+                            disabled={!this.props.values || this.props.isLocked}
                             label="Please select or drop a .sql file that will be used to initialize your database"
                             onFileSelected={this.props.onFileSelected}
                             fname={this.props.values?.bootstrapFilename}

--- a/client/web/src/settings/DatabaseSubform.js
+++ b/client/web/src/settings/DatabaseSubform.js
@@ -77,7 +77,7 @@ export default class DatabaseSubform extends React.Component {
                   name={this.props.formikServicePrefix + '.provisionDb'}
                   id={this.props.formikServicePrefix + '.provisionDb'}
                   value={!!this.props?.provisionDb ? true : false}
-                  label="Provision a database for the application"
+                  label="Provision a database for this service"
                 />
                 {this.props.provisionDb && (
                   <Row>

--- a/client/web/src/settings/DatabaseSubform.js
+++ b/client/web/src/settings/DatabaseSubform.js
@@ -35,35 +35,13 @@ export default class DatabaseSubform extends React.Component {
     return options
   }
 
-  getInstanceOptions() {
+  getVersionOptions() {
     const engineVal = this.props.values?.engine
     const engine = this.props.dbOptions?.find((en) => en.engine === engineVal)
     if (!engine) {
       return null
     }
-    const instances = engine.instances
-    const options = instances?.map((instance) => {
-      return (
-        <option value={instance.instance} key={instance.instance}>
-          {instance.class} ({instance.description})
-        </option>
-      )
-    })
-    return options
-  }
-
-  getVersionOptions() {
-    const engineVal = this.props.values?.engine
-    const engine = this.props.dbOptions?.find((en) => en.engine === engineVal)
-    const instanceVal = this.props.values?.instance
-    if (!engine || !instanceVal) {
-      return null
-    }
-    const instance = engine.instances.find((i) => i.instance === instanceVal)
-    if (!instance) {
-      return null
-    }
-    const versions = instance?.versions
+    const versions = engine?.versions
     const options = versions.map((version) => {
       return (
         <option value={version.version} key={version.version}>
@@ -78,14 +56,13 @@ export default class DatabaseSubform extends React.Component {
     const v = event.target.value
     const engineVal = this.props.values?.engine
     const engine = this.props.dbOptions?.find((en) => en.engine === engineVal)
-    const instanceVal = this.props.values?.instance
-    if (!engine || !instanceVal) {
+    if (!engine) {
       return null
     }
-    const instance = engine.instances.find((i) => i.instance === instanceVal)
-    const version = instance.versions.find((ver) => ver.version === v)
+    const version = engine.versions.find((ver) => ver.version === v)
     this.props.values.version = v
     this.props.values.family = version.family
+    this.props.setFieldValue(event.target.attributes.name.value, v)
   }
 
   render() {
@@ -97,8 +74,9 @@ export default class DatabaseSubform extends React.Component {
               <CardHeader>Database</CardHeader>
               <CardBody>
                 <SaasBoostCheckbox
-                  name={this.props.formikTierPrefix + '.provisionDb'}
-                  id={this.props.formikTierPrefix + '.provisionDb'}
+                  name={this.props.formikServicePrefix + '.provisionDb'}
+                  id={this.props.formikServicePrefix + '.provisionDb'}
+                  value={!!this.props?.provisionDb ? true : false}
                   label="Provision a database for the application"
                 />
                 {this.props.provisionDb && (
@@ -106,8 +84,8 @@ export default class DatabaseSubform extends React.Component {
                     <Col xl={6}>
                       <SaasBoostSelect
                         label="Engine"
-                        name={this.props.formikTierPrefix + '.database.engine'}
-                        id={this.props.formikTierPrefix + '.database.engine'}
+                        name={this.props.formikServicePrefix + '.database.engine'}
+                        id={this.props.formikServicePrefix + '.database.engine'}
                         value={this.props.values?.engine}
                         disabled={this.props.isLocked}
                       >
@@ -118,43 +96,29 @@ export default class DatabaseSubform extends React.Component {
                         disabled={
                           !!!this.props.values?.engine || this.props.isLocked
                         }
-                        label="Instance"
-                        name={
-                          this.props.formikTierPrefix + '.database.instance'
-                        }
-                        id={this.props.formikTierPrefix + '.database.instance'}
-                        value={this.props.values?.instance}
-                      >
-                        <option value="">Please select</option>
-                        {this.getInstanceOptions()}
-                      </SaasBoostSelect>
-                      <SaasBoostSelect
-                        disabled={
-                          !!!this.props.values?.instance || this.props.isLocked
-                        }
                         onChange={this.versionChanged}
                         label="Version"
-                        name={this.props.formikTierPrefix + '.database.version'}
-                        id={this.props.formikTierPrefix + '.database.version'}
+                        name={this.props.formikServicePrefix + '.database.version'}
+                        id={this.props.formikServicePrefix + '.database.version'}
                         value={this.props.values?.version}
                       >
                         <option value="">Please select</option>
                         {this.getVersionOptions()}
                       </SaasBoostSelect>
                       <SaasBoostInput
-                        key={this.props.formikTierPrefix + '.database.username'}
+                        key={this.props.formikServicePrefix + '.database.username'}
                         label="Username"
                         name={
-                          this.props.formikTierPrefix + '.database.username'
+                          this.props.formikServicePrefix + '.database.username'
                         }
                         type="text"
                         disabled={this.props.isLocked}
                       />
                       <SaasBoostInput
-                        key={this.props.formikTierPrefix + '.database.password'}
+                        key={this.props.formikServicePrefix + '.database.password'}
                         label="Password"
                         name={
-                          this.props.formikTierPrefix + '.database.password'
+                          this.props.formikServicePrefix + '.database.password'
                         }
                         type="password"
                         disabled={this.props.isLocked}
@@ -169,11 +133,11 @@ export default class DatabaseSubform extends React.Component {
                         <CardBody>
                           <SaasBoostInput
                             key={
-                              this.props.formikTierPrefix + '.database.database'
+                              this.props.formikServicePrefix + '.database.database'
                             }
                             label="Database Name"
                             name={
-                              this.props.formikTierPrefix + '.database.database'
+                              this.props.formikServicePrefix + '.database.database'
                             }
                             type="text"
                             disabled={this.props.isLocked}

--- a/client/web/src/settings/DatabaseTierSubform.js
+++ b/client/web/src/settings/DatabaseTierSubform.js
@@ -1,0 +1,88 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { PropTypes } from 'prop-types'
+import React, { Fragment } from 'react'
+import { Row, Col, Card, CardBody, CardHeader } from 'reactstrap'
+import {SaasBoostSelect} from '../components/FormComponents'
+
+export default class DatabaseTierSubform extends React.Component {
+
+  getInstanceOptions() {
+    const engineVal = this.props.serviceValues?.engine
+    const versionVal = this.props.serviceValues?.version
+    const engine = this.props.dbOptions?.find((en) => en.engine === engineVal)
+    if (!engine || !versionVal) {
+      return null
+    }
+    const version = engine.versions.find((ver) => ver.version === versionVal)
+    if (!version) {
+      return null
+    }
+    const instances = version.instances
+    const options = instances?.map((instance) => {
+      return (
+        <option value={instance.instance} key={instance.instance}>
+          {instance.class} ({instance.description})
+        </option>
+      )
+    })
+    return options
+  }
+
+  render() {
+    return (
+      <Fragment>
+        {this.props.provisionDb && (
+        <Row className="mt-3">
+          <Col xs={12}>
+            <Card>
+              <CardHeader>Database</CardHeader>
+              <CardBody>
+                  <Row>
+                    <Col xl={6}>
+                      <SaasBoostSelect
+                        disabled={
+                          !!!this.props.serviceValues?.version || this.props.isLocked
+                        }
+                        label="Instance"
+                        name={
+                          this.props.formikDatabaseTierPrefix + '.instance'
+                        }
+                        id={this.props.formikDatabaseTierPrefix + '.instance'}
+                        value={this.props.tierValues?.instance}
+                      >
+                        <option value="">Please select</option>
+                        {this.getInstanceOptions()}
+                      </SaasBoostSelect>
+                    </Col>
+                  </Row>
+                {this.props.provisionDb && this.props.dbOptions?.loading && (
+                  <div>Loading ....</div>
+                )}
+              </CardBody>
+            </Card>
+          </Col>
+        </Row>)}
+      </Fragment>
+    )
+  }
+}
+
+DatabaseTierSubform.propTypes = {
+  values: PropTypes.object,
+  provisionDb: PropTypes.bool,
+  isLocked: PropTypes.bool,
+}

--- a/client/web/src/settings/DatabaseTierSubform.js
+++ b/client/web/src/settings/DatabaseTierSubform.js
@@ -43,6 +43,12 @@ export default class DatabaseTierSubform extends React.Component {
   }
 
   render() {
+
+    if (this.props.provisionDb && !!!this.props.tierValues?.instance && !!this.props.defaultTierValues?.instance) {
+      // set instance to default if it doesn't exist already
+      this.props.setFieldValue(this.props.formikDatabaseTierPrefix + '.instance', this.props.defaultTierValues?.instance)
+    }
+
     return (
       <Fragment>
         {this.props.provisionDb && (
@@ -62,7 +68,6 @@ export default class DatabaseTierSubform extends React.Component {
                           this.props.formikDatabaseTierPrefix + '.instance'
                         }
                         id={this.props.formikDatabaseTierPrefix + '.instance'}
-                        value={this.props.tierValues?.instance}
                       >
                         <option value="">Please select</option>
                         {this.getInstanceOptions()}
@@ -85,4 +90,5 @@ DatabaseTierSubform.propTypes = {
   values: PropTypes.object,
   provisionDb: PropTypes.bool,
   isLocked: PropTypes.bool,
+  setFieldValue: PropTypes.func,
 }

--- a/client/web/src/settings/ServiceSettingsSubform.js
+++ b/client/web/src/settings/ServiceSettingsSubform.js
@@ -21,9 +21,10 @@ import { SaasBoostSelect, SaasBoostCheckbox, SaasBoostInput, SaasBoostTextarea }
 import { PropTypes } from 'prop-types'
 import { cibWindows, cibLinux } from '@coreui/icons'
 import CIcon from '@coreui/icons-react'
+import DatabaseSubform from './DatabaseSubform'
 
 const ServiceSettingsSubform = (props) => {
-  const { formikErrors, formikService, osOptions, isLocked, serviceIndex } = props
+  const { formikErrors, serviceValues, osOptions, dbOptions, serviceName, onFileSelected, isLocked, serviceIndex } = props
   const getWinServerOptions = (serviceIndex) => {
     if (!osOptions) {
       return null
@@ -37,7 +38,7 @@ const ServiceSettingsSubform = (props) => {
         </option>
       )
     })
-    return formikService?.operatingSystem === 'WINDOWS' && osOptions ? (
+    return serviceValues?.operatingSystem === 'WINDOWS' && osOptions ? (
       <FormGroup>
         <SaasBoostSelect
           type="select"
@@ -52,20 +53,7 @@ const ServiceSettingsSubform = (props) => {
     ) : null
   }
 
-  // Normally we'd let formik handle this, but we also need to change the filesystem type
-  // based on the container OS
- const onOperatingSystemChange = (val, serviceName) => {
-   const os = val?.target?.value
-   props.formik.setFieldValue(serviceName + '.operatingSystem', os)
-   let fileSystemType = ''
-   if (os === 'WINDOWS') {
-     fileSystemType = 'FSX'
-   }
-   if (os === 'LINUX') {
-     fileSystemType = 'EFS'
-   }
-   props.formik.setFieldValue(serviceName + '.filesystem.fileSystemType', fileSystemType)
- }
+  const operatingSystemFeedback = !!formikErrors.services ? formikErrors.services[serviceIndex].operatingSystem : undefined
 
   return (
     <>
@@ -116,7 +104,6 @@ const ServiceSettingsSubform = (props) => {
                         className="form-check-input"
                         type="radio"
                         id={"os-linux-" + serviceIndex}
-                        onChange={(val) => onOperatingSystemChange(val, "services[" + serviceIndex + "]")}
                         name={"services[" + serviceIndex + "].operatingSystem"}
                         value="LINUX"
                         disabled={isLocked}
@@ -130,7 +117,6 @@ const ServiceSettingsSubform = (props) => {
                         className="form-check-input"
                         type="radio"
                         id={"os-windows-" + serviceIndex}
-                        onChange={(val) => onOperatingSystemChange(val, "services[" + serviceIndex + "]")}
                         name={"services[" + serviceIndex + "].operatingSystem"}
                         value="WINDOWS"
                         disabled={isLocked}
@@ -140,13 +126,9 @@ const ServiceSettingsSubform = (props) => {
                       </Label>
                     </FormGroup>
                     <FormFeedback
-                      invalid={
-                        formikErrors.operatingSystem
-                          ? formikErrors.operatingSystem
-                          : undefined
-                      }
+                      invalid={!!operatingSystemFeedback}
                     >
-                      {formikErrors.operatingSystem}
+                      {operatingSystemFeedback}
                     </FormFeedback>
                   </FormGroup>
                   {getWinServerOptions(serviceIndex)}
@@ -182,6 +164,21 @@ const ServiceSettingsSubform = (props) => {
                   />
                 </Col>
               </Row>
+              <Row>
+                <Col>
+                  <DatabaseSubform
+                    isLocked={isLocked}
+                    formikServicePrefix={'services[' + serviceIndex + ']'}
+                    dbOptions={dbOptions}
+                    provisionDb={
+                      serviceValues?.provisionDb
+                    }
+                    values={serviceValues?.database}
+                    onFileSelected={(file) => onFileSelected(serviceName, file)}
+                    setFieldValue={props.setFieldValue}
+                  ></DatabaseSubform>
+                </Col>
+              </Row>
             </CardBody>
           </Card>
         </Col>
@@ -193,7 +190,9 @@ const ServiceSettingsSubform = (props) => {
 ServiceSettingsSubform.propTypes = {
   osOptions: PropTypes.object,
   isLocked: PropTypes.bool,
-  formikService: PropTypes.object,
+  dbOptions: PropTypes.array,
+  onFileSelected: PropTypes.func,
+  serviceValues: PropTypes.object,
   formikErrors: PropTypes.object,
   serviceIndex: PropTypes.number,
 }

--- a/client/web/src/settings/ServiceSettingsSubform.js
+++ b/client/web/src/settings/ServiceSettingsSubform.js
@@ -53,7 +53,7 @@ const ServiceSettingsSubform = (props) => {
     ) : null
   }
 
-  const operatingSystemFeedback = !!formikErrors.services ? formikErrors.services[serviceIndex].operatingSystem : undefined
+  const operatingSystemFeedback = !!formikErrors.services ? formikErrors.services[serviceIndex]?.operatingSystem : undefined
 
   return (
     <>

--- a/client/web/src/settings/ServicesComponent.js
+++ b/client/web/src/settings/ServicesComponent.js
@@ -56,7 +56,7 @@ const ServicesComponent = (props) => {
   }
 
   const defaultTier = () => {
-    return tiers.filter(t => t.defaultTier)[0].name
+    return tiers?.filter(t => t.defaultTier)[0].name
   }
 
   return (

--- a/client/web/src/settings/ServicesComponent.js
+++ b/client/web/src/settings/ServicesComponent.js
@@ -30,8 +30,7 @@ const ServicesComponent = (props) => {
     dbOptions,
     onFileSelected,
     tiers,
-    initService,
-    setFieldValue
+    initService
   } = props
 
   const [services, setServices] = useState(formik.values.services)
@@ -55,6 +54,11 @@ const ServicesComponent = (props) => {
     // kick off validation so the schema recognizes the tombstone and clears any pending errors
     formik.validateForm()
   }
+
+  const defaultTier = () => {
+    return tiers.filter(t => t.defaultTier)[0].name
+  }
+
   return (
     <>
       <Card className="mb-3">
@@ -90,6 +94,7 @@ const ServicesComponent = (props) => {
                       ></ServiceSettingsSubform>
                       <TierServiceSettingsSubform
                         tiers={tiers}
+                        defaultTier={defaultTier()}
                         isLocked={hasTenants}
                         serviceName={service.name}
                         serviceValues={formik.values.services[index]}

--- a/client/web/src/settings/ServicesComponent.js
+++ b/client/web/src/settings/ServicesComponent.js
@@ -31,6 +31,7 @@ const ServicesComponent = (props) => {
     onFileSelected,
     tiers,
     initService,
+    setFieldValue
   } = props
 
   const [services, setServices] = useState(formik.values.services)
@@ -44,6 +45,7 @@ const ServicesComponent = (props) => {
     let newService = initService(serviceName)
     formik.values.services.push(newService)
     setServices([...formik.values.services])
+    formik.validateForm()
   }
 
   const deleteService = (index) => {
@@ -77,10 +79,14 @@ const ServicesComponent = (props) => {
                       <ServiceSettingsSubform
                         formik={formik}
                         isLocked={hasTenants}
-                        formikService={formik.values.services[index]}
+                        serviceValues={formik.values.services[index]}
                         formikErrors={formikErrors}
                         osOptions={osOptions}
+                        dbOptions={dbOptions}
+                        onFileSelected={onFileSelected}
+                        serviceName={service.name}
                         serviceIndex={index}
+                        setFieldValue={(k, v) => formik.setFieldValue(k, v)}
                       ></ServiceSettingsSubform>
                       <TierServiceSettingsSubform
                         tiers={tiers}
@@ -88,8 +94,8 @@ const ServicesComponent = (props) => {
                         serviceName={service.name}
                         serviceValues={formik.values.services[index]}
                         dbOptions={dbOptions}
-                        onFileSelected={onFileSelected}
                         formikServicePrefix={'services[' + index + ']'}
+                        setFieldValue={(k, v) => formik.setFieldValue(k, v)}
                       ></TierServiceSettingsSubform>
                       <Container className="mt-3">
                         <Row>

--- a/client/web/src/settings/ServicesComponent.js
+++ b/client/web/src/settings/ServicesComponent.js
@@ -56,7 +56,10 @@ const ServicesComponent = (props) => {
   }
 
   const defaultTier = () => {
-    return tiers?.filter(t => t.defaultTier)[0].name
+    let filteredTiers = tiers?.filter(t => t.defaultTier)
+    if (!!filteredTiers && filteredTiers.length > 0) {
+      return filteredTiers[0].name
+    }
   }
 
   return (

--- a/client/web/src/settings/TierServiceSettingsSubform.js
+++ b/client/web/src/settings/TierServiceSettingsSubform.js
@@ -19,7 +19,7 @@ import { SaasBoostSelect, SaasBoostInput } from '../components/FormComponents'
 import { Dropdown, Card, Row, Col } from 'react-bootstrap'
 import { PropTypes } from 'prop-types'
 import FileSystemSubform from './FileSystemSubform'
-import DatabaseSubform from './DatabaseSubform'
+import DatabaseTierSubform from './DatabaseTierSubform'
 
 const TierServiceSettingsSubform = (props) => {
   const {
@@ -36,10 +36,6 @@ const TierServiceSettingsSubform = (props) => {
     !!tiers && !!tiers[0] ? tiers[0].name : ''
   )
 
-  // TODO we have a tierNames list we get from the tier service?
-  // TODO does that need to be controlled by the ApplicationContainer.. wherever the initialValues are set?
-  // TODO I think we can override initialValues as we go along
-  // TODO the only important thing is that it's set going back
   return (
     <>
       <Row>
@@ -149,18 +145,14 @@ const TierServiceSettingsSubform = (props) => {
                     containerOs={serviceValues?.operatingSystem}
                     setFieldValue={props.setFieldValue}
                   ></FileSystemSubform>
-                  <DatabaseSubform
-                    isLocked={isLocked}
-                    formikTierPrefix={
-                      formikServicePrefix + '.tiers[' + selectedTier + ']'
-                    }
+                  <DatabaseTierSubform
+                    serviceValues={serviceValues?.database}
+                    tierValues={serviceValues?.database?.tiers[selectedTier]}
+                    provisionDb={serviceValues?.provisionDb}
                     dbOptions={dbOptions}
-                    provisionDb={
-                      serviceValues?.tiers[selectedTier]?.provisionDb
-                    }
-                    values={serviceValues?.tiers[selectedTier]?.database}
-                    onFileSelected={(file) => onFileSelected(serviceName, file)}
-                  ></DatabaseSubform>
+                    formikDatabaseTierPrefix={formikServicePrefix + '.database.tiers[' + selectedTier + ']'}
+                    isLocked={isLocked}
+                  ></DatabaseTierSubform>
                 </Col>
               </Row>
             </Card.Body>

--- a/client/web/src/settings/TierServiceSettingsSubform.js
+++ b/client/web/src/settings/TierServiceSettingsSubform.js
@@ -25,16 +25,36 @@ const TierServiceSettingsSubform = (props) => {
   const {
     tiers,
     isLocked,
-    serviceName,
     serviceValues,
     dbOptions,
-    onFileSelected,
     formikServicePrefix,
+    defaultTier,
+    setFieldValue
   } = props
 
   const [selectedTier, setSelectedTier] = useState(
     !!tiers && !!tiers[0] ? tiers[0].name : ''
   )
+
+  const formikTierPrefix = formikServicePrefix + '.tiers[' + selectedTier + ']'
+
+  // set compute size if default exists and this tier doesn't
+  if (!!!serviceValues?.tiers[selectedTier]?.computeSize && !!serviceValues?.tiers[defaultTier]?.computeSize) {
+    // set instance to default if it doesn't exist already
+    setFieldValue(formikTierPrefix + '.computeSize', serviceValues?.tiers[defaultTier]?.computeSize)
+  }
+
+  // set min if default exists and this tier doesn't
+  if (!!!serviceValues?.tiers[selectedTier]?.min && !!serviceValues?.tiers[defaultTier]?.min) {
+    // set instance to default if it doesn't exist already
+    setFieldValue(formikTierPrefix + '.min', serviceValues?.tiers[defaultTier]?.min)
+  }
+
+  // set max if default exists and this tier doesn't
+  if (!!!serviceValues?.tiers[selectedTier]?.max && !!serviceValues?.tiers[defaultTier]?.max) {
+    // set instance to default if it doesn't exist already
+    setFieldValue(formikTierPrefix + '.max', serviceValues?.tiers[defaultTier]?.max)
+  }
 
   return (
     <>
@@ -71,18 +91,8 @@ const TierServiceSettingsSubform = (props) => {
                 <Col xs={6}>
                   <SaasBoostSelect
                     type="select"
-                    name={
-                      formikServicePrefix +
-                      '.tiers[' +
-                      selectedTier +
-                      '].computeSize'
-                    }
-                    id={
-                      formikServicePrefix +
-                      '.tiers[' +
-                      selectedTier +
-                      '].computeSize'
-                    }
+                    name={formikTierPrefix + '.computeSize'}
+                    id={formikTierPrefix + '.computeSize'}
                     label="Compute Size"
                   >
                     <option value="">Select One...</option>
@@ -94,37 +104,17 @@ const TierServiceSettingsSubform = (props) => {
                   <Row>
                     <Col>
                       <SaasBoostInput
-                        key={
-                          formikServicePrefix +
-                          '.tiers[' +
-                          selectedTier +
-                          '].min'
-                        }
+                        key={formikTierPrefix + '.min'}
                         label="Minimum Instance Count"
-                        name={
-                          formikServicePrefix +
-                          '.tiers[' +
-                          selectedTier +
-                          '].min'
-                        }
+                        name={formikTierPrefix + '.min'}
                         type="number"
                       />
                     </Col>
                     <Col>
                       <SaasBoostInput
-                        key={
-                          formikServicePrefix +
-                          '.tiers[' +
-                          selectedTier +
-                          '].max'
-                        }
+                        key={formikTierPrefix + '.max'}
                         label="Maximum Instance Count"
-                        name={
-                          formikServicePrefix +
-                          '.tiers[' +
-                          selectedTier +
-                          '].max'
-                        }
+                        name={formikTierPrefix + '.max'}
                         type="number"
                       />
                     </Col>
@@ -135,9 +125,7 @@ const TierServiceSettingsSubform = (props) => {
                 <Col>
                   <FileSystemSubform
                     isLocked={isLocked}
-                    formikTierPrefix={
-                      formikServicePrefix + '.tiers[' + selectedTier + ']'
-                    }
+                    formikTierPrefix={formikTierPrefix}
                     filesystem={serviceValues?.tiers[selectedTier]?.filesystem}
                     provisionFs={
                       serviceValues?.tiers[selectedTier]?.provisionFS
@@ -147,11 +135,13 @@ const TierServiceSettingsSubform = (props) => {
                   ></FileSystemSubform>
                   <DatabaseTierSubform
                     serviceValues={serviceValues?.database}
+                    defaultTierValues={serviceValues?.database?.tiers[defaultTier]}
                     tierValues={serviceValues?.database?.tiers[selectedTier]}
                     provisionDb={serviceValues?.provisionDb}
                     dbOptions={dbOptions}
                     formikDatabaseTierPrefix={formikServicePrefix + '.database.tiers[' + selectedTier + ']'}
                     isLocked={isLocked}
+                    setFieldValue={props.setFieldValue}
                   ></DatabaseTierSubform>
                 </Col>
               </Row>
@@ -168,8 +158,8 @@ TierServiceSettingsSubform.propTypes = {
   isLocked: PropTypes.bool,
   serviceIndex: PropTypes.number,
   formikServiceNamePrefix: PropTypes.string,
-  onFileSelected: PropTypes.func,
   setFieldValue: PropTypes.func,
+  defaultTier: PropTypes.string,
 }
 
 export default TierServiceSettingsSubform

--- a/client/web/src/settings/ducks/index.js
+++ b/client/web/src/settings/ducks/index.js
@@ -308,7 +308,7 @@ export const selectServiceToS3BucketMap = (state) => {
       const map = {
         ...prev,
         [curr]:
-          appConfig?.services[curr].tiers?.default?.database?.bootstrapFilename,
+          appConfig?.services[curr].database?.bootstrapFilename,
       }
       return map
     }, {})

--- a/client/web/update_local_env.sh
+++ b/client/web/update_local_env.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+myEnv="$1"
+if [ "z$myEnv" == "z" ]; then
+    read -p "What environment? " myEnv
+fi
+
+echo "$AWS_DEFAULT_REGION $AWS_REGION" > .env
+myRegion="us-west-2"
+echo "AWS_DEFAULT_REGION=$myRegion" >> .env
+echo "REACT_APP_AWS_REGION=$myRegion" >> .env
+echo "REACT_APP_ENVIRONMENT=$myEnv" >> .env
+echo "REACT_APP_AWS_ACCOUNT=786938756705" >> .env
+echo "DEBUG=true" >> .env
+
+userPoolId=$(aws cognito-idp list-user-pools --max-results 20 | jq -c '.UserPools[] | select (.Name == "'sb-${myEnv}-users'").Id' | cut -d\" -f2)
+echo "REACT_APP_COGNITO_USERPOOL=$userPoolId" >> .env
+
+poolClientId=$(aws cognito-idp list-user-pool-clients --user-pool-id ${userPoolId} | jq '.UserPoolClients[0].ClientId' | cut -d\" -f2)
+echo "REACT_APP_CLIENT_ID=$poolClientId" >> .env
+
+publicApiGId=$(aws apigateway get-rest-apis | jq '.items[] | select (.name == "sb-test-public-api").id' | cut -d\" -f2)
+echo "REACT_APP_API_URI=https://${publicApiGId}.execute-api.${myRegion}.amazonaws.com/v1" >> .env
+
+cat .env

--- a/resources/custom-resources/rds-options/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/Database.java
+++ b/resources/custom-resources/rds-options/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/Database.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 @JsonDeserialize(builder = Database.Builder.class)
 public class Database {
 
-    enum RDS_ENGINE {
+    enum RdsEngine {
         AURORA_PG("aurora-postgresql", "Amazon Aurora PostgreSQL", 5432),
         AURORA_MYSQL("aurora-mysql", "Amazon Aurora MySQL", 3306),
         MYSQL("mysql", "MySQL", 3306),
@@ -38,7 +38,7 @@ public class Database {
         private final String description;
         private final Integer port;
 
-        RDS_ENGINE(String name, String description, Integer port) {
+        RdsEngine(String name, String description, Integer port) {
             this.engine = name;
             this.description = description;
             this.port = port;
@@ -56,9 +56,9 @@ public class Database {
             return port;
         }
 
-        public static RDS_ENGINE ofEngine(String engine) {
-            RDS_ENGINE rdsEngine = null;
-            for (RDS_ENGINE e : RDS_ENGINE.values()) {
+        public static RdsEngine ofEngine(String engine) {
+            RdsEngine rdsEngine = null;
+            for (RdsEngine e : RdsEngine.values()) {
                 if (e.getEngine().equals(engine)) {
                     rdsEngine = e;
                     break;
@@ -66,9 +66,9 @@ public class Database {
             }
             return rdsEngine;
         }
-    };
+    }
 
-    enum RDS_INSTANCE {
+    enum RdsInstance {
         T3_MICRO("db.t3.micro", "2 vCPUs 1 GiB RAM"),
         T3_SMALL("db.t3.small", "2 vCPUs 2 GiB RAM"),
         T3_MEDIUM("db.t3.medium", "2 vCPUs 4 GiB RAM"),
@@ -91,7 +91,7 @@ public class Database {
         private final String instanceClass;
         private final String description;
 
-        RDS_INSTANCE(String name, String description) {
+        RdsInstance(String name, String description) {
             this.instanceClass = name;
             this.description = description;
         }
@@ -104,9 +104,9 @@ public class Database {
             return description;
         }
 
-        public static RDS_INSTANCE ofInstanceClass(String instanceClass) {
-            RDS_INSTANCE instance = null;
-            for (RDS_INSTANCE ec2 : RDS_INSTANCE.values()) {
+        public static RdsInstance ofInstanceClass(String instanceClass) {
+            RdsInstance instance = null;
+            for (RdsInstance ec2 : RdsInstance.values()) {
                 if (ec2.getInstanceClass().equals(instanceClass)) {
                     instance = ec2;
                     break;
@@ -116,8 +116,8 @@ public class Database {
         }
     }
 
-    private RDS_ENGINE engine;
-    private RDS_INSTANCE instance;
+    private RdsEngine engine;
+    private RdsInstance instance;
     private String version;
     private String family;
     private String database;
@@ -182,8 +182,8 @@ public class Database {
     @JsonIgnoreProperties(value = {"engineName", "instanceClass", "port"})
     public static final class Builder {
 
-        private RDS_ENGINE engine;
-        private RDS_INSTANCE instance;
+        private RdsEngine engine;
+        private RdsInstance instance;
         private String version;
         private String family;
         private String database;
@@ -195,18 +195,18 @@ public class Database {
 
         public Builder engine(String engine) {
             try {
-                this.engine = RDS_ENGINE.valueOf(engine);
+                this.engine = RdsEngine.valueOf(engine);
             } catch (IllegalArgumentException e) {
-                this.engine = RDS_ENGINE.ofEngine(engine);
+                this.engine = RdsEngine.ofEngine(engine);
             }
             return this;
         }
 
         public Builder instance(String instance) {
             try {
-                this.instance = RDS_INSTANCE.valueOf(instance);
+                this.instance = RdsInstance.valueOf(instance);
             } catch (IllegalArgumentException e) {
-                this.instance = RDS_INSTANCE.ofInstanceClass(instance);
+                this.instance = RdsInstance.ofInstanceClass(instance);
             }
             return this;
         }

--- a/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingService.java
+++ b/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingService.java
@@ -887,13 +887,15 @@ public class OnboardingService {
                         Integer dbPort = -1;
                         String dbDatabase = "";
                         String dbBootstrap = "";
-                        Map<String, Object> database = (Map<String, Object>) tierConfig.get("database");
+                        Map<String, Object> database = (Map<String, Object>) service.get("database");
                         if (database != null && !database.isEmpty()) {
                             enableDatabase = Boolean.TRUE;
                             dbEngine = (String) database.get("engineName");
                             dbVersion = (String) database.get("version");
                             dbFamily = (String) database.get("family");
-                            dbInstanceClass = (String) database.get("instanceClass");
+                            Map<String, Object> databaseTiers = (Map<String, Object>) database.get("tiers");
+                            Map<String, Object> databaseTierConfig = (Map<String, Object>) databaseTiers.get(tier);
+                            dbInstanceClass = (String) databaseTierConfig.get("instanceClass");
                             dbDatabase = Objects.toString(database.get("database"), "");
                             dbUsername = (String) database.get("username");
                             dbPort = (Integer) database.get("port");

--- a/services/settings-service/pom.xml
+++ b/services/settings-service/pom.xml
@@ -33,7 +33,7 @@ limitations under the License.
     </licenses>
 
     <properties>
-        <checkstyle.maxAllowedViolations>68</checkstyle.maxAllowedViolations>
+        <checkstyle.maxAllowedViolations>46</checkstyle.maxAllowedViolations>
     </properties>
 
     <build>

--- a/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SettingsService.java
+++ b/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SettingsService.java
@@ -58,7 +58,7 @@ public class SettingsService implements RequestHandler<Map<String, Object>, APIG
                     "SERVICE_NAME", "IS_PUBLIC", "PATH", "COMPUTE_SIZE", "TASK_CPU", "TASK_MEMORY", "CONTAINER_PORT", "HEALTH_CHECK",
                     "FILE_SYSTEM_MOUNT_POINT", "FILE_SYSTEM_ENCRYPT", "FILE_SYSTEM_LIFECYCLE", "MIN_COUNT", "MAX_COUNT", "DB_ENGINE",
                     "DB_VERSION", "DB_PARAM_FAMILY", "DB_INSTANCE_TYPE", "DB_NAME", "DB_HOST", "DB_PORT", "DB_MASTER_USERNAME",
-                    "DB_MASTER_PASSWORD", "DB_BOOTSTRAP_FILE", "CLUSTER_OS", "CLUSTER_INSTANCE_TYPE",
+                    "DB_PASSWORD", "DB_BOOTSTRAP_FILE", "CLUSTER_OS", "CLUSTER_INSTANCE_TYPE",
                     //Added for FSX
                     "FILE_SYSTEM_TYPE", // EFS or FSX
                     "FSX_STORAGE_GB", // GB 32 to 65,536

--- a/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SettingsService.java
+++ b/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SettingsService.java
@@ -607,11 +607,8 @@ public class SettingsService implements RequestHandler<Map<String, Object>, APIG
         for (Map.Entry<String, ServiceConfig> serviceConfig : appConfig.getServices().entrySet()) {
             if (serviceName.equals(serviceConfig.getKey())) {
                 ServiceConfig service = serviceConfig.getValue();
-                for (Map.Entry<String, ServiceTierConfig> tierConfig : service.getTiers().entrySet()) {
-                    ServiceTierConfig tier = tierConfig.getValue();
-                    LOGGER.info("Saving bootstrap.sql file for {} {} tier", service.getName(), tierConfig.getKey());
-                    tier.getDatabase().setBootstrapFilename(key);
-                }
+                LOGGER.info("Saving bootstrap.sql file for {}", service.getName());
+                service.getDatabase().setBootstrapFilename(key);
                 dal.setServiceConfig(service);
                 break;
             }
@@ -678,29 +675,24 @@ public class SettingsService implements RequestHandler<Map<String, Object>, APIG
         for (Map.Entry<String, ServiceConfig> serviceConfig : appConfig.getServices().entrySet()) {
             String serviceName = serviceConfig.getKey();
             ServiceConfig service = serviceConfig.getValue();
-            for (Map.Entry<String, ServiceTierConfig> tierConfig : service.getTiers().entrySet()) {
-                ServiceTierConfig tier = tierConfig.getValue();
-                if (tier.hasDatabase() && Utils.isBlank(tier.getDatabase().getBootstrapFilename())) {
-                    try {
-                        // Create a presigned S3 URL to upload the database bootstrap file to
-                        LOGGER.info("Generating S3 presigned URL for service {}", serviceName);
-                        final String key = "services/" + serviceName + "/bootstrap.sql";
-                        final Duration expires = Duration.ofMinutes(15); // UI times out in 10 min
-                        PresignedPutObjectRequest presignedObject = presigner.presignPutObject(request -> request
-                                .signatureDuration(expires)
-                                .putObjectRequest(PutObjectRequest.builder()
-                                        .bucket(RESOURCES_BUCKET)
-                                        .key(key)
-                                        .build()
-                                )
-                                .build()
-                        );
-                        tier.getDatabase().setBootstrapFilename(presignedObject.url().toString());
-                    } catch (S3Exception s3Error) {
-                        LOGGER.error("s3 presign url failed", s3Error);
-                        LOGGER.error(Utils.getFullStackTrace(s3Error));
-                        throw s3Error;
-                    }
+            if (service.hasDatabase() && Utils.isBlank(service.getDatabase().getBootstrapFilename())) {
+                try {
+                    // Create a presigned S3 URL to upload the database bootstrap file to
+                    final String key = "services/" + serviceName + "/bootstrap.sql";
+                    final Duration expires = Duration.ofMinutes(15); // UI times out in 10 min
+                    PresignedPutObjectRequest presignedObject = presigner.presignPutObject(request -> request
+                            .signatureDuration(expires)
+                            .putObjectRequest(PutObjectRequest.builder()
+                                    .bucket(RESOURCES_BUCKET)
+                                    .key(key)
+                                    .build()
+                            ).build()
+                    );
+                    service.getDatabase().setBootstrapFilename(presignedObject.url().toString());
+                } catch (S3Exception s3Error) {
+                    LOGGER.error("s3 presign url failed", s3Error);
+                    LOGGER.error(Utils.getFullStackTrace(s3Error));
+                    throw s3Error;
                 }
             }
         }

--- a/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SettingsServiceDAL.java
+++ b/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SettingsServiceDAL.java
@@ -352,7 +352,7 @@ public class SettingsServiceDAL {
 
         for (Map.Entry<String, String> appSetting : appSettings.entrySet()) {
             // every key that contains a "/" is necessarily nested under app
-            // e.g. /app/service_001/DB_MASTER_PASSWORD
+            // e.g. /app/service_001/DB_PASSWORD
             //      /app/service_001/SERVICE_JSON
             if (appSetting.getKey().contains("/") && appSetting.getKey().endsWith("SERVICE_JSON")) {
                 ServiceConfig existingServiceConfig = Utils.fromJson(appSetting.getValue(), ServiceConfig.class);
@@ -361,7 +361,7 @@ public class SettingsServiceDAL {
                 ServiceConfig.Builder editedServiceConfigBuilder = ServiceConfig.builder(existingServiceConfig);
                 if (existingServiceConfig.hasDatabase()) {
                     Database.Builder editedDatabaseBuilder = Database.builder(existingServiceConfig.getDatabase());
-                    Setting dbMasterPasswordSetting = getSetting(APP_BASE_PATH + existingServiceConfig.getName() + "/DB_MASTER_PASSWORD", false);
+                    Setting dbMasterPasswordSetting = getSetting(APP_BASE_PATH + existingServiceConfig.getName() + "/DB_PASSWORD", false);
                     if (dbMasterPasswordSetting != null) {
                         editedDatabaseBuilder.password(dbMasterPasswordSetting.getValue());
                     }
@@ -510,8 +510,8 @@ public class SettingsServiceDAL {
 
     public List<Setting> serviceConfigToSettings(ServiceConfig serviceConfig) {
         List<Setting> settings = new ArrayList<>();
-        // we're keeping the DB_MASTER_PASSWORD separate so we have an accessible form *somewhere*
-        // but that means we need to create the DB_MASTER_PASSWORD for each Service
+        // we're keeping the DB_PASSWORD separate so we have an accessible form *somewhere*
+        // but that means we need to create the DB_PASSWORD for each Service
 
         // editedServiceConfig so that we can replace the password in all databases in tiers to have empty passwords
         // that way we aren't storing actual passwords.
@@ -521,7 +521,7 @@ public class SettingsServiceDAL {
             dbPasswordSettingValue = serviceConfig.getDatabase().getPassword();
 
             Setting dbPasswordSetting = Setting.builder()
-                    .name(APP_BASE_PATH + serviceConfig.getName() + "/DB_MASTER_PASSWORD")
+                    .name(APP_BASE_PATH + serviceConfig.getName() + "/DB_PASSWORD")
                     .value(dbPasswordSettingValue)
                     .secure(true).readOnly(false).build();
             settings.add(dbPasswordSetting);
@@ -529,7 +529,7 @@ public class SettingsServiceDAL {
             // place the passwordParam so appConfig holders can find the password if they need it
             // and override password
             // passwordParam should be an arn of the form
-            // arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/saas-boost/${Environment}/DB_MASTER_PASSWORD
+            // arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/saas-boost/${Environment}/DB_PASSWORD
             editedServiceConfigBuilder.database(Database.builder(serviceConfig.getDatabase())
                     .password("**encrypted**")
                     .passwordParam(toParameterStore(dbPasswordSetting).name())

--- a/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SettingsServiceDAL.java
+++ b/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SettingsServiceDAL.java
@@ -195,11 +195,11 @@ public class SettingsServiceDAL {
         return certificateSummaries;
     }
 
-    private static final Comparator<Map<String, Object>> INSTANCE_TYPE_COMPARATOR = ((instance1, instance2) -> {
+    private static final Comparator<Map<String, String>> INSTANCE_TYPE_COMPARATOR = ((instance1, instance2) -> {
         // T's before M's before R's
         int compare = 0;
-        char type1 = ((String) instance1.get("instance")).charAt(0);
-        char type2 = ((String) instance2.get("instance")).charAt(0);
+        char type1 = instance1.get("instance").charAt(0);
+        char type2 = instance2.get("instance").charAt(0);
         if (type1 != type2) {
             if ('T' == type1) {
                 compare = -1;
@@ -214,15 +214,15 @@ public class SettingsServiceDAL {
         return compare;
     });
 
-    private static final Comparator<Map<String, Object>> INSTANCE_GENERATION_COMPARATOR = ((instance1, instance2) -> {
-        Integer gen1 = Integer.valueOf(((String) instance1.get("instance")).substring(1, 2));
-        Integer gen2 = Integer.valueOf(((String) instance2.get("instance")).substring(1, 2));
+    private static final Comparator<Map<String, String>> INSTANCE_GENERATION_COMPARATOR = ((instance1, instance2) -> {
+        Integer gen1 = Integer.valueOf(instance1.get("instance").substring(1, 2));
+        Integer gen2 = Integer.valueOf(instance2.get("instance").substring(1, 2));
         return gen1.compareTo(gen2);
     });
 
-    private static final Comparator<Map<String, Object>> INSTANCE_SIZE_COMPARATOR = ((instance1, instance2) -> {
-        String size1 = ((String) instance1.get("instance")).substring(3);
-        String size2 = ((String) instance2.get("instance")).substring(3);
+    private static final Comparator<Map<String, String>> INSTANCE_SIZE_COMPARATOR = ((instance1, instance2) -> {
+        String size1 = instance1.get("instance").substring(3);
+        String size2 = instance2.get("instance").substring(3);
         List<String> sizes = Arrays.asList(
                 "MICRO",
                 "SMALL",
@@ -237,7 +237,7 @@ public class SettingsServiceDAL {
         return Integer.compare(sizes.indexOf(size1), sizes.indexOf(size2));
     });
 
-    public static final Comparator<Map<String, Object>> RDS_INSTANCE_COMPARATOR = INSTANCE_TYPE_COMPARATOR
+    public static final Comparator<Map<String, String>> RDS_INSTANCE_COMPARATOR = INSTANCE_TYPE_COMPARATOR
             .thenComparing(INSTANCE_GENERATION_COMPARATOR)
             .thenComparing(INSTANCE_SIZE_COMPARATOR);
 
@@ -249,32 +249,29 @@ public class SettingsServiceDAL {
         option.put("name", optionAttributes.get("name").s());
         option.put("description", optionAttributes.get("description").s());
 
-        List<Map<String, Object>> instances = new ArrayList<>();
-        for (Map.Entry<String, AttributeValue> optionAttribute : optionAttributes.get("instances").m().entrySet()) {
-            //build the instance entry
-            Map<String, Object> instance = new LinkedHashMap<>(); // Used a linked map so we can sort stuff
-            Map<String, AttributeValue> instanceAttributes = optionAttribute.getValue().m();
-            instance.put("instance",optionAttribute.getKey());
-            instance.put("class",instanceAttributes.get("class").s());
-            instance.put("description",instanceAttributes.get("description").s());
+        List<Map<String, Object>> versions = new ArrayList<>();
+        for (AttributeValue versionAttribute : optionAttributes.get("versions").l()) {
+            // build the version entry
+            Map<String, AttributeValue> versionAttributeMap = versionAttribute.m();
+            Map<String, Object> version = new LinkedHashMap<>(); // use a linked map so we can sort
+            version.put("description", versionAttributeMap.get("description").s());
+            version.put("family", versionAttributeMap.get("family").s());
+            version.put("version", versionAttributeMap.get("version").s());
 
-            List<Map<String, String>> versions = new ArrayList<>();
-            List<AttributeValue> versionAttributes = instanceAttributes.get("versions").l();
-            for (AttributeValue versionAttribute : versionAttributes) {
-                versions.add(
-                        versionAttribute.m().entrySet().stream()
-                                .collect(Collectors.toMap(
-                                        entry -> entry.getKey(),
-                                        entry -> entry.getValue().s()
-                                ))
-                );
+            List<Map<String, String>> instances = new ArrayList<>();
+            Map<String, AttributeValue> instancesAttributeMap = versionAttributeMap.get("instances").m();
+            for (Map.Entry<String, AttributeValue> instanceAttribute : instancesAttributeMap.entrySet()) {
+                Map<String, String> instance = new LinkedHashMap<>(); // use a linked map so we can sort
+                instance.put("instance", instanceAttribute.getKey());
+                instance.put("class", instanceAttribute.getValue().m().get("class").s());
+                instance.put("description", instanceAttribute.getValue().m().get("description").s());
+                instances.add(instance);
             }
-
-            instance.put("versions", versions);
-            instances.add(instance);
+            Collections.sort(instances, RDS_INSTANCE_COMPARATOR);
+            version.put("instances", instances);
+            versions.add(version);
         }
-        Collections.sort(instances, RDS_INSTANCE_COMPARATOR);
-        option.put("instances", instances);
+        option.put("versions", versions);
 
         return option;
     }
@@ -359,25 +356,18 @@ public class SettingsServiceDAL {
             //      /app/service_001/SERVICE_JSON
             if (appSetting.getKey().contains("/") && appSetting.getKey().endsWith("SERVICE_JSON")) {
                 ServiceConfig existingServiceConfig = Utils.fromJson(appSetting.getValue(), ServiceConfig.class);
-                ServiceConfig.Builder editedServiceConfig = ServiceConfig.builder(existingServiceConfig);
-                Map<String, ServiceTierConfig> newTiers = new HashMap<>();
-                for (Map.Entry<String, ServiceTierConfig> nameAndTier : existingServiceConfig.getTiers().entrySet()) {
-                    String name = nameAndTier.getKey();
-                    ServiceTierConfig tier = nameAndTier.getValue();
-                    ServiceTierConfig.Builder editedTier = ServiceTierConfig.builder(tier);
-                    if (tier.hasDatabase()) {
-                        // if this tier has a database, override the password with the encrypted version
-                        Database.Builder editedDatabase = Database.builder(tier.getDatabase());
-                        Setting dbMasterPasswordSetting = getSetting(APP_BASE_PATH + existingServiceConfig.getName() + "/" + name + "/DB_MASTER_PASSWORD", false);
-                        if (dbMasterPasswordSetting != null) {
-                            editedDatabase.password(dbMasterPasswordSetting.getValue());
-                        }
-                        editedTier.database(editedDatabase.build());
+
+                // if this serviceConfig has a database, override the password with the encrypted version
+                ServiceConfig.Builder editedServiceConfigBuilder = ServiceConfig.builder(existingServiceConfig);
+                if (existingServiceConfig.hasDatabase()) {
+                    Database.Builder editedDatabaseBuilder = Database.builder(existingServiceConfig.getDatabase());
+                    Setting dbMasterPasswordSetting = getSetting(APP_BASE_PATH + existingServiceConfig.getName() + "/DB_MASTER_PASSWORD", false);
+                    if (dbMasterPasswordSetting != null) {
+                        editedDatabaseBuilder.password(dbMasterPasswordSetting.getValue());
                     }
-                    newTiers.put(name, editedTier.build());
+                    editedServiceConfigBuilder.database(editedDatabaseBuilder.build());
                 }
-                editedServiceConfig.tiers(newTiers);
-                appConfigBuilder.serviceConfig(editedServiceConfig.build());
+                appConfigBuilder.serviceConfig(editedServiceConfigBuilder.build());
             }
         }
 
@@ -525,50 +515,30 @@ public class SettingsServiceDAL {
 
         // editedServiceConfig so that we can replace the password in all databases in tiers to have empty passwords
         // that way we aren't storing actual passwords.
-        ServiceConfig.Builder editedServiceConfig = ServiceConfig.builder(serviceConfig);
-        Map<String, ServiceTierConfig> editedTiers = new HashMap<>();
-        for (Map.Entry<String, ServiceTierConfig> nameAndTierConfig : serviceConfig.getTiers().entrySet()) {
-            String dbPasswordSettingValue = null;
-            if (nameAndTierConfig.getValue().hasDatabase()) {
-                dbPasswordSettingValue = nameAndTierConfig.getValue().getDatabase().getPassword();
+        ServiceConfig.Builder editedServiceConfigBuilder = ServiceConfig.builder(serviceConfig);
+        String dbPasswordSettingValue = null;
+        if (serviceConfig.hasDatabase()) {
+            dbPasswordSettingValue = serviceConfig.getDatabase().getPassword();
 
-                // tiers are /saas-boost/env/app/serviceName/tierName/
-                // but we're setting db password at service level
-                Setting dbPasswordSetting = Setting.builder()
-                        .name(APP_BASE_PATH + serviceConfig.getName() + "/" + nameAndTierConfig.getKey() + "/DB_MASTER_PASSWORD")
-                        .value(dbPasswordSettingValue)
-                        .secure(true).readOnly(false).build();
-                settings.add(dbPasswordSetting);
+            Setting dbPasswordSetting = Setting.builder()
+                    .name(APP_BASE_PATH + serviceConfig.getName() + "/DB_MASTER_PASSWORD")
+                    .value(dbPasswordSettingValue)
+                    .secure(true).readOnly(false).build();
+            settings.add(dbPasswordSetting);
 
-                // place the passwordParam so appConfig holders can find the password if they need it
-                // and override password
-                // passwordParam should be an arn of the form
-                // arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/saas-boost/${Environment}/DB_MASTER_PASSWORD
-                ServiceTierConfig.Builder editedTierConfig = ServiceTierConfig.builder(nameAndTierConfig.getValue());
-                editedTierConfig.database(
-                    Database.builder(nameAndTierConfig.getValue().getDatabase())
-                        .password("**encrypted**")
-                        .passwordParam(toParameterStore(dbPasswordSetting).name())
-                        .build());
-                editedTiers.put(nameAndTierConfig.getKey(), editedTierConfig.build());
-            } else {
-                editedTiers.put(nameAndTierConfig.getKey(), nameAndTierConfig.getValue());
-            }
+            // place the passwordParam so appConfig holders can find the password if they need it
+            // and override password
+            // passwordParam should be an arn of the form
+            // arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/saas-boost/${Environment}/DB_MASTER_PASSWORD
+            editedServiceConfigBuilder.database(Database.builder(serviceConfig.getDatabase())
+                    .password("**encrypted**")
+                    .passwordParam(toParameterStore(dbPasswordSetting).name())
+                    .build());
         }
 
-        editedServiceConfig.tiers(editedTiers);
-        // if we don't remove the password from the database object in serviceConfig we'll end up storing it
-        // we can't @Ignore password because we're expecting to send it back
-        // the UI could have two defaults: '' means no database already configured, just the value of param otherwise
-        // we have this logic in the settings service to check if it's the same as the encrypted value though
-        // and we do that with the billing api key. it makes more sense to do the same with the database.
-        // which means we should return the encrypted password
-        // which means we can't ignore the password
-        // which means when we store this password in this serviceConfig we need to obfuscate.
-        // but that's what I'm saying.. it doesn't matter what I store, as long as it isn't the plaintext.
         settings.add(Setting.builder()
                 .name(APP_BASE_PATH + serviceConfig.getName() + "/SERVICE_JSON")
-                .value(Utils.toJson(editedServiceConfig.build()))
+                .value(Utils.toJson(editedServiceConfigBuilder.build()))
                 .readOnly(false).build());
 
         return settings;

--- a/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/Database.java
+++ b/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/Database.java
@@ -20,107 +20,14 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 @JsonDeserialize(builder = Database.Builder.class)
 public class Database {
 
-    enum RDS_ENGINE {
-        AURORA_PG("aurora-postgresql", "Amazon Aurora PostgreSQL", 5432),
-        AURORA_MYSQL("aurora-mysql", "Amazon Aurora MySQL", 3306),
-        MYSQL("mysql", "MySQL", 3306),
-        MARIADB("mariadb", "MariaDB", 3306),
-        POSTGRES("postgres", "PostgreSQL", 5432),
-        MS_SQL_EXPRESS("sqlserver-ex", "SQL Server Express Edition", 1433),
-        MS_SQL_WEB("sqlserver-web", "SQL Server Web Edition", 1433),
-        MS_SQL_STANDARD("sqlserver-se", "SQL Server Standard Edition", 1433),
-        MS_SQL_ENTERPRISE("sqlserver-ee", "SQL Server Enterprise Edition", 1433),
-        ORACLE("oracle-ee", "Oracle", 1521);
-
-        private final String engine;
-        private final String description;
-        private final Integer port;
-
-        RDS_ENGINE(String name, String description, Integer port) {
-            this.engine = name;
-            this.description = description;
-            this.port = port;
-        }
-
-        public String getEngine() {
-            return engine;
-        }
-
-        public String getDescription() {
-            return description;
-        }
-
-        public Integer getPort() {
-            return port;
-        }
-
-        public static RDS_ENGINE ofEngine(String engine) {
-            RDS_ENGINE rdsEngine = null;
-            for (RDS_ENGINE e : RDS_ENGINE.values()) {
-                if (e.getEngine().equals(engine)) {
-                    rdsEngine = e;
-                    break;
-                }
-            }
-            return rdsEngine;
-        }
-    }
-
-    enum RDS_INSTANCE {
-        T3_MICRO("db.t3.micro", "2 vCPUs 1 GiB RAM"),
-        T3_SMALL("db.t3.small", "2 vCPUs 2 GiB RAM"),
-        T3_MEDIUM("db.t3.medium", "2 vCPUs 4 GiB RAM"),
-        T3_LARGE("db.t3.large", "2 vCPUs 8 GiB RAM"),
-        T3_XL("db.t3.xlarge", "4 vCPUs 16 GiB RAM"),
-        T3_2XL("db.t3.2xlarge", "8 vCPUs 32 GiB RAM"),
-        M5_LARGE("db.m5.large", "2 vCPUs 8 GiB RAM"),
-        M5_XL("db.m5.xlarge", "4 vCPUs 16 GiB RAM"),
-        M5_2XL("db.m5.2xlarge", "8 vCPUs 32 GiB RAM"),
-        M5_4XL("db.m5.4xlarge", "16 vCPUs 64 GiB RAM"),
-        M5_12XL("db.m5.12xlarge", "48 vCPUs 192 GiB RAM"),
-        M5_24XL("db.m5.24xlarge", "96 vCPUs 384 GiB RAM"),
-        R5_LARGE("db.r5.large", "2 vCPUs 16 GiB RAM"),
-        R5_XL("db.r5.xlarge", "4 vCPUs 32 GiB RAM"),
-        R5_2XL("db.r5.2xlarge", "8 vCPUs 64 GiB RAM"),
-        R5_4XL("db.r5.4xlarge", "16 vCPUs 128 GiB RAM"),
-        R5_12XL("db.r5.12xlarge", "48 vCPUs 384 GiB RAM"),
-        R5_24XL("db.r5.24xlarge", "96 vCPUs 768 GiB RAM");
-
-        private final String instanceClass;
-        private final String description;
-
-        RDS_INSTANCE(String name, String description) {
-            this.instanceClass = name;
-            this.description = description;
-        }
-
-        public String getInstanceClass() {
-            return instanceClass;
-        }
-
-        public String getDescription() {
-            return description;
-        }
-
-        public static RDS_INSTANCE ofInstanceClass(String instanceClass) {
-            RDS_INSTANCE instance = null;
-            for (RDS_INSTANCE ec2 : RDS_INSTANCE.values()) {
-                if (ec2.getInstanceClass().equals(instanceClass)) {
-                    instance = ec2;
-                    break;
-                }
-            }
-            return instance;
-        }
-    }
-
-    private final RDS_ENGINE engine;
-    private final RDS_INSTANCE instance;
+    private final RdsEngine engine;
     private final String version;
     private final String family;
     private final String database;
@@ -128,10 +35,10 @@ public class Database {
     private final String password;
     private String bootstrapFilename;
     private String passwordParam;
+    private final Map<String, DatabaseTierConfig> tiers;
 
     private Database(Builder builder) {
         this.engine = builder.engine;
-        this.instance = builder.instance;
         this.version = builder.version;
         this.family = builder.family;
         this.database = builder.database;
@@ -139,6 +46,7 @@ public class Database {
         this.password = builder.password;
         this.bootstrapFilename = builder.bootstrapFilename;
         this.passwordParam = builder.passwordParam;
+        this.tiers = builder.tiers;
     }
 
     public String getEngine() {
@@ -147,14 +55,6 @@ public class Database {
 
     public String getEngineName() {
         return engine != null ? engine.getEngine() : null;
-    }
-
-    public String getInstance() {
-        return instance != null ? instance.name() : null;
-    }
-
-    public String getInstanceClass() {
-        return instance != null ? instance.getInstanceClass() : null;
     }
 
     public String getVersion() {
@@ -197,6 +97,10 @@ public class Database {
         this.bootstrapFilename = bootstrapFilename;
     }
 
+    public Map<String, DatabaseTierConfig> getTiers() {
+        return tiers;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (obj == null) {
@@ -211,21 +115,38 @@ public class Database {
             return false;
         }
         final Database other = (Database) obj;
+
+        boolean tiersEqual = tiers != null && other.tiers != null;
+        if (tiersEqual) {
+            tiersEqual = tiers.size() == other.tiers.size();
+            if (tiersEqual) {
+                for (Map.Entry<String, DatabaseTierConfig> tier : tiers.entrySet()) {
+                    tiersEqual = tier.getValue().equals(other.tiers.get(tier.getKey()));
+                    if (!tiersEqual) {
+                        break;
+                    }
+                }
+            }
+        }
+
         return (
                 ((version == null && other.version == null) || (version != null && version.equals(other.version)))
                 && ((family == null && other.family == null) || (family != null && family.equals(other.family)))
-                && ((database == null && other.database == null) || (database != null && database.equalsIgnoreCase(other.database)))
-                && ((username == null && other.username == null) || (username != null && username.equals(other.username)))
-                && ((password == null && other.password == null) || (password != null && password.equals(other.password)))
-                && ((bootstrapFilename == null && other.bootstrapFilename == null) || (bootstrapFilename != null && bootstrapFilename.equals(other.bootstrapFilename)))
+                && ((database == null && other.database == null)
+                    || (database != null && database.equalsIgnoreCase(other.database)))
+                && ((username == null && other.username == null)
+                    || (username != null && username.equals(other.username)))
+                && ((password == null && other.password == null)
+                    || (password != null && password.equals(other.password)))
+                && ((bootstrapFilename == null && other.bootstrapFilename == null)
+                    || (bootstrapFilename != null && bootstrapFilename.equals(other.bootstrapFilename)))
                 && (engine == other.engine)
-                && (instance == other.instance)
-        );
+                && ((tiers == null && other.tiers == null) || tiersEqual));
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(version, family, database, username, password, bootstrapFilename, engine, instance);
+        return Objects.hash(version, family, database, username, password, bootstrapFilename, engine, tiers);
     }
 
     public static Builder builder() {
@@ -235,22 +156,21 @@ public class Database {
     public static Builder builder(Database other) {
         return new Builder()
             .engine(other.getEngine())
-            .instance(other.getInstance())
             .version(other.getVersion())
             .family(other.getFamily())
             .database(other.getDatabase())
             .username(other.getUsername())
             .password(other.getPassword())
             .passwordParam(other.getPasswordParam())
-            .bootstrapFilename(other.getBootstrapFilename());
+            .bootstrapFilename(other.getBootstrapFilename())
+            .tiers(other.getTiers());
     }
 
     @JsonPOJOBuilder(withPrefix = "") // setters aren't named with[Property]
-    @JsonIgnoreProperties(value = {"engineName", "instanceClass", "port"})
+    @JsonIgnoreProperties(value = {"engineName", "port"})
     public static final class Builder {
 
-        private RDS_ENGINE engine;
-        private RDS_INSTANCE instance;
+        private RdsEngine engine;
         private String version;
         private String family;
         private String database;
@@ -258,24 +178,16 @@ public class Database {
         private String password;
         private String passwordParam;
         private String bootstrapFilename;
+        private Map<String, DatabaseTierConfig> tiers = new HashMap<>();
 
         private Builder() {
         }
 
         public Builder engine(String engine) {
             try {
-                this.engine = RDS_ENGINE.valueOf(engine);
+                this.engine = RdsEngine.valueOf(engine);
             } catch (IllegalArgumentException e) {
-                this.engine = RDS_ENGINE.ofEngine(engine);
-            }
-            return this;
-        }
-
-        public Builder instance(String instance) {
-            try {
-                this.instance = RDS_INSTANCE.valueOf(instance);
-            } catch (IllegalArgumentException e) {
-                this.instance = RDS_INSTANCE.ofInstanceClass(instance);
+                this.engine = RdsEngine.ofEngine(engine);
             }
             return this;
         }
@@ -315,8 +227,59 @@ public class Database {
             return this;
         }
 
+        public Builder tiers(Map<String, DatabaseTierConfig> tiers) {
+            this.tiers = tiers != null ? tiers : new HashMap<>();
+            return this;
+        }
+
         public Database build() {
             return new Database(this);
+        }
+    }
+
+    enum RdsEngine {
+        AURORA_PG("aurora-postgresql", "Amazon Aurora PostgreSQL", 5432),
+        AURORA_MYSQL("aurora-mysql", "Amazon Aurora MySQL", 3306),
+        MYSQL("mysql", "MySQL", 3306),
+        MARIADB("mariadb", "MariaDB", 3306),
+        POSTGRES("postgres", "PostgreSQL", 5432),
+        MS_SQL_EXPRESS("sqlserver-ex", "SQL Server Express Edition", 1433),
+        MS_SQL_WEB("sqlserver-web", "SQL Server Web Edition", 1433),
+        MS_SQL_STANDARD("sqlserver-se", "SQL Server Standard Edition", 1433),
+        MS_SQL_ENTERPRISE("sqlserver-ee", "SQL Server Enterprise Edition", 1433),
+        ORACLE("oracle-ee", "Oracle", 1521);
+
+        private final String engine;
+        private final String description;
+        private final Integer port;
+
+        RdsEngine(String name, String description, Integer port) {
+            this.engine = name;
+            this.description = description;
+            this.port = port;
+        }
+
+        public String getEngine() {
+            return engine;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public Integer getPort() {
+            return port;
+        }
+
+        public static RdsEngine ofEngine(String engine) {
+            RdsEngine rdsEngine = null;
+            for (RdsEngine e : RdsEngine.values()) {
+                if (e.getEngine().equals(engine)) {
+                    rdsEngine = e;
+                    break;
+                }
+            }
+            return rdsEngine;
         }
     }
 }

--- a/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/DatabaseTierConfig.java
+++ b/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/DatabaseTierConfig.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.amazon.aws.partners.saasfactory.saasboost.appconfig;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import java.util.Objects;
+
+@JsonDeserialize(builder = DatabaseTierConfig.Builder.class)
+public final class DatabaseTierConfig {
+
+    private final RdsInstance instance;
+
+    public DatabaseTierConfig(Builder builder) {
+        this.instance = builder.instance;
+    }
+
+    public String getInstance() {
+        return instance != null ? instance.name() : null;
+    }
+
+    public String getInstanceClass() {
+        return instance != null ? instance.getInstanceClass() : null;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        // Same reference?
+        if (this == obj) {
+            return true;
+        }
+        // Same type?
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final DatabaseTierConfig other = (DatabaseTierConfig) obj;
+        return (instance == other.instance);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(instance);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static Builder builder(DatabaseTierConfig other) {
+        return new Builder().instance(other.getInstance());
+    }
+
+    @JsonPOJOBuilder(withPrefix = "") // setters aren't named with[Property]
+    @JsonIgnoreProperties(value = {"instanceClass"})
+    public static final class Builder {
+
+        private RdsInstance instance;
+
+        private Builder() {
+
+        }
+
+        public Builder instance(RdsInstance instance) {
+            this.instance = instance;
+            return this;
+        }
+
+        public Builder instance(String instance) {
+            try {
+                this.instance = RdsInstance.valueOf(instance);
+            } catch (IllegalArgumentException e) {
+                this.instance = RdsInstance.ofInstanceClass(instance);
+            }
+            return this;
+        }
+
+        public DatabaseTierConfig build() {
+            return new DatabaseTierConfig(this);
+        }
+    }
+
+    enum RdsInstance {
+        T3_MICRO("db.t3.micro", "2 vCPUs 1 GiB RAM"),
+        T3_SMALL("db.t3.small", "2 vCPUs 2 GiB RAM"),
+        T3_MEDIUM("db.t3.medium", "2 vCPUs 4 GiB RAM"),
+        T3_LARGE("db.t3.large", "2 vCPUs 8 GiB RAM"),
+        T3_XL("db.t3.xlarge", "4 vCPUs 16 GiB RAM"),
+        T3_2XL("db.t3.2xlarge", "8 vCPUs 32 GiB RAM"),
+        M5_LARGE("db.m5.large", "2 vCPUs 8 GiB RAM"),
+        M5_XL("db.m5.xlarge", "4 vCPUs 16 GiB RAM"),
+        M5_2XL("db.m5.2xlarge", "8 vCPUs 32 GiB RAM"),
+        M5_4XL("db.m5.4xlarge", "16 vCPUs 64 GiB RAM"),
+        M5_12XL("db.m5.12xlarge", "48 vCPUs 192 GiB RAM"),
+        M5_24XL("db.m5.24xlarge", "96 vCPUs 384 GiB RAM"),
+        R5_LARGE("db.r5.large", "2 vCPUs 16 GiB RAM"),
+        R5_XL("db.r5.xlarge", "4 vCPUs 32 GiB RAM"),
+        R5_2XL("db.r5.2xlarge", "8 vCPUs 64 GiB RAM"),
+        R5_4XL("db.r5.4xlarge", "16 vCPUs 128 GiB RAM"),
+        R5_12XL("db.r5.12xlarge", "48 vCPUs 384 GiB RAM"),
+        R5_24XL("db.r5.24xlarge", "96 vCPUs 768 GiB RAM");
+
+        private final String instanceClass;
+        private final String description;
+
+        RdsInstance(String name, String description) {
+            this.instanceClass = name;
+            this.description = description;
+        }
+
+        public String getInstanceClass() {
+            return instanceClass;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public static RdsInstance ofInstanceClass(String instanceClass) {
+            RdsInstance instance = null;
+            for (RdsInstance ec2 : RdsInstance.values()) {
+                if (ec2.getInstanceClass().equals(instanceClass)) {
+                    instance = ec2;
+                    break;
+                }
+            }
+            return instance;
+        }
+    }
+}

--- a/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/ServiceConfig.java
+++ b/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/ServiceConfig.java
@@ -40,6 +40,7 @@ public class ServiceConfig {
     private final String containerTag;
     private final String healthCheckUrl;
     private final OperatingSystem operatingSystem;
+    private final Database database;
 
     private ServiceConfig(Builder builder) {
         this.publiclyAddressable = builder.publiclyAddressable;
@@ -52,6 +53,7 @@ public class ServiceConfig {
         this.healthCheckUrl = builder.healthCheckUrl;
         this.operatingSystem = builder.operatingSystem;
         this.tiers = builder.tiers;
+        this.database = builder.database;
     }
 
     public static Builder builder() {
@@ -69,7 +71,8 @@ public class ServiceConfig {
                 .containerRepo(other.getContainerRepo())
                 .containerTag(other.getContainerTag())
                 .healthCheckUrl(other.getHealthCheckUrl())
-                .operatingSystem(other.getOperatingSystem());
+                .operatingSystem(other.getOperatingSystem())
+                .database(other.getDatabase());
     }
 
     public Boolean isPublic() {
@@ -112,6 +115,14 @@ public class ServiceConfig {
         return tiers != null ? Map.copyOf(tiers) : null;
     }
 
+    public Database getDatabase() {
+        return database;
+    }
+
+    public boolean hasDatabase() {
+        return database != null;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (obj == null) {
@@ -143,22 +154,29 @@ public class ServiceConfig {
 
         return (
                 ((name == null && other.name == null) || (name != null && name.equals(other.name)))
-                && ((description == null && other.description == null) || (description != null && description.equals(other.description)))
+                && ((description == null && other.description == null)
+                    || (description != null && description.equals(other.description)))
                 && ((path == null && other.path == null) || (path != null && path.equals(other.path)))
-                && ((publiclyAddressable == null && other.publiclyAddressable == null) || (publiclyAddressable != null && publiclyAddressable.equals(other.publiclyAddressable)))
-                && ((containerPort == null && other.containerPort == null) || (containerPort != null && containerPort.equals(other.containerPort)))
-                && ((containerRepo == null && other.containerRepo == null) || (containerRepo != null && containerRepo.equals(other.containerRepo)))
-                && ((containerTag == null && other.containerTag == null) || (containerTag != null && containerTag.equals(other.containerTag)))
-                && ((healthCheckUrl == null && other.healthCheckUrl == null) || (healthCheckUrl != null && healthCheckUrl.equals(other.healthCheckUrl)))
+                && ((publiclyAddressable == null && other.publiclyAddressable == null)
+                    || (publiclyAddressable != null && publiclyAddressable.equals(other.publiclyAddressable)))
+                && ((containerPort == null && other.containerPort == null)
+                    || (containerPort != null && containerPort.equals(other.containerPort)))
+                && ((containerRepo == null && other.containerRepo == null)
+                    || (containerRepo != null && containerRepo.equals(other.containerRepo)))
+                && ((containerTag == null && other.containerTag == null)
+                    || (containerTag != null && containerTag.equals(other.containerTag)))
+                && ((healthCheckUrl == null && other.healthCheckUrl == null)
+                    || (healthCheckUrl != null && healthCheckUrl.equals(other.healthCheckUrl)))
                 && (operatingSystem == other.operatingSystem)
                 && ((tiers == null && other.tiers == null) || tiersEqual)
-        );
+                && ((database == null && other.database == null)
+                    || (database != null && database.equals(other.database))));
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(name, description, path, publiclyAddressable, containerPort, containerRepo, containerTag,
-                healthCheckUrl, operatingSystem)
+                healthCheckUrl, operatingSystem, database)
                 + Arrays.hashCode(tiers != null ? tiers.keySet().toArray(new String[0]) : null)
                 + Arrays.hashCode(tiers != null ? tiers.values().toArray(new Object[0]) : null);
     }
@@ -177,6 +195,7 @@ public class ServiceConfig {
         private String healthCheckUrl;
         private OperatingSystem operatingSystem;
         private Map<String, ServiceTierConfig> tiers = new HashMap<>();
+        private Database database;
 
         private Builder() {
         }
@@ -250,6 +269,11 @@ public class ServiceConfig {
 
         public Builder tiers(Map<String, ServiceTierConfig> tiers) {
             this.tiers = tiers != null ? tiers : new HashMap<>();
+            return this;
+        }
+
+        public Builder database(Database database) {
+            this.database = database;
             return this;
         }
 

--- a/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/ServiceTierConfig.java
+++ b/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/ServiceTierConfig.java
@@ -31,7 +31,6 @@ public class ServiceTierConfig {
     private final Integer memory;
     private final String instanceType;
     private final SharedFilesystem filesystem;
-    private final Database database;
 
     private ServiceTierConfig(Builder builder) {
         this.min = builder.min;
@@ -41,7 +40,6 @@ public class ServiceTierConfig {
         this.memory = builder.memory;
         this.instanceType = builder.instanceType;
         this.filesystem = builder.filesystem;
-        this.database = builder.database;
     }
 
     public static ServiceTierConfig.Builder builder() {
@@ -56,8 +54,7 @@ public class ServiceTierConfig {
             .cpu(other.getCpu())
             .memory(other.getMemory())
             .instanceType(other.getInstanceType())
-            .filesystem(other.getFilesystem())
-            .database(other.getDatabase());
+            .filesystem(other.getFilesystem());
     }
 
     public Integer getMin() {
@@ -97,14 +94,6 @@ public class ServiceTierConfig {
         return filesystem;
     }
 
-    public Database getDatabase() {
-        return database;
-    }
-
-    public boolean hasDatabase() {
-        return database != null;
-    }
-
     @Override
     public String toString() {
         return Utils.toJson(this);
@@ -130,15 +119,15 @@ public class ServiceTierConfig {
                 && ((computeSize == null && other.computeSize == null) || (computeSize == other.computeSize))
                 && ((cpu == null && other.cpu == null) || (cpu != null && cpu.equals(other.cpu)))
                 && ((memory == null && other.memory == null) || (memory != null && memory.equals(other.memory)))
-                && ((instanceType == null && other.instanceType == null) || (instanceType != null && instanceType.equals(other.instanceType)))
-                && ((filesystem == null && other.filesystem == null) || (filesystem != null && filesystem.equals(other.filesystem)))
-                && ((database == null && other.database == null) || (database != null && database.equals(other.database)))
-        );
+                && ((instanceType == null && other.instanceType == null)
+                    || (instanceType != null && instanceType.equals(other.instanceType)))
+                && ((filesystem == null && other.filesystem == null)
+                    || (filesystem != null && filesystem.equals(other.filesystem))));
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(min, max, computeSize, cpu, memory, instanceType, filesystem, database);
+        return Objects.hash(min, max, computeSize, cpu, memory, instanceType, filesystem);
     }
 
     @JsonPOJOBuilder(withPrefix = "") // setters aren't named with[Property]
@@ -150,7 +139,6 @@ public class ServiceTierConfig {
         private Integer memory;
         private String instanceType;
         private SharedFilesystem filesystem;
-        private Database database;
 
         private Builder() {
         }
@@ -218,11 +206,6 @@ public class ServiceTierConfig {
 
         public Builder filesystem(SharedFilesystem filesystem) {
             this.filesystem = filesystem;
-            return this;
-        }
-
-        public Builder database(Database database) {
-            this.database = database;
             return this;
         }
 

--- a/services/settings-service/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/SettingsServiceDALTest.java
+++ b/services/settings-service/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/SettingsServiceDALTest.java
@@ -436,7 +436,7 @@ public class SettingsServiceDALTest {
     public void testRdsOptionsSorting() throws Exception {
         try (InputStream json = Files.newInputStream(Path.of(this.getClass().getClassLoader().getResource("rdsInstancesUnsorted.json").toURI()))) {
             LinkedHashMap<String, Object> options = Utils.fromJson(json, LinkedHashMap.class);
-            ArrayList<LinkedHashMap<String, Object>> instances = (ArrayList<LinkedHashMap<String, Object>>) options.get("instances");
+            ArrayList<LinkedHashMap<String, String>> instances = (ArrayList<LinkedHashMap<String, String>>) options.get("instances");
 
             //System.out.println("Unsorted:");
             //System.out.println(Utils.toJson(instances));
@@ -474,7 +474,7 @@ public class SettingsServiceDALTest {
             int firstIndexOf24XL = -1;
 
             for (int i = instances.size(); i-- > 0;) {
-                LinkedHashMap<String, Object> instance = instances.get(i);
+                LinkedHashMap<String, String> instance = instances.get(i);
                 char type = ((String) instance.get("instance")).charAt(0);
                 Integer generation = Integer.valueOf(((String) instance.get("instance")).substring(1, 2));
                 String size = ((String) instance.get("instance")).substring(3);
@@ -522,7 +522,7 @@ public class SettingsServiceDALTest {
             }
 
             for (int i = 0; i < instances.size(); i++) {
-                LinkedHashMap<String, Object> instance = instances.get(i);
+                LinkedHashMap<String, String> instance = instances.get(i);
                 char type = ((String) instance.get("instance")).charAt(0);
                 Integer generation = Integer.valueOf(((String) instance.get("instance")).substring(1, 2));
                 String size = ((String) instance.get("instance")).substring(3);

--- a/services/settings-service/src/test/resources/appConfig.json
+++ b/services/settings-service/src/test/resources/appConfig.json
@@ -14,6 +14,7 @@
       "containerPort": 7000,
       "containerRepo": "",
       "containerTag": "latest",
+      "database": null,
       "tiers": {
         "default": {
           "instanceType": "t3.medium",
@@ -21,7 +22,6 @@
           "memory": 1024,
           "min": 1,
           "max": 2,
-          "database": null,
           "filesystem": null
         }
       }
@@ -36,6 +36,7 @@
       "containerPort": 7000,
       "containerRepo": "",
       "containerTag": "latest",
+      "database": null,
       "tiers": {
         "default": {
           "instanceType": "t3.medium",
@@ -43,7 +44,6 @@
           "memory": 1024,
           "min": 1,
           "max": 2,
-          "database": null,
           "filesystem": null
         }
       }
@@ -58,6 +58,7 @@
       "containerPort": 7000,
       "containerRepo": "",
       "containerTag": "latest",
+      "database": null,
       "tiers": {
         "default": {
           "instanceType": "t3.medium",
@@ -65,7 +66,6 @@
           "memory": 1024,
           "min": 1,
           "max": 2,
-          "database": null,
           "filesystem": null
         }
       }


### PR DESCRIPTION
This commit refactors the way that AppConfig is saved for databases:
moving the database configuration object to be service specific and
allowing only the database performance characteristics to be
configurable by tier, replacing the existing logic where all database
configurations were configurable by tier. Note that this brings with it
the restriction that now services cannot be created where a difference
of tier leads to a difference of database version, engine, or existence.

This commit also reworks the UI to support the above changes and the
RdsOptions custom resource to more accurately represent RDS built-in
dependencies when selecting database configurations, as well as changing
the Onboarding service to correctly select from the AppConfig object.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
