### PR TITLE
Support for FSx ONTAP during tenant onboarding.

### DIFF
--- a/functions/onboarding-stack-listener/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingStackListener.java
+++ b/functions/onboarding-stack-listener/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingStackListener.java
@@ -185,6 +185,19 @@ public class OnboardingStackListener implements RequestHandler<SNSEvent, Object>
                                         "consoleUrl", AwsResource.PRIVATE_SUBNET_B.formatUrl(AWS_REGION, physicalResourceId))
                                 );
                             }
+                        } else if ("AWS::EC2::RouteTable".equals(resourceType)) {
+                            // Process all of the route table resources together because we only want the route table
+                            // for the private subnets and there are other route tables in the stack which may end up
+                            // overwriting the values in the resources map depending on which order they are listed in
+                            // from the stack summary
+                            if ("RouteTablePrivate".equals(logicalId)) {
+                                LOGGER.info("Saving Private Route Table {} {}", logicalId, physicalResourceId);
+                                tenantResources.put(AwsResource.PRIVATE_ROUTE_TABLE.name(), Map.of(
+                                        "name", physicalResourceId,
+                                        "arn", AwsResource.PRIVATE_ROUTE_TABLE.formatArn(partition, AWS_REGION, accountId, physicalResourceId),
+                                        "consoleUrl", AwsResource.PRIVATE_ROUTE_TABLE.formatUrl(AWS_REGION, physicalResourceId))
+                                );
+                            }
                         } else {
                             // Match on the resource type and build the console url
                             for (AwsResource awsResource : AwsResource.values()) {

--- a/installer/pom.xml
+++ b/installer/pom.xml
@@ -170,6 +170,11 @@ limitations under the License.
             <version>${aws.java.sdk.version}</version>
         </dependency>
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>secretsmanager</artifactId>
+            <version>${aws.java.sdk.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
             <version>2.13.3</version>

--- a/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/clients/AwsClientBuilderFactory.java
+++ b/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/clients/AwsClientBuilderFactory.java
@@ -37,6 +37,8 @@ import software.amazon.awssdk.services.quicksight.QuickSightClient;
 import software.amazon.awssdk.services.quicksight.QuickSightClientBuilder;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClientBuilder;
 import software.amazon.awssdk.services.ssm.SsmClient;
 import software.amazon.awssdk.services.ssm.SsmClientBuilder;
 import software.amazon.awssdk.services.sts.StsClient;
@@ -113,6 +115,10 @@ public class AwsClientBuilderFactory {
 
     public StsClientBuilder stsBuilder() {
         return decorateBuilderWithDefaults(StsClient.builder());
+    }
+
+    public SecretsManagerClientBuilder secretsManagerBuilder() {
+        return decorateBuilderWithDefaults(SecretsManagerClient.builder());
     }
 
     public static Builder builder() {

--- a/layers/cloudformation-utils/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/AwsResource.java
+++ b/layers/cloudformation-utils/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/AwsResource.java
@@ -8,7 +8,7 @@ import java.util.IllegalFormatException;
 public enum AwsResource {
 
     RDS_CLUSTER("https://%s.console.aws.amazon.com/rds/home#database:id=%s;is-cluster=true",
-            "",
+            "arn:%s:rds:%s:%s:cluster:%s",
             "AWS::RDS::DBCluster", false),
     RDS_INSTANCE("https://%s.console.aws.amazon.com/rds/home?region=%s#dbinstance:id=%s",
             "arn:%s:rds:%s:%s:db:%s",
@@ -28,6 +28,9 @@ public enum AwsResource {
     PRIVATE_SUBNET_B("https://%s.console.aws.amazon.com/vpc/home?region=%s#SubnetDetails:subnetId=%s",
             "arn:%s:ec2:%s:%s:subnet/%s",
             "AWS::EC2::Subnet", true),
+    PRIVATE_ROUTE_TABLE("https://%s.console.aws.amazon.com/vpc/home?region=%s#RouteTables:routeTableId=%s",
+            "arn:%s:ec2:%s:%s:route-table/%s",
+            "AWS::EC2::RouteTable", true),
     CODE_PIPELINE("https://%s.console.aws.amazon.com/codesuite/codepipeline/pipelines/%s/view",
             "arn:%s:codepipeline:%s:%s:%s",
             "AWS::CodePipeline::Pipeline", false),
@@ -35,13 +38,13 @@ public enum AwsResource {
             "arn:%s:ecr:%s:%s:repository/%s",
             "AWS::ECR::Repository", false),
     LOAD_BALANCER("https://%s.console.aws.amazon.com/ec2/v2/home?region=%s#LoadBalancers:search=%s",
-            "",
+            "arn:%s:elasticloadbalancing:%s:%s:loadbalancer/app/%s", // ${LoadBalancerName}/${LoadBalancerId}
             "AWS::ElasticLoadBalancingV2::LoadBalancer", true),
     HTTP_LISTENER("https://%s.console.aws.amazon.com/ec2/v2/home?region=%s#LoadBalancers:search=%s",
-            "",
+            "arn:%s:elasticloadbalancing:%s:%s:listener/app/%s", // ${LoadBalancerName}/${LoadBalancerId}/${ListenerId}
             "AWS::ElasticLoadBalancingV2::Listener", true),
     HTTPS_LISTENER("https://%s.console.aws.amazon.com/ec2/v2/home?region=%s#LoadBalancers:search=%s",
-            "",
+            "arn:%s:elasticloadbalancing:%s:%s:listener/app/%s", // ${LoadBalancerName}/${LoadBalancerId}/${ListenerId}
             "AWS::ElasticLoadBalancingV2::Listener", true),
     CLOUDFORMATION("https://%s.console.aws.amazon.com/cloudformation/home?region=%s#/stacks/stackinfo?filteringStatus=active&viewNested=true&hideStacks=false&stackId=%s",
             "arn:%s:cloudformation:%s:%s:stack/%s",

--- a/resources/custom-resources/fsx-dns-name/update_service.sh
+++ b/resources/custom-resources/fsx-dns-name/update_service.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+MY_AWS_REGION=$(aws configure list | grep region | awk '{print $2}')
+echo "AWS Region = $MY_AWS_REGION"
+
+if [ "X$1" = "X" ]; then
+    echo "usage: $0 <Environment>"
+    exit 2
+fi
+ENVIRONMENT=$1
+LAMBDA_STAGE_FOLDER=$2
+if [ "X$LAMBDA_STAGE_FOLDER" = "X" ]; then
+	LAMBDA_STAGE_FOLDER="lambdas"
+fi
+
+LAMBDA_CODE=FsxDnsName-lambda.zip
+
+#set this for V2 AWS CLI to disable paging
+export AWS_PAGER=""
+
+SAAS_BOOST_BUCKET=`aws ssm get-parameter --name "/saas-boost/${ENVIRONMENT}/SAAS_BOOST_BUCKET" --query "Parameter.Value" --output text`
+echo "SaaS Boost Bucket = $SAAS_BOOST_BUCKET"
+if [ "X$SAAS_BOOST_BUCKET" = "X" ]; then
+    echo "/saas-boost/${ENVIRONMENT}/SAAS_BOOST_BUCKET SSM parameter not read from AWS env"
+    exit 1
+fi
+
+
+
+mvn
+if [ $? -ne 0 ]; then
+    echo "Error building project"
+    exit 1
+fi
+
+aws s3 cp target/$LAMBDA_CODE s3://$SAAS_BOOST_BUCKET/$LAMBDA_STAGE_FOLDER/
+
+# Find all the functions provisioned for tenants
+eval FUNCTIONS=\$\("aws --region $MY_AWS_REGION lambda list-functions --query 'Functions[?starts_with(FunctionName, \`sb-${ENVIRONMENT}-fsx-dns-tenant-\`)] | [].FunctionName' --output text"\)
+FUNCTIONS=($FUNCTIONS)
+for FX in "${FUNCTIONS[@]}"; do
+    printf "Updating function code for %s\n" $FX
+    aws lambda --region "$MY_AWS_REGION" update-function-code --function-name "$FX" --s3-bucket "$SAAS_BOOST_BUCKET" --s3-key $LAMBDA_STAGE_FOLDER/$LAMBDA_CODE
+done

--- a/resources/saas-boost-managed-ad.yaml
+++ b/resources/saas-boost-managed-ad.yaml
@@ -70,7 +70,7 @@ Resources:
     Properties:
       Name: !Sub /saas-boost/${Environment}/ACTIVE_DIRECTORY_USER
       Type: String
-      Value: !Sub ${Environment}.${AWS::Region}.saasboost.com\admin
+      Value: admin
   SSMParamDirectoryId:
     Type: AWS::SSM::Parameter
     Properties:

--- a/resources/saas-boost-svc-onboarding.yaml
+++ b/resources/saas-boost-svc-onboarding.yaml
@@ -356,6 +356,11 @@ Resources:
               - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/saas-boost/${Environment}/*
           - Effect: Allow
             Action:
+              - secretsmanager:GetSecretValue
+            Resource:
+              - !Sub arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/saas-boost/${Environment}/*
+          - Effect: Allow
+            Action:
               - ssm:GetParameters
             Resource:
               - arn:aws:ssm:*:*:parameter/aws/service/ami-windows-latest/*
@@ -458,6 +463,7 @@ Resources:
               - ec2:DeleteTags
             Resource:
               - !Sub arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*
+              - !Sub arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:launch-template/*
               - !Sub arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:internet-gateway/*
               - !Sub arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:vpc/*
               - !Sub arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:route-table/*
@@ -467,6 +473,7 @@ Resources:
           - Effect: Allow
             Action:
               - ec2:CreateLaunchTemplate
+              - ec2:DeleteLaunchTemplate
             Resource:
               - !Sub arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:launch-template/*
           - Effect: Allow
@@ -548,6 +555,7 @@ Resources:
               - iam:GetRole
               - iam:CreateRole
               - iam:DeleteRole
+              - iam:AttachRolePolicy
               - iam:GetRolePolicy
               - iam:PutRolePolicy
               - iam:DeleteRolePolicy
@@ -731,14 +739,39 @@ Resources:
               - fsx:CreateFileSystem
               - fsx:DeleteFileSystem
               - fsx:TagResource
+              - fsx:UntagResource
             Resource:
               - !Sub arn:aws:fsx:${AWS::Region}:${AWS::AccountId}:file-system/*
+          - Effect: Allow
+            Action:
+              - fsx:CreateStorageVirtualMachine
+            Resource:
+              - !Sub arn:aws:fsx:${AWS::Region}:${AWS::AccountId}:storage-virtual-machine/*
+              - !Sub arn:aws:fsx:${AWS::Region}:${AWS::AccountId}:file-system/*
+          - Effect: Allow
+            Action:
+              - fsx:TagResource
+              - fsx:UntagResource
+              - fsx:DeleteStorageVirtualMachine
+            Resource:
+              - !Sub arn:aws:fsx:${AWS::Region}:${AWS::AccountId}:storage-virtual-machine/*
+          - Effect: Allow
+            Action:
+              - fsx:TagResource
+              - fsx:UntagResource
+              - fsx:CreateVolume
+              - fsx:DeleteVolume
+            Resource:
+              - !Sub arn:aws:fsx:${AWS::Region}:${AWS::AccountId}:volume/*/*
+              - !Sub arn:aws:fsx:${AWS::Region}:${AWS::AccountId}:storage-virtual-machine/*/*
           - Effect: Allow
             Action:
               - elasticfilesystem:CreateFileSystem
               - elasticfilesystem:DeleteFileSystem
               - ds:DescribeDirectories
               - fsx:DescribeFileSystems
+              - fsx:DescribeStorageVirtualMachines
+              - fsx:DescribeVolumes
             Resource:
               - '*'
           - Effect: Allow

--- a/resources/tenant-onboarding-app.yaml
+++ b/resources/tenant-onboarding-app.yaml
@@ -40,12 +40,12 @@ Parameters:
   PubliclyAddressable:
     Description: Is this service publicly accessible from the Internet?
     Type: String
-    AllowedValues: [true, false]
-    Default: false
+    AllowedValues: ['true', 'false']
+    Default: 'true'
   PublicPathRoute:
     Description: If this service is public, what path part routes to it?
     Type: String
-    Default: '*'
+    Default: '/*'
   PublicPathRulePriority:
     Description: The ALB listener rule priority for this path route
     Type: Number
@@ -59,8 +59,8 @@ Parameters:
   SubnetPrivateB:
     Description: Private subnet in this tenant's VPC
     Type: String
-  ECSLoadBalancer:
-    Description: The ARN of the ALB fronting the public services for this application
+  PrivateRouteTable:
+    Description: Route table for the private subnets in this tenant's VPC
     Type: String
   ECSLoadBalancerHttpListener:
     Description: The ARN of the ALB listener for HTTP traffic
@@ -109,35 +109,11 @@ Parameters:
   ContainerHealthCheckPath:
     Description: The destination on the Container for the Load Balancer to use for health checks
     Type: String
-  UseEFS:
-    Description: Deploy the EFS nested stack?
-    Type: String
-    AllowedValues: [true, false]
-    Default: false
-  MountPoint:
-    Description: Container mount point for EFS file system
-    Type: String
-  EncryptEFS:
-    Description: Turn on EFS encryption at rest?
-    Type: String
-    AllowedValues: [true, false]
-    Default: false
-  EFSLifecyclePolicy:
-    Description: Enable EFS IA lifecycle?
-    Type: String
-    AllowedValues:
-      - NEVER
-      - AFTER_7_DAYS
-      - AFTER_14_DAYS
-      - AFTER_30_DAYS
-      - AFTER_60_DAYS
-      - AFTER_90_DAYS
-    Default: NEVER
   UseRDS:
     Description: Deploy the RDS nested stack?
     Type: String
-    AllowedValues: [true, false]
-    Default: false
+    AllowedValues: ['true', 'false']
+    Default: 'false'
   RDSInstanceClass:
     Description: The compute and memory capacity of the DB instance
     Type: String
@@ -171,44 +147,76 @@ Parameters:
   EventBus:
     Description: Optional. SaaS boost Metering and Billing EventBridge bus.
     Type: String
+  FileSystemMountPoint:
+    Description: Container mount point for the file system
+    Type: String
+    Default: ''
+  UseEFS:
+    Description: Deploy the EFS nested stack?
+    Type: String
+    AllowedValues: ['true', 'false']
+    Default: 'false'
+  EncryptEFS:
+    Description: Turn on EFS encryption at rest?
+    Type: String
+    AllowedValues: ['true', 'false']
+    Default: 'true'
+  EFSLifecyclePolicy:
+    Description: Enable EFS IA lifecycle?
+    Type: String
+    AllowedValues:
+      - NEVER
+      - AFTER_7_DAYS
+      - AFTER_14_DAYS
+      - AFTER_30_DAYS
+      - AFTER_60_DAYS
+      - AFTER_90_DAYS
+    Default: NEVER
   UseFSx:
     Description: Deploy the FSX nested stack?
     Type: String
-    AllowedValues: [true, false]
-    Default: false
-  FSxWeeklyMaintenanceTime:
-    Description: Specify the preferred start time to perform weekly maintenance, formatted d:HH:MM in the UTC time zone
-    Default: '7:02:00'
+    AllowedValues: ['true', 'false']
+    Default: 'false'
+  FSxFileSystemType:
+    Description: Type of FSx file system to provision
     Type: String
-  FSxStorageCapacity:
+    AllowedValues: [FSX_WINDOWS, FSX_ONTAP]
+    Default: FSX_WINDOWS
+  FSxWindowsMountDrive:
+    Description: Windows drive to mount attach the file system to
+    Type: String
+    Default: 'G:'
+  FileSystemStorage:
+    Description: Storage capacity for the file system in GB
+    Type: Number
+    MinValue: 32
+    MaxValue: 65536
     Default: 32
-    Description: Specify the storage capacity of the file system being created, in gibibytes.
-      Valid values are 32 GiB - 65,536 GiB. Consider choosing a higher value for greater capacity.
+  FileSystemThroughput:
+    Description: Throughput capacity for the file system in MB/s
     Type: Number
-  FSxThroughputCapacity:
-    Default: 8
-    Description: Specify the throughput of the Amazon FSx file system. Valid values are 8 - 2048.
-      Consider choosing a higher value for better performance.
-    Type: Number
+    MinValue: 8
+    MaxValue: 2048
+    Default: 16
   FSxBackupRetention:
-    Description: Specify the number of days to retain automatic backups.
-      Setting this value to 0 disables the creation of automatic backups. The maximum retention period
-      for backups is 35 days.
-    Default: 7
+    Description: Number of days to retain automatic backups
+    MinValue: 0
+    MaxValue: 35
+    Default: 0
     Type: Number
   FSxDailyBackupTime:
-    Description: Specify the preferred time to take daily automatic backups, formatted HH:MM in the UTC time zone.
+    Description: Preferred time to take daily automatic backups, formatted HH:MM in the UTC time zone.
     Default: '01:00'
     Type: String
-  FSxWindowsMountDrive:
-    Description: Specify the Windows drive to mount the FSX file system in format G:, F:, etc.
-    Default: 'G:'
+  FSxWeeklyMaintenanceTime:
+    Description: Preferred start time to perform weekly maintenance, formatted d:HH:MM in the UTC time zone
+    Default: '7:02:00'
     Type: String
   Disable:
     Description: Disable the tenant's access to the application
     Type: String
-    AllowedValues: [true, false]
-    Default: false
+    AllowedValues: ['true', 'false']
+    Default: 'false'
   # These params are here to read the image values from the public SSM. Leave the defaults.
   WIN2022FULL:
     Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
@@ -253,12 +261,11 @@ Conditions:
     - Condition: LinuxOS
   ProvisionFSx: !And
     - !Equals [!Ref UseFSx, 'true']
-    - Condition: WindowsOS
+    - Condition: Ec2LaunchType
   IsWin2019Full: !Equals [WIN2019FULL, !Ref ContainerOS]
   IsWin2019Core: !Equals [WIN2019CORE, !Ref ContainerOS]
   IsWin2022Full: !Equals [WIN2022FULL, !Ref ContainerOS]
   IsWin2022Core: !Equals [WIN2022CORE, !Ref ContainerOS]
-  IsWin2016Full: !Equals [WIN2016FULL, !Ref ContainerOS]
   IsWin20H2Core: !Equals [WIN20H2CORE, !Ref ContainerOS]
 Resources:
   CapacityProvider:
@@ -413,13 +420,6 @@ Resources:
                   - s3:GetObjectVersion
                 Resource:
                   - !Sub arn:aws:s3:::{{resolve:ssm:/saas-boost/${Environment}/RESOURCES_BUCKET}}/tenants/${TenantId}/*
-              - Effect: Allow
-                Action:
-                  - ssmmessages:CreateControlChannel
-                  - ssmmessages:CreateDataChannel
-                  - ssmmessages:OpenControlChannel
-                  - ssmmessages:OpenDataChannel
-                Resource: '*'
   ECSTaskDefinition:
     Type: AWS::ECS::TaskDefinition
     Properties:
@@ -436,9 +436,21 @@ Resources:
       Cpu: !If [FargateLaunchType, !Ref TaskCPU, !Ref 'AWS::NoValue']
       NetworkMode:
         Fn::If:
-          - Ec2LaunchType
-          - !If [WindowsOS, !Ref 'AWS::NoValue', awsvpc]
+          - Ec2Windows
+          - !Ref 'AWS::NoValue'
           - awsvpc
+      Volumes:
+        Fn::If:
+          - ProvisionFSx
+          - - Name: !GetAtt fsx.Outputs.FileSystemId
+              Host:
+                SourcePath: !Sub '${FSxWindowsMountDrive}\'
+          - !If
+            - ProvisionEFS
+            - - Name: !GetAtt efs.Outputs.FileSystemId
+                EFSVolumeConfiguration:
+                  FilesystemId: !GetAtt efs.Outputs.FileSystemId
+            - !Ref 'AWS::NoValue'
       Tags:
         - Key: Tenant
           Value: !Ref TenantId
@@ -495,13 +507,13 @@ Resources:
             - Type: s3
               Value: !Sub 'arn:aws:s3:::{{resolve:ssm:/saas-boost/${Environment}/RESOURCES_BUCKET}}/tenants/${TenantId}/ServiceDiscovery.env'
           MountPoints:
-            !If
+            Fn::If:
               - ProvisionEFS
-              - - ContainerPath: !Ref MountPoint
+              - - ContainerPath: !Ref FileSystemMountPoint
                   SourceVolume: !GetAtt efs.Outputs.FileSystemId
               - !If
                 - ProvisionFSx
-                - - ContainerPath: !Ref MountPoint
+                - - ContainerPath: !Ref FileSystemMountPoint
                     SourceVolume: !GetAtt fsx.Outputs.FileSystemId
                 - !Ref 'AWS::NoValue'
           LinuxParameters:
@@ -515,18 +527,6 @@ Resources:
               - - Name: DB_PASSWORD
                   ValueFrom: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${RDSPasswordParam}
               - !Ref 'AWS::NoValue'
-      Volumes:
-        !If
-          - ProvisionEFS
-          - - Name: !GetAtt efs.Outputs.FileSystemId
-              EfsVolumeConfiguration:
-                FileSystemId: !GetAtt efs.Outputs.FileSystemId
-          - !If
-            - ProvisionFSx
-            - - Name: !GetAtt fsx.Outputs.FileSystemId
-                Host:
-                  SourcePath: !Sub ${FSxWindowsMountDrive}\
-            - !Ref 'AWS::NoValue'
   CodePipeline:
     Type: AWS::CodePipeline::Pipeline
     Properties:
@@ -591,7 +591,7 @@ Resources:
     Type: AWS::CloudFormation::WaitCondition
     Properties:
       Handle: !If [ProvisionFSx, !Ref FsxWaitHandle, !Ref WaitHandle]
-      Timeout: 1
+      Timeout: '1'
       Count: 0
   # We either need an Auto Scaling Group, Instance Profile, and Launch Template (Windows/EC2)
   # Or we need an Target Group (Linux/Fargate)
@@ -609,9 +609,9 @@ Resources:
         LaunchTemplateId: !If [Ec2Windows, !Ref WindowsLaunchTemplate, !Ref LinuxLaunchTemplate]
         Version: !If [Ec2Windows, !GetAtt WindowsLaunchTemplate.LatestVersionNumber, !GetAtt LinuxLaunchTemplate.LatestVersionNumber]
       NewInstancesProtectedFromScaleIn: true
-      MinSize: 0
-      MaxSize: 20
-      DesiredCapacity: 0
+      MinSize: '0'
+      MaxSize: '20'
+      DesiredCapacity: '0'
       #Cooldown:
       HealthCheckGracePeriod: 30
       #HealthCheckType:
@@ -623,7 +623,7 @@ Resources:
         #MinSuccessfulInstancesPercent: 0
         MaxBatchSize: 1
         PauseTime: PT5M
-        WaitOnResourceSignals: true
+        WaitOnResourceSignals: false
         SuspendProcesses:
           - HealthCheck
           - ReplaceUnhealthy
@@ -646,6 +646,9 @@ Resources:
                 - ec2.amazonaws.com
             Action:
               - sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+        - arn:aws:iam::aws:policy/AmazonSSMDirectoryServiceAccess
       Policies:
         - PolicyName:
             Fn::Join: ['', ['sb-', !Ref Environment, '-ecs-instance-tenant-', !Select [0, !Split ['-', !Ref TenantId]]]]
@@ -701,7 +704,6 @@ Resources:
                 Action:
                   - ecs:DiscoverPollEndpoint
                 Resource: '*'
-                # Same permissions as AmazonSSMManagedInstanceCore and AmazonSSMDirectoryServiceAccess AWS policies
               - Effect: Allow
                 Action:
                   - ssm:GetParameter
@@ -711,11 +713,6 @@ Resources:
                   - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/saas-boost/${Environment}/ACTIVE_DIRECTORY_PASSWORD
                   - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/saas-boost/${Environment}/ACTIVE_DIRECTORY_DNS_IPS
                   - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/saas-boost/${Environment}/ACTIVE_DIRECTORY_DNS_NAME
-              - Effect: Allow
-                Action:
-                  - ds:CreateComputer
-                  - ds:DescribeDirectories
-                Resource: '*'
               - Effect: Allow
                 Action:
                   - kms:Decrypt
@@ -755,6 +752,15 @@ Resources:
                   - c:\\cfn\\cfn-hup.conf
                   - c:\\etc\\cfn\\hooks.d\\cfn-auto-reloader.conf
     Properties:
+      TagSpecifications:
+        - ResourceType: launch-template
+          Tags:
+            - Key: Name
+              Value:
+                Fn::Join: ['', ['sb-', !Ref Environment, '-tenant-', !Select [0, !Split ['-', !Ref TenantId]], '-', !Ref ServiceResourceName]]
+            - Key: Tenant
+              Value:
+                !Ref TenantId
       LaunchTemplateData:
         ImageId:
           Fn::If:
@@ -780,76 +786,111 @@ Resources:
         SecurityGroupIds:
           - !Ref ECSSecurityGroup
         UserData:
-          Fn::Base64: !Sub |
-            <powershell>
-            Start-Transcript -Path "C:\UserData.log" -Append
-            Write-Output ("Download and install the CloudWatch agent")
-            Invoke-WebRequest https://s3.${AWS::Region}.amazonaws.com/amazoncloudwatch-agent-${AWS::Region}/windows/amd64/latest/amazon-cloudwatch-agent.msi -OutFile c:\Windows\Temp\amazon-cloudwatch-agent.msi
+          Fn::If:
+          - ProvisionFSx
+          - Fn::Base64:
+              !Sub |
+                <powershell>
+                Start-Transcript -Path "C:\UserData.log" -Append
+                Write-Output ("Download and install the CloudWatch agent")
+                Invoke-WebRequest https://s3.${AWS::Region}.amazonaws.com/amazoncloudwatch-agent-${AWS::Region}/windows/amd64/latest/amazon-cloudwatch-agent.msi -OutFile c:\Windows\Temp\amazon-cloudwatch-agent.msi
 
-            Start-Process msiexec.exe -Wait -ArgumentList '/I c:\Windows\Temp\amazon-cloudwatch-agent.msi /quiet'
+                Start-Process msiexec.exe -Wait -ArgumentList '/I c:\Windows\Temp\amazon-cloudwatch-agent.msi /quiet'
 
-            Write-Output ("Write a config file for the CloudWatch agent and then reload/restart the agent")
-            cd $Env:ProgramFiles\Amazon\AmazonCloudWatchAgent
-            .\amazon-cloudwatch-agent-ctl.ps1 -m ec2 -a fetch-config -s
+                Write-Output ("Write a config file for the CloudWatch agent and then reload/restart the agent")
+                cd $Env:ProgramFiles\Amazon\AmazonCloudWatchAgent
+                .\amazon-cloudwatch-agent-ctl.ps1 -m ec2 -a fetch-config -s
 
-            # Setup the ECS agent to point to our cluster and enable task IAM role and the awslogs driver
-            Write-Output ("Starting up ECS Agent and joining the ${ECSCluster} cluster")
-            Import-Module ECSTools
-            Initialize-ECSAgent -Cluster ${ECSCluster} -EnableTaskIAMRole -LoggingDrivers '["json-file","awslogs"]'
+                # Setup the ECS agent to point to our cluster and enable task IAM role and the awslogs driver
+                Write-Output ("Starting up ECS Agent and joining the ${ECSCluster} cluster")
+                Import-Module ECSTools
+                Initialize-ECSAgent -Cluster ${ECSCluster} -EnableTaskIAMRole -LoggingDrivers '["json-file","awslogs"]'
 
-            # If you have task IAM roles, awslogs doesn't work unless you set this environment variable
-            [Environment]::SetEnvironmentVariable("ECS_ENABLE_AWSLOGS_EXECUTIONROLE_OVERRIDE", $TRUE, "Machine")
-            Restart-Service AmazonECS
+                # If you have task IAM roles, awslogs doesn't work unless you set this environment variable
+                [Environment]::SetEnvironmentVariable("ECS_ENABLE_AWSLOGS_EXECUTIONROLE_OVERRIDE", $TRUE, "Machine")
+                Restart-Service AmazonECS
 
-            Write-Output ("UseFsx value is ${UseFSx}")
-            If ('${UseFSx}' -eq 'true')  {
                 Write-Output ("Getting SSM Parameters for the Active Directory domain")
+                $directoryName = (Get-SSMParameterValue -Name /saas-boost/${Environment}/ACTIVE_DIRECTORY_DNS_NAME).Parameters[0].Value
                 $username = (Get-SSMParameterValue -Name /saas-boost/${Environment}/ACTIVE_DIRECTORY_USER).Parameters[0].Value
                 $password = (Get-SSMParameterValue -Name /saas-boost/${Environment}/ACTIVE_DIRECTORY_PASSWORD -WithDecryption $True).Parameters[0].Value | ConvertTo-SecureString -asPlainText -Force
-                $credential = New-Object System.Management.Automation.PSCredential($username,$password)
-                $directoryName = (Get-SSMParameterValue -Name /saas-boost/${Environment}/ACTIVE_DIRECTORY_DNS_NAME).Parameters[0].Value
                 $ipdns = (Get-SSMParameterValue -Name /saas-boost/${Environment}/ACTIVE_DIRECTORY_DNS_IPS).Parameters[0].Value
                 $ips = $ipdns.Split(",")
 
                 Write-Output ("Reading the existing VPC DNS Server IP")
                 # Get the VPC DNS server.
-                $dnsclient = Get-DnsClientServerAddress -AddressFamily IPv4 | Where-Object {$_.ServerAddresses.Count -gt 0} | Select-Object -First 1
+                $dnsClient = Get-DnsClientServerAddress -AddressFamily IPv4 | Where-Object {$_.ServerAddresses.Count -gt 0} | Select-Object -First 1
 
                 # During retry, we should avoid adding duplicate DNS servers, if it was already added in the previous attempt.
                 # VPC DNS server is the last one in the list.
-                $vpcdns = $dnsclient.ServerAddresses | select -last 1
+                $vpcdns = $dnsClient.ServerAddresses | Select -Last 1
 
                 # Set up the IPv4 address of the AD DNS server as the first DNS server on this machine
-                $dnsserverstoupdate = $("{0},{1}" -f $ips[0], $vpcdns)
-                Write-Output ("Adding AD DNS server addresses :{0} to the IPV4 interface Index:{1}." -f $dnsserverstoupdate, $dnsclient.InterfaceIndex)
-                Set-DnsClientServerAddress -InterfaceIndex $dnsclient.InterfaceIndex -ServerAddresses $dnsserverstoupdate
+                $dnsServersToUpdate = $("{0},{1}" -f $ips[0], $vpcdns)
+                Write-Output ("Adding AD DNS server addresses: {0} to the IPV4 interface Index: {1}" -f $dnsServersToUpdate, $dnsClient.InterfaceIndex)
+                Set-DnsClientServerAddress -InterfaceIndex $dnsClient.InterfaceIndex -ServerAddresses $dnsServersToUpdate
 
                 # Join the domain
                 Write-Output ("Joining domain $directoryName")
+                $credential = New-Object System.Management.Automation.PSCredential("$directoryName\$username", $password)
                 Add-Computer -DomainName $directoryName -Credential $credential -Verbose -WarningAction Ignore
 
-                Write-Output ("Setting FSx File Server remote path")
-                $fileserverpath = "\\{0}\share" -f "${fsx.Outputs.WindowsFSxDnsName}"
+                If ('${FSxFileSystemType}' -eq 'FSXO')  {
+                    $fileServerPath = "\\{0}\C$" -f "${fsx.Outputs.FSxDnsName}"
+                }
+                Else {
+                    $fileServerPath = "\\{0}\share" -f "${fsx.Outputs.FSxDnsName}"
+                }
+                Write-Output ("Setting FSx File Server remote path to $fileServerPath")
 
                 # Map the share to local drive letter
                 Write-Output ("Mapping $fileserverpath to ${FSxWindowsMountDrive}")
-                New-SmbGlobalMapping -RemotePath $fileserverpath -Credential $credential -LocalPath ${FSxWindowsMountDrive} -RequirePrivacy $true -ErrorAction Stop
-            }  # end if for UseFsx
+                New-SmbGlobalMapping -RemotePath $fileServerPath -Credential $credential -LocalPath ${FSxWindowsMountDrive} -RequirePrivacy $true -ErrorAction Stop
 
-            Write-Output ("CloudFormation signal completion")
-            # Signal CloudFormation that we're done setting up
-            cfn-init.exe -v -s ${AWS::StackName} -r WindowsLaunchTemplate --region ${AWS::Region}
-            cfn-signal.exe -e %ERRORLEVEL% --stack ${AWS::StackName} --resource ECSAutoScalingGroup --region ${AWS::Region}
+                Write-Output ("CloudFormation signal completion")
+                # Signal CloudFormation that we're done setting up
+                cfn-init.exe -v -s ${AWS::StackName} -r WindowsLaunchTemplate --region ${AWS::Region}
+                cfn-signal.exe -e %ERRORLEVEL% --stack ${AWS::StackName} --resource ECSAutoScalingGroup --region ${AWS::Region}
 
-            Stop-Transcript
-            </powershell>
-            <persist>true</persist>
+                Stop-Transcript
+                </powershell>
+                <persist>true</persist>
+          - Fn::Base64:
+              !Sub |
+                <powershell>
+                Start-Transcript -Path "C:\UserData.log" -Append
+                Write-Output ("Download and install the CloudWatch agent")
+                Invoke-WebRequest https://s3.${AWS::Region}.amazonaws.com/amazoncloudwatch-agent-${AWS::Region}/windows/amd64/latest/amazon-cloudwatch-agent.msi -OutFile c:\Windows\Temp\amazon-cloudwatch-agent.msi
+
+                Start-Process msiexec.exe -Wait -ArgumentList '/I c:\Windows\Temp\amazon-cloudwatch-agent.msi /quiet'
+
+                Write-Output ("Write a config file for the CloudWatch agent and then reload/restart the agent")
+                cd $Env:ProgramFiles\Amazon\AmazonCloudWatchAgent
+                .\amazon-cloudwatch-agent-ctl.ps1 -m ec2 -a fetch-config -s
+
+                # Setup the ECS agent to point to our cluster and enable task IAM role and the awslogs driver
+                Write-Output ("Starting up ECS Agent and joining the ${ECSCluster} cluster")
+                Import-Module ECSTools
+                Initialize-ECSAgent -Cluster ${ECSCluster} -EnableTaskIAMRole -LoggingDrivers '["json-file","awslogs"]'
+
+                # If you have task IAM roles, awslogs doesn't work unless you set this environment variable
+                [Environment]::SetEnvironmentVariable("ECS_ENABLE_AWSLOGS_EXECUTIONROLE_OVERRIDE", $TRUE, "Machine")
+                Restart-Service AmazonECS
+
+                Write-Output ("CloudFormation signal completion")
+                # Signal CloudFormation that we're done setting up
+                cfn-init.exe -v -s ${AWS::StackName} -r WindowsLaunchTemplate --region ${AWS::Region}
+                cfn-signal.exe -e %ERRORLEVEL% --stack ${AWS::StackName} --resource ECSAutoScalingGroup --region ${AWS::Region}
+
+                Stop-Transcript
+                </powershell>
+                <persist>true</persist>
         TagSpecifications:
           - ResourceType: instance
             Tags:
               - Key: Name
                 Value:
-                  Fn::Join: ['', ['sb-', !Ref Environment, '-tenant-', !Select [0, !Split ['-', !Ref TenantId]]]]
+                  Fn::Join: ['', ['sb-', !Ref Environment, '-tenant-', !Select [0, !Split ['-', !Ref TenantId]], '-', !Ref ServiceResourceName]]
               - Key: Tenant
                 Value:
                   !Ref TenantId
@@ -881,6 +922,15 @@ Resources:
                   - /etc/cfn/cfn-hup.conf
                   - /etc/cfn/hooks.d/cfn-auto-reloader.conf
     Properties:
+      TagSpecifications:
+        - ResourceType: launch-template
+          Tags:
+            - Key: Name
+              Value:
+                Fn::Join: ['', ['sb-', !Ref Environment, '-tenant-', !Select [0, !Split ['-', !Ref TenantId]], '-', !Ref ServiceResourceName]]
+            - Key: Tenant
+              Value:
+                !Ref TenantId
       LaunchTemplateData:
         ImageId: !Ref AMZNLINUX2
         InstanceType: !Ref ClusterInstanceType
@@ -908,7 +958,7 @@ Resources:
             Tags:
               - Key: Name
                 Value:
-                  Fn::Join: ['', ['sb-', !Ref Environment, '-tenant-', !Select [0, !Split ['-', !Ref TenantId]]]]
+                  Fn::Join: ['', ['sb-', !Ref Environment, '-tenant-', !Select [0, !Split ['-', !Ref TenantId]], '-', !Ref ServiceResourceName]]
               - Key: Tenant
                 Value:
                   !Ref TenantId
@@ -954,7 +1004,7 @@ Resources:
             !If
               - DisableAccess
               - ContentType: text/html
-                StatusCode: 200
+                StatusCode: '200'
                 MessageBody: <html><body>Access to this application is disabled. Contact support if you have questions.</body></html>
               - !Ref 'AWS::NoValue'
       Conditions:
@@ -974,7 +1024,7 @@ Resources:
             !If
               - DisableAccess
               - ContentType: text/html
-                StatusCode: 200
+                StatusCode: '200'
                 MessageBody: <html><body>Access to this application is disabled. Contact support if you have questions.</body></html>
               - !Ref 'AWS::NoValue'
       Conditions:
@@ -1064,7 +1114,7 @@ Resources:
     Type: AWS::ApplicationAutoScaling::ScalingPolicy
     Properties:
       PolicyName:
-            Fn::Join: ['', ['sb-', !Ref Environment, '-tenant-', !Select [0, !Split ['-', !Ref TenantId]], '-autoscaling-policy-cpu']]
+        Fn::Join: ['', ['sb-', !Ref Environment, '-tenant-', !Select [0, !Split ['-', !Ref TenantId]], '-autoscaling-policy-cpu']]
       PolicyType: TargetTrackingScaling
       ScalingTargetId: !Ref ECSServiceAutoScalingTarget
       TargetTrackingScalingPolicyConfiguration:
@@ -1077,7 +1127,7 @@ Resources:
     Type: AWS::ApplicationAutoScaling::ScalingPolicy
     Properties:
       PolicyName:
-            Fn::Join: ['', ['sb-', !Ref Environment, '-tenant-', !Select [0, !Split ['-', !Ref TenantId]], '-autoscaling-policy-mem']]
+        Fn::Join: ['', ['sb-', !Ref Environment, '-tenant-', !Select [0, !Split ['-', !Ref TenantId]], '-autoscaling-policy-mem']]
       PolicyType: TargetTrackingScaling
       ScalingTargetId: !Ref ECSServiceAutoScalingTarget
       TargetTrackingScalingPolicyConfiguration:
@@ -1090,27 +1140,30 @@ Resources:
     Type: AWS::CloudFormation::Stack
     Condition: ProvisionFSx
     Properties:
-      TemplateURL: !Sub 'https://{{resolve:ssm:/saas-boost/${Environment}/SAAS_BOOST_BUCKET}}.s3.amazonaws.com/tenant-onboarding-fsx.yaml'
+      TemplateURL: !Sub 'https://{{resolve:ssm:/saas-boost/${Environment}/SAAS_BOOST_BUCKET}}.s3.${AWS::Region}.amazonaws.com/tenant-onboarding-fsx.yaml'
       Parameters:
         Environment: !Ref Environment
         TenantId: !Ref TenantId
         ServiceResourceName: !Ref ServiceResourceName
         ActiveDirectoryId: !Sub '{{resolve:ssm:/saas-boost/${Environment}/ACTIVE_DIRECTORY_ID}}'
+        ActiveDirectoryDnsIps: !Sub '{{resolve:ssm:/saas-boost/${Environment}/ACTIVE_DIRECTORY_DNS_IPS}}'
         PrivateSubnetA: !Ref SubnetPrivateA
         PrivateSubnetB: !Ref SubnetPrivateB
+        PrivateRouteTable: !Ref PrivateRouteTable
         VPC: !Ref VPC
         SaaSBoostBucket: !Sub '{{resolve:ssm:/saas-boost/${Environment}/SAAS_BOOST_BUCKET}}'
+        FileSystemType: !Ref FSxFileSystemType
         BackupRetention: !Ref FSxBackupRetention
         DailyBackupTime: !Ref FSxDailyBackupTime
         WeeklyMaintenanceTime: !Ref FSxWeeklyMaintenanceTime
-        StorageCapacity: !Ref FSxStorageCapacity
-        ThroughputCapacity: !Ref FSxThroughputCapacity
+        StorageCapacity: !Ref FileSystemStorage
+        ThroughputCapacity: !Ref FileSystemThroughput
         ECSSecurityGroup: !Ref ECSSecurityGroup
   efs:
     Type: AWS::CloudFormation::Stack
     Condition: ProvisionEFS
     Properties:
-      TemplateURL: !Sub 'https://{{resolve:ssm:/saas-boost/${Environment}/SAAS_BOOST_BUCKET}}.s3.amazonaws.com/tenant-onboarding-efs.yaml'
+      TemplateURL: !Sub 'https://{{resolve:ssm:/saas-boost/${Environment}/SAAS_BOOST_BUCKET}}.s3.${AWS::Region}.amazonaws.com/tenant-onboarding-efs.yaml'
       Parameters:
         Environment: !Ref Environment
         TenantId: !Ref TenantId
@@ -1125,7 +1178,7 @@ Resources:
     Type: AWS::CloudFormation::Stack
     Condition: ProvisionRDS
     Properties:
-      TemplateURL: !Sub 'https://{{resolve:ssm:/saas-boost/${Environment}/SAAS_BOOST_BUCKET}}.s3.amazonaws.com/tenant-onboarding-rds.yaml'
+      TemplateURL: !Sub 'https://{{resolve:ssm:/saas-boost/${Environment}/SAAS_BOOST_BUCKET}}.s3.${AWS::Region}.amazonaws.com/tenant-onboarding-rds.yaml'
       Parameters:
         Environment: !Ref Environment
         SaaSBoostBucket: !Sub '{{resolve:ssm:/saas-boost/${Environment}/SAAS_BOOST_BUCKET}}'

--- a/resources/tenant-onboarding-efs.yaml
+++ b/resources/tenant-onboarding-efs.yaml
@@ -40,7 +40,7 @@ Parameters:
     Description: Turn on EFS encryption at rest?
     Type: String
     AllowedValues: ['true', 'false']
-    Default: 'false'
+    Default: 'true'
   EFSLifecyclePolicy:
     Description: Enable EFS IA lifecycle?
     Type: String

--- a/resources/tenant-onboarding-fsx.yaml
+++ b/resources/tenant-onboarding-fsx.yaml
@@ -87,6 +87,12 @@ Parameters:
      Description: Specify the preferred start time to perform weekly maintenance, formatted d:HH:MM in the UTC time zone
      Type: String
      Default: '7:02:00'
+  OntapVolumeSize:
+    Description: Specify the size of the ONTAP volume to create inside the Storage Virtual Machine in MB
+    Type: Number
+    Default: 40
+    MinValue: 20
+    MaxValue: 104857600
 Conditions:
   UseAWSDirectoryService: !Not [!Equals [!Ref ActiveDirectoryId, '']]
   HasKey: !Equals [!Ref FSxEncryptionKey, 'UseKey']
@@ -463,7 +469,7 @@ Resources:
       OntapConfiguration:
         JunctionPath: /vol1
         SecurityStyle: NTFS
-        SizeInMegabytes: '40' # Quoted to make cfn-lint happy
+        SizeInMegabytes: !Ref OntapVolumeSize
         StorageEfficiencyEnabled: 'false' # Quoted to make cfn-lint happy
         StorageVirtualMachineId: !Ref StorageVirtualMachine
       Tags:

--- a/resources/tenant-onboarding-fsx.yaml
+++ b/resources/tenant-onboarding-fsx.yaml
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: 2010-09-09
 Description: AWS SaaS Boost Tenant Onboarding FSx for Windows File Server Extension
 Parameters:
   Environment:
@@ -36,53 +36,64 @@ Parameters:
   PrivateSubnetB:
     Description: Choose the Id of the private subnet 2 in Availability Zone 2 (e.g., subnet-a0246dcd).
     Type: AWS::EC2::Subnet::Id
+  PrivateRouteTable:
+    Description: Route table for the private subnets in this tenant's VPC
+    Type: String
   ECSSecurityGroup:
     Description: Source security group of ECS instances
     Type: AWS::EC2::SecurityGroup::Id
   ActiveDirectoryId:
     Description: Id of the AWS Managed Microsoft AD. If you are using self-managed Active Directory, leave this blank.
     Type: String
+  ActiveDirectoryDnsIps:
+    Description: Comma delimited string of DNS IP addresses for the Active Directory instance to join the SVM to for FSx ONTAP
+    Type: String
+    Default: ''
+  FileSystemType:
+    Description: FSx file system type
+    Type: String
+    AllowedValues: [FSX_WINDOWS, FSX_ONTAP]
+    Default: FSX_WINDOWS
   FSxEncryptionKey:
-    AllowedValues:
-      - 'Default'
-      - 'GenerateKey'
-      - 'UseKey'
     Description: Use the default AWS Key Management Service (AWS KMS) key for Amazon FSx, choose GenerateKey to create a key,
       or choose UseKey to use an existing key for encryption at rest on the Amazon FSx for Windows file system.
-    Default: 'Default'
     Type: String
+    AllowedValues: [Default, GenerateKey, UseKey]
+    Default: Default
   FSxExistingKeyID:
     Description: If you chose the option to use an existing key, you must specify the KMS Key ID you want to use.
-    Default: ''
     Type: String
+    Default: ''
   StorageCapacity:
-    Default: 32
     Description: Specify the storage capacity of the file system being created, in gibibytes.
       Valid values are 32 GiB - 65,536 GiB.
     Type: Number
+    Default: 32
   ThroughputCapacity:
-    Default: 8
     Description: Specify the throughput of the Amazon FSx file system. Valid values are 8 - 2048.
     Type: Number
+    Default: 16
   BackupRetention:
     Description: Number of days to retain automatic backups.
       Setting this to 0 disables the creation of automatic backups. The maximum retention period
       for backups is 35 days.
-    Default: 7
     Type: Number
+    Default: 7
   DailyBackupTime:
     Description: Preferred time to take daily automatic backups, formatted HH:MM in the UTC time zone.
-    Default: '01:00'
     Type: String
+    Default: '01:00'
   WeeklyMaintenanceTime:
      Description: Specify the preferred start time to perform weekly maintenance, formatted d:HH:MM in the UTC time zone
-     Default: '7:02:00'
      Type: String
+     Default: '7:02:00'
 Conditions:
   UseAWSDirectoryService: !Not [!Equals [!Ref ActiveDirectoryId, '']]
   HasKey: !Equals [!Ref FSxEncryptionKey, 'UseKey']
   CreateKey: !Equals [!Ref FSxEncryptionKey, 'GenerateKey']
   UseNonDefault: !Not [!Equals [!Ref FSxEncryptionKey, 'Default']]
+  FSxWindows: !Equals [!Ref FileSystemType, 'FSX_WINDOWS']
+  FSxONTAP: !Equals [!Ref FileSystemType, 'FSX_ONTAP']
 Resources:
   FSxKMSKey:
     Condition: CreateKey
@@ -129,90 +140,248 @@ Resources:
       AliasName:
         Fn::Join: ['', ['alias/sb-', !Ref Environment, '-fsx-tenant-', !Select [0, !Split ['-', !Ref TenantId]], '-', !Ref ServiceResourceName]]
       TargetKeyId: !Ref FSxKMSKey
-  FSxSecurityGroup:
+  FSxActiveDirectorySecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
       VpcId: !Ref VPC
-      GroupDescription: FSx File System Security Group
+      GroupDescription: FSx Active Directory Security Group
       GroupName:
-        Fn::Join: ['', ['sb-', !Ref Environment, '-fsx-tenant-', !Select [0, !Split ['-', !Ref TenantId]], '-', !Ref ServiceResourceName]]
+        Fn::Join: ['', ['sb-', !Ref Environment, '-fsx-ad-tenant-', !Select [0, !Split ['-', !Ref TenantId]], '-', !Ref ServiceResourceName]]
       SecurityGroupIngress:
         - IpProtocol: tcp
           FromPort: 53
           ToPort: 53
+          Description: DNS
           SourceSecurityGroupId: !Ref ECSSecurityGroup
         - IpProtocol: udp
           FromPort: 53
           ToPort: 53
+          Description: DNS
           SourceSecurityGroupId: !Ref ECSSecurityGroup
         - IpProtocol: tcp
           FromPort: 88
           ToPort: 88
+          Description: Kerberos authentication
           SourceSecurityGroupId: !Ref ECSSecurityGroup
         - IpProtocol: udp
           FromPort: 88
           ToPort: 88
+          Description: Kerberos authentication
           SourceSecurityGroupId: !Ref ECSSecurityGroup
         - IpProtocol: udp
           FromPort: 123
           ToPort: 123
+          Description: NTP
           SourceSecurityGroupId: !Ref ECSSecurityGroup
         - IpProtocol: tcp
           FromPort: 135
           ToPort: 135
+          Description: DCE / EPMAP
           SourceSecurityGroupId: !Ref ECSSecurityGroup
         - IpProtocol: udp
           FromPort: 389
           ToPort: 389
+          Description: LDAP
           SourceSecurityGroupId: !Ref ECSSecurityGroup
         - IpProtocol: tcp
           FromPort: 389
           ToPort: 389
-          SourceSecurityGroupId: !Ref ECSSecurityGroup
-        - IpProtocol: udp
-          FromPort: 445
-          ToPort: 445
+          Description: LDAP
           SourceSecurityGroupId: !Ref ECSSecurityGroup
         - IpProtocol: tcp
           FromPort: 445
           ToPort: 445
+          Description: Directory Services SMB file sharing
           SourceSecurityGroupId: !Ref ECSSecurityGroup
         - IpProtocol: udp
           FromPort: 464
           ToPort: 464
+          Description: Change or Set password
           SourceSecurityGroupId: !Ref ECSSecurityGroup
         - IpProtocol: tcp
           FromPort: 464
           ToPort: 464
+          Description: Change or Set password
           SourceSecurityGroupId: !Ref ECSSecurityGroup
         - IpProtocol: tcp
           FromPort: 636
           ToPort: 636
+          Description: LDAP over SSL
           SourceSecurityGroupId: !Ref ECSSecurityGroup
         - IpProtocol: tcp
           FromPort: 3268
           ToPort: 3268
+          Description: Microsoft Global Catalog
           SourceSecurityGroupId: !Ref ECSSecurityGroup
         - IpProtocol: tcp
           FromPort: 3269
           ToPort: 3269
+          Description: Microsoft Global Catalog over SSL
           SourceSecurityGroupId: !Ref ECSSecurityGroup
         - IpProtocol: tcp
           FromPort: 5985
           ToPort: 5985
+          Description: WinRM 2.0
           SourceSecurityGroupId: !Ref ECSSecurityGroup
         - IpProtocol: tcp
           FromPort: 9389
           ToPort: 9389
+          Description: Microsoft AD DS Web Services and PowerShell
           SourceSecurityGroupId: !Ref ECSSecurityGroup
         - IpProtocol: tcp
           FromPort: 49152
           ToPort: 65535
+          Description: RPC ephemeral ports
           SourceSecurityGroupId: !Ref ECSSecurityGroup
-  WindowsFSx:
+  FSxOntapSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Condition: FSxONTAP
+    Properties:
+      VpcId: !Ref VPC
+      GroupDescription: FSx ONTAP Security Group
+      GroupName:
+        Fn::Join: ['', ['sb-', !Ref Environment, '-fsx-ontap-tenant-', !Select [0, !Split ['-', !Ref TenantId]], '-', !Ref ServiceResourceName]]
+      SecurityGroupIngress:
+        - IpProtocol: icmp
+          FromPort: -1
+          ToPort: -1
+          Description: ICMP Ping
+          SourceSecurityGroupId: !Ref ECSSecurityGroup
+        - IpProtocol: tcp
+          FromPort: 22
+          ToPort: 22
+          Description: SSH access to cluster or node management LIF
+          SourceSecurityGroupId: !Ref ECSSecurityGroup
+        - IpProtocol: tcp
+          FromPort: 111
+          ToPort: 111
+          Description: Remote procedure call for NFS
+          SourceSecurityGroupId: !Ref ECSSecurityGroup
+        - IpProtocol: udp
+          FromPort: 111
+          ToPort: 111
+          Description: Remote procedure call for NFS
+          SourceSecurityGroupId: !Ref ECSSecurityGroup
+        - IpProtocol: tcp
+          FromPort: 135
+          ToPort: 135
+          Description: Remote procedure call for CIFS
+          SourceSecurityGroupId: !Ref ECSSecurityGroup
+        - IpProtocol: udp
+          FromPort: 135
+          ToPort: 135
+          Description: Remote procedure call for CIFS
+          SourceSecurityGroupId: !Ref ECSSecurityGroup
+        - IpProtocol: udp
+          FromPort: 137
+          ToPort: 137
+          Description: NetBIOS name resolution for CIFS
+          SourceSecurityGroupId: !Ref ECSSecurityGroup
+        - IpProtocol: tcp
+          FromPort: 139
+          ToPort: 139
+          Description: NetBIOS service session for CIFS
+          SourceSecurityGroupId: !Ref ECSSecurityGroup
+        - IpProtocol: udp
+          FromPort: 139
+          ToPort: 139
+          Description: NetBIOS service session for CIFS
+          SourceSecurityGroupId: !Ref ECSSecurityGroup
+        - IpProtocol: tcp
+          FromPort: 161
+          ToPort: 162
+          Description: SNMP
+          SourceSecurityGroupId: !Ref ECSSecurityGroup
+        - IpProtocol: udp
+          FromPort: 161
+          ToPort: 162
+          Description: SNMP
+          SourceSecurityGroupId: !Ref ECSSecurityGroup
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          Description: ONTAP REST API access for cluster management LIF or SVM management LIF
+          SourceSecurityGroupId: !Ref ECSSecurityGroup
+        - IpProtocol: tcp
+          FromPort: 635
+          ToPort: 635
+          Description: NFS mount
+          SourceSecurityGroupId: !Ref ECSSecurityGroup
+        - IpProtocol: udp
+          FromPort: 635
+          ToPort: 635
+          Description: NFS mount
+          SourceSecurityGroupId: !Ref ECSSecurityGroup
+        - IpProtocol: tcp
+          FromPort: 749
+          ToPort: 749
+          Description: Kerberos
+          SourceSecurityGroupId: !Ref ECSSecurityGroup
+        - IpProtocol: tcp
+          FromPort: 2049
+          ToPort: 2049
+          Description: NFS server daemon
+          SourceSecurityGroupId: !Ref ECSSecurityGroup
+        - IpProtocol: udp
+          FromPort: 2049
+          ToPort: 2049
+          Description: NFS server daemon
+          SourceSecurityGroupId: !Ref ECSSecurityGroup
+        - IpProtocol: tcp
+          FromPort: 3260
+          ToPort: 3260
+          Description: iSCSI to the iSCSI data LIF
+          SourceSecurityGroupId: !Ref ECSSecurityGroup
+        - IpProtocol: tcp
+          FromPort: 4045
+          ToPort: 4045
+          Description: NFS lock daemon
+          SourceSecurityGroupId: !Ref ECSSecurityGroup
+        - IpProtocol: udp
+          FromPort: 4045
+          ToPort: 4045
+          Description: NFS lock daemon
+          SourceSecurityGroupId: !Ref ECSSecurityGroup
+        - IpProtocol: tcp
+          FromPort: 4046
+          ToPort: 4046
+          Description: NFS network status monitor
+          SourceSecurityGroupId: !Ref ECSSecurityGroup
+        - IpProtocol: udp
+          FromPort: 4046
+          ToPort: 4046
+          Description: NFS network status monitor
+          SourceSecurityGroupId: !Ref ECSSecurityGroup
+        - IpProtocol: udp
+          FromPort: 4049
+          ToPort: 4049
+          Description: NFS quota protocol
+          SourceSecurityGroupId: !Ref ECSSecurityGroup
+        - IpProtocol: tcp
+          FromPort: 10000
+          ToPort: 10000
+          Description: NDMP and NetApp SnapMirror
+          SourceSecurityGroupId: !Ref ECSSecurityGroup
+        - IpProtocol: tcp
+          FromPort: 11104
+          ToPort: 11104
+          Description: NetApp SnapMirror management
+          SourceSecurityGroupId: !Ref ECSSecurityGroup
+        - IpProtocol: tcp
+          FromPort: 11105
+          ToPort: 11105
+          Description: NetApp SnapMirror data transfer
+          SourceSecurityGroupId: !Ref ECSSecurityGroup
+  FSxFileSystem:
     Type: AWS::FSx::FileSystem
     Properties:
-      FileSystemType: WINDOWS
+      FileSystemType: !If
+        - FSxWindows
+        - WINDOWS
+        - !If
+          - FSxONTAP
+          - ONTAP
+          - !Ref 'AWS::NoValue'
       KmsKeyId: !If
         - UseNonDefault
         - !If
@@ -225,18 +394,84 @@ Resources:
         - !Ref PrivateSubnetA
         - !Ref PrivateSubnetB
       SecurityGroupIds:
-        - !Ref FSxSecurityGroup
+        - !Ref FSxActiveDirectorySecurityGroup
+        - !If [FSxONTAP, !Ref FSxOntapSecurityGroup, !Ref 'AWS::NoValue']
       Tags:
+        - Key: Name
+          Value:
+            Fn::Join: ['', ['sb-', !Ref Environment, '-tenant-', !Select [0, !Split ['-', !Ref TenantId]], '-', !Ref ServiceResourceName]]
         - Key: Tenant
           Value: !Ref TenantId
-      WindowsConfiguration:
-        ActiveDirectoryId: !If [UseAWSDirectoryService, !Ref ActiveDirectoryId, !Ref 'AWS::NoValue']
-        WeeklyMaintenanceStartTime: !Ref WeeklyMaintenanceTime
-        DailyAutomaticBackupStartTime: !Ref DailyBackupTime
-        AutomaticBackupRetentionDays: !Ref BackupRetention
-        DeploymentType: MULTI_AZ_1
-        PreferredSubnetId: !Ref PrivateSubnetA
-        ThroughputCapacity: !Ref ThroughputCapacity
+      WindowsConfiguration: !If
+        - FSxWindows
+        -
+          ActiveDirectoryId: !If [UseAWSDirectoryService, !Ref ActiveDirectoryId, !Ref 'AWS::NoValue']
+          WeeklyMaintenanceStartTime: !Ref WeeklyMaintenanceTime
+          DailyAutomaticBackupStartTime: !Ref DailyBackupTime
+          AutomaticBackupRetentionDays: !Ref BackupRetention
+          DeploymentType: MULTI_AZ_1
+          PreferredSubnetId: !Ref PrivateSubnetA
+          ThroughputCapacity: !Ref ThroughputCapacity
+        - !Ref 'AWS::NoValue'
+      OntapConfiguration: !If
+        - FSxONTAP
+        -
+          WeeklyMaintenanceStartTime: !Ref WeeklyMaintenanceTime
+          DailyAutomaticBackupStartTime: !Ref DailyBackupTime
+          AutomaticBackupRetentionDays: !Ref BackupRetention
+          DeploymentType: MULTI_AZ_1
+          PreferredSubnetId: !Ref PrivateSubnetA
+          ThroughputCapacity: !Ref ThroughputCapacity
+          RouteTableIds: !Split [',', !Ref PrivateRouteTable]
+        - !Ref 'AWS::NoValue'
+  StorageVirtualMachine:
+    Type: AWS::FSx::StorageVirtualMachine
+    Condition: FSxONTAP
+    Properties:
+      FileSystemId: !Ref FSxFileSystem
+      Name:
+        Fn::Join: ['', ['sb-', !Ref Environment, '-tenant-', !Select [0, !Split ['-', !Ref TenantId]], '-', !Ref ServiceResourceName]]
+      RootVolumeSecurityStyle: NTFS
+      ActiveDirectoryConfiguration:
+        # Max string length 15. Since this is bound to a SVM and a File System, we don't need the env or service name.
+        NetBiosName:
+          Fn::Join: ['', ['tenant-', !Select [0, !Split ['-', !Ref TenantId]]]]
+        # TODO how do we support non SaaS Boost provisioned AD instances?
+        SelfManagedActiveDirectoryConfiguration:
+          OrganizationalUnitDistinguishedName: !Sub OU=Computers,OU=sb-${Environment},DC=${Environment},DC=${AWS::Region},DC=saasboost,DC=com
+          FileSystemAdministratorsGroup: AWS Delegated FSx Administrators
+          DomainName: !Sub '{{resolve:ssm:/saas-boost/${Environment}/ACTIVE_DIRECTORY_DNS_NAME}}'
+          # Must pass the comma delimited string in as a parameter, because {{resolve:ssm:}} can't
+          # be nested inside a Fn::Split. The split happens before the resolution of the parameter.
+          DnsIps: !Split [',', !Ref ActiveDirectoryDnsIps]
+          # Don't use Domain\Username here - only Username
+          UserName: !Sub '{{resolve:ssm:/saas-boost/${Environment}/ACTIVE_DIRECTORY_USER}}'
+          # Can't use ssm-secure here
+          Password: !Sub '{{resolve:secretsmanager:/saas-boost/${Environment}/ACTIVE_DIRECTORY_PASSWORD::::}}'
+      Tags:
+        - Key: Name
+          Value:
+            Fn::Join: ['', ['sb-', !Ref Environment, '-tenant-', !Select [0, !Split ['-', !Ref TenantId]], '-', !Ref ServiceResourceName]]
+        - Key: Tenant
+          Value: !Ref TenantId
+  StorageVolume:
+    Type: AWS::FSx::Volume
+    Condition: FSxONTAP
+    Properties:
+      VolumeType: ONTAP
+      Name: vol1
+      OntapConfiguration:
+        JunctionPath: /vol1
+        SecurityStyle: NTFS
+        SizeInMegabytes: '40' # Quoted to make cfn-lint happy
+        StorageEfficiencyEnabled: 'false' # Quoted to make cfn-lint happy
+        StorageVirtualMachineId: !Ref StorageVirtualMachine
+      Tags:
+        - Key: Name
+          Value:
+            Fn::Join: ['', ['sb-', !Ref Environment, '-tenant-', !Select [0, !Split ['-', !Ref TenantId]], '-', !Ref ServiceResourceName]]
+        - Key: Tenant
+          Value: !Ref TenantId
   FsxDnsNameRole:
     Type: AWS::IAM::Role
     Properties:
@@ -275,10 +510,8 @@ Resources:
                   - ec2:CreateNetworkInterface
                   - ec2:DescribeNetworkInterfaces
                   - ec2:DeleteNetworkInterface
-                Resource: '*'
-              - Effect: Allow
-                Action:
                   - fsx:DescribeFileSystems
+                  - fsx:DescribeStorageVirtualMachines
                 Resource: '*'
   FsxDnsNameLogs:
     Type: AWS::Logs::LogGroup
@@ -300,7 +533,8 @@ Resources:
       # Has to be a VPC Lambda because we're talking to FSx
       VpcConfig:
         SecurityGroupIds:
-          - !Ref FSxSecurityGroup
+          - !Ref FSxActiveDirectorySecurityGroup
+          - !If [FSxONTAP, !Ref FSxOntapSecurityGroup, !Ref 'AWS::NoValue']
         SubnetIds:
           - !Ref PrivateSubnetA
           - !Ref PrivateSubnetB
@@ -315,6 +549,9 @@ Resources:
         Variables:
           JAVA_TOOL_OPTIONS: '-XX:+TieredCompilation -XX:TieredStopAtLevel=1'
       Tags:
+        - Key: Name
+          Value:
+            Fn::Join: ['', ['sb-', !Ref Environment, '-tenant-', !Select [0, !Split ['-', !Ref TenantId]], '-', !Ref ServiceResourceName]]
         - Key: Tenant
           Value: !Ref TenantId
   InvokeGetFsxDnsName:
@@ -323,11 +560,12 @@ Resources:
       - FsxDnsNameLogs
     Properties:
       ServiceToken: !GetAtt FsxDnsNameFunction.Arn
-      FsxFileSystemId: !Ref WindowsFSx
+      FsxFileSystemId: !Ref FSxFileSystem
+      StorageVirtualMachineId: !If [FSxONTAP, !Ref StorageVirtualMachine, '']
 Outputs:
   FileSystemId:
-    Description: File System ID for FSx for Windows File Server
-    Value: !Ref WindowsFSx
-  WindowsFSxDnsName:
+    Description: FSx File System ID
+    Value: !Ref FSxFileSystem
+  FSxDnsName:
     Value: !GetAtt InvokeGetFsxDnsName.DnsName
-    Description: FSx for Windows File Server DNS Name
+    Description: FSx File Server DNS Name


### PR DESCRIPTION
- Changes to the tenant-onboarding tempates to create FSx ONTAP
  resources
- Adding the private subnet route table to the tenant resources so we
  can pass it to the FSx file system resource
- Have the installer save the AD password to Secrets Manager so we can
  resolve it in CloudFormation for the storage virtual machine resource
- Updates to security groups and IAM policies
- Update the DNS hostname custom resource to work for both FSx Windows
  and FSx ONTAP
- Update the user data boot script for Windows to properly mount the
  storage virtual machine

Co-authored-by: netapp-vedantsethia Vedant.Sethia@netapp.com
Co-authored-by: netapp-dhruv-tyagi Dhruv.Tyagi@netapp.com


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
