### PR TITLE
Support FSX Ontap in AppConfig.

### DIFF
--- a/resources/saas-boost-svc-onboarding.yaml
+++ b/resources/saas-boost-svc-onboarding.yaml
@@ -556,6 +556,7 @@ Resources:
               - iam:CreateRole
               - iam:DeleteRole
               - iam:AttachRolePolicy
+              - iam:DetachRolePolicy
               - iam:GetRolePolicy
               - iam:PutRolePolicy
               - iam:DeleteRolePolicy
@@ -791,6 +792,7 @@ Resources:
               - lambda:CreateFunction
               - lambda:InvokeFunction
               - lambda:DeleteFunction
+              - lambda:TagResource
             Resource:
               - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:sb-${Environment}-fsx-dns-tenant-*
           - Effect: Allow

--- a/resources/tenant-onboarding-app.yaml
+++ b/resources/tenant-onboarding-app.yaml
@@ -212,6 +212,12 @@ Parameters:
     Description: Preferred start time to perform weekly maintenance, formatted d:HH:MM in the UTC time zone
     Default: '7:02:00'
     Type: String
+  OntapVolumeSize:
+    Description: Specify the size of the ONTAP volume to create inside the Storage Virtual Machine in MB
+    Type: Number
+    Default: 40
+    MinValue: 20
+    MaxValue: 104857600
   Disable:
     Description: Disable the tenant's access to the application
     Type: String
@@ -1162,6 +1168,7 @@ Resources:
         StorageCapacity: !Ref FileSystemStorage
         ThroughputCapacity: !Ref FileSystemThroughput
         ECSSecurityGroup: !Ref ECSSecurityGroup
+        OntapVolumeSize: !Ref OntapVolumeSize
   efs:
     Type: AWS::CloudFormation::Stack
     Condition: ProvisionEFS

--- a/resources/tenant-onboarding-app.yaml
+++ b/resources/tenant-onboarding-app.yaml
@@ -189,28 +189,24 @@ Parameters:
   FileSystemStorage:
     Description: Storage capacity for the file system in GB
     Type: Number
-    MinValue: 32
-    MaxValue: 65536
     Default: 32
   FileSystemThroughput:
     Description: Throughput capacity for the file system in MB/s
     Type: Number
-    MinValue: 8
-    MaxValue: 2048
     Default: 16
   FSxBackupRetention:
     Description: Number of days to retain automatic backups
     MinValue: 0
-    MaxValue: 35
+    MaxValue: 90
     Default: 0
     Type: Number
   FSxDailyBackupTime:
     Description: Preferred time to take daily automatic backups, formatted HH:MM in the UTC time zone.
-    Default: '01:00'
+    Default: '02:00'
     Type: String
   FSxWeeklyMaintenanceTime:
     Description: Preferred start time to perform weekly maintenance, formatted d:HH:MM in the UTC time zone
-    Default: '7:02:00'
+    Default: '7:01:00'
     Type: String
   OntapVolumeSize:
     Description: Specify the size of the ONTAP volume to create inside the Storage Virtual Machine in MB

--- a/resources/tenant-onboarding-fsx.yaml
+++ b/resources/tenant-onboarding-fsx.yaml
@@ -65,28 +65,25 @@ Parameters:
     Type: String
     Default: ''
   StorageCapacity:
-    Description: Specify the storage capacity of the file system being created, in gibibytes.
-      Valid values are 32 GiB - 65,536 GiB.
+    Description: Specify the storage capacity of the file system being created in GB
     Type: Number
     Default: 32
   ThroughputCapacity:
-    Description: Specify the throughput of the Amazon FSx file system. Valid values are 8 - 2048.
+    Description: Specify the throughput of the Amazon FSx file system
     Type: Number
     Default: 16
   BackupRetention:
-    Description: Number of days to retain automatic backups.
-      Setting this to 0 disables the creation of automatic backups. The maximum retention period
-      for backups is 35 days.
+    Description: Number of days to retain automatic backups
     Type: Number
     Default: 7
   DailyBackupTime:
     Description: Preferred time to take daily automatic backups, formatted HH:MM in the UTC time zone.
     Type: String
-    Default: '01:00'
+    Default: '02:00'
   WeeklyMaintenanceTime:
      Description: Specify the preferred start time to perform weekly maintenance, formatted d:HH:MM in the UTC time zone
      Type: String
-     Default: '7:02:00'
+     Default: '7:01:00'
   OntapVolumeSize:
     Description: Specify the size of the ONTAP volume to create inside the Storage Virtual Machine in MB
     Type: Number

--- a/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingService.java
+++ b/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingService.java
@@ -841,7 +841,6 @@ public class OnboardingService {
 
                         Map<String, Object> tierConfig = (Map<String, Object>) tiers.get(tier);
                         String clusterInstanceType = (String) tierConfig.get("instanceType");
-                        // TODO Update App Config to capture what launch type to use
                         String launchType = (String) service.get("ecsLaunchType");
                         Integer taskMemory = (Integer) tierConfig.get("memory");
                         Integer taskCpu = (Integer) tierConfig.get("cpu");
@@ -851,15 +850,15 @@ public class OnboardingService {
                         // Does this service use a shared filesystem?
                         Boolean enableEfs = Boolean.FALSE;
                         Boolean enableFSx = Boolean.FALSE;
-                        String mountPoint = "";
+                        String mountPoint = "/mnt";
                         Boolean encryptFilesystem = Boolean.TRUE;
                         String filesystemLifecycle = "NEVER";
                         Integer fsxStorageGb = 32;
                         Integer fsxThroughputMbs = 8;
-                        Integer fsxBackupRetentionDays = 7;
-                        String fsxDailyBackupTime = "";
-                        String fsxWeeklyMaintenanceTime = "";
-                        String fsxWindowsMountDrive = "";
+                        Integer fsxBackupRetentionDays = 0;
+                        String fsxDailyBackupTime = "02:00";
+                        String fsxWeeklyMaintenanceTime = "7:01:00";
+                        String fsxWindowsMountDrive = "G:";
                         Integer ontapVolumeSize = 40;
                         String fileSystemType = "FSX_WINDOWS";
                         Map<String, Object> filesystem = (Map<String, Object>) tierConfig.get("filesystem");
@@ -868,7 +867,6 @@ public class OnboardingService {
                             mountPoint = (String) filesystem.get("mountPoint");
                             if ("EFS".equals(fileSystemType)) {
                                 enableEfs = Boolean.TRUE;
-                                // Map<String, Object> efsConfig = (Map<String, Object>) filesystem.get("efs");
                                 encryptFilesystem = (Boolean) filesystem.get("encrypt");
                                 if (encryptFilesystem == null) {
                                     encryptFilesystem = Boolean.FALSE;
@@ -879,32 +877,29 @@ public class OnboardingService {
                                 }
                             } else if ("FSX_WINDOWS".equals(fileSystemType) || "FSX_ONTAP".equals(fileSystemType)) {
                                 enableFSx = Boolean.TRUE;
-                                // Map<String, Object> fsxConfig = (Map<String, Object>) filesystem.get("fsx");
-                                fsxStorageGb = (Integer) filesystem.get("storageGb"); // GB 32 to 65,536
+                                fsxStorageGb = (Integer) filesystem.get("storageGb");
                                 if (fsxStorageGb == null) {
-                                    fsxStorageGb = 0;
+                                    fsxStorageGb = "FSX_ONTAP".equals(fileSystemType) ? 1024 : 32;
                                 }
-                                fsxThroughputMbs = (Integer) filesystem.get("throughputMbs"); // MB/s
+                                fsxThroughputMbs = (Integer) filesystem.get("throughputMbs");
                                 if (fsxThroughputMbs == null) {
-                                    fsxThroughputMbs = 0;
+                                    fsxThroughputMbs = "FSX_ONTAP".equals(fileSystemType) ? 128 : 8;
                                 }
-                                fsxBackupRetentionDays = (Integer) filesystem.get("backupRetentionDays"); // 7 to 35
+                                fsxBackupRetentionDays = (Integer) filesystem.get("backupRetentionDays");
                                 if (fsxBackupRetentionDays == null) {
-                                    fsxBackupRetentionDays = 7;
+                                    fsxBackupRetentionDays = 0; // Turn off automated backups
                                 }
-                                fsxDailyBackupTime = (String) filesystem.get("dailyBackupTime"); //HH:MM in UTC
+                                fsxDailyBackupTime = (String) filesystem.get("dailyBackupTime");
                                 if (fsxDailyBackupTime == null) {
-                                    fsxDailyBackupTime = "";
+                                    fsxDailyBackupTime = "02:00"; // 2:00 AM
                                 }
-                                fsxWeeklyMaintenanceTime = (String) filesystem.get("weeklyMaintenanceTime");//d:HH:MM in UTC
+                                fsxWeeklyMaintenanceTime = (String) filesystem.get("weeklyMaintenanceTime");
                                 if (fsxWeeklyMaintenanceTime == null) {
-                                    fsxWeeklyMaintenanceTime = "";
+                                    fsxWeeklyMaintenanceTime = "7:01:00"; // Sun 1:00 AM
                                 }
-                                if ("FSX_WINDOWS".equals(fileSystemType)) {
-                                    fsxWindowsMountDrive = (String) filesystem.get("windowsMountDrive");
-                                    if (fsxWindowsMountDrive == null) {
-                                        fsxWindowsMountDrive = "";
-                                    }
+                                fsxWindowsMountDrive = (String) filesystem.get("windowsMountDrive");
+                                if (fsxWindowsMountDrive == null) {
+                                    fsxWindowsMountDrive = "G:";
                                 }
                                 if ("FSX_ONTAP".equals(fileSystemType)) {
                                     ontapVolumeSize = (Integer) filesystem.get("volumeSize");

--- a/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingService.java
+++ b/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingService.java
@@ -860,7 +860,8 @@ public class OnboardingService {
                         String fsxDailyBackupTime = "";
                         String fsxWeeklyMaintenanceTime = "";
                         String fsxWindowsMountDrive = "";
-                        String fileSystemType = "";
+                        Integer ontapVolumeSize = 40;
+                        String fileSystemType = "FSX_WINDOWS";
                         Map<String, Object> filesystem = (Map<String, Object>) tierConfig.get("filesystem");
                         if (filesystem != null && !filesystem.isEmpty()) {
                             fileSystemType = (String) filesystem.get("type");
@@ -876,7 +877,7 @@ public class OnboardingService {
                                 if (filesystemLifecycle == null) {
                                     filesystemLifecycle = "NEVER";
                                 }
-                            } else if ("FSX_WINDOWS".equals(fileSystemType)) {
+                            } else if ("FSX_WINDOWS".equals(fileSystemType) || "FSX_ONTAP".equals(fileSystemType)) {
                                 enableFSx = Boolean.TRUE;
                                 // Map<String, Object> fsxConfig = (Map<String, Object>) filesystem.get("fsx");
                                 fsxStorageGb = (Integer) filesystem.get("storageGb"); // GB 32 to 65,536
@@ -899,10 +900,21 @@ public class OnboardingService {
                                 if (fsxWeeklyMaintenanceTime == null) {
                                     fsxWeeklyMaintenanceTime = "";
                                 }
-                                fsxWindowsMountDrive = (String) filesystem.get("windowsMountDrive");
-                                if (fsxWindowsMountDrive == null) {
-                                    fsxWindowsMountDrive = "";
+                                if ("FSX_WINDOWS".equals(fileSystemType)) {
+                                    fsxWindowsMountDrive = (String) filesystem.get("windowsMountDrive");
+                                    if (fsxWindowsMountDrive == null) {
+                                        fsxWindowsMountDrive = "";
+                                    }
                                 }
+                                if ("FSX_ONTAP".equals(fileSystemType)) {
+                                    ontapVolumeSize = (Integer) filesystem.get("volumeSize");
+                                    if (ontapVolumeSize == null) {
+                                        ontapVolumeSize = 40;
+                                    }
+                                }
+                            }
+                            if (fileSystemType == null) {
+                                fileSystemType = "FSX_WINDOWS";
                             }
                         }
 
@@ -972,6 +984,7 @@ public class OnboardingService {
                         templateParameters.add(Parameter.builder().parameterKey("FileSystemThroughput").parameterValue(fsxThroughputMbs.toString()).build());
                         templateParameters.add(Parameter.builder().parameterKey("FileSystemStorage").parameterValue(fsxStorageGb.toString()).build());
                         templateParameters.add(Parameter.builder().parameterKey("FSxWeeklyMaintenanceTime").parameterValue(fsxWeeklyMaintenanceTime).build());
+                        templateParameters.add(Parameter.builder().parameterKey("OntapVolumeSize").parameterValue(ontapVolumeSize.toString()).build());
                         templateParameters.add(Parameter.builder().parameterKey("UseRDS").parameterValue(enableDatabase.toString()).build());
                         templateParameters.add(Parameter.builder().parameterKey("RDSInstanceClass").parameterValue(dbInstanceClass).build());
                         templateParameters.add(Parameter.builder().parameterKey("RDSEngine").parameterValue(dbEngine).build());

--- a/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/filesystem/AbstractFilesystem.java
+++ b/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/filesystem/AbstractFilesystem.java
@@ -89,7 +89,7 @@ public abstract class AbstractFilesystem {
 
     @Override
     public int hashCode() {
-        return Objects.hash(mountPoint);
+        return Objects.hash(mountPoint, encrypt, encryptionKey);
     }
 
     @JsonPOJOBuilder(withPrefix = "") // setters aren't named with[Property]

--- a/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/filesystem/AbstractFilesystem.java
+++ b/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/filesystem/AbstractFilesystem.java
@@ -32,11 +32,13 @@ import java.util.Objects;
 )
 @JsonSubTypes({
     @Type(value = EfsFilesystem.class, name = AbstractFilesystem.EFS),
-    @Type(value = FsxWindowsFilesystem.class, name = AbstractFilesystem.FSXW)
+    @Type(value = FsxWindowsFilesystem.class, name = AbstractFilesystem.FSXW),
+    @Type(value = FsxOntapFilesystem.class, name = AbstractFilesystem.FSXO)
 })
 public abstract class AbstractFilesystem {
     protected static final String EFS = "EFS";
     protected static final String FSXW = "FSX_WINDOWS";
+    protected static final String FSXO = "FSX_ONTAP";
 
     private String mountPoint;
 

--- a/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/filesystem/AbstractFsxFilesystem.java
+++ b/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/filesystem/AbstractFsxFilesystem.java
@@ -34,7 +34,7 @@ public abstract class AbstractFsxFilesystem extends AbstractFilesystem {
     protected AbstractFsxFilesystem(Builder b) {
         super(b);
         if (b.storageGb == null) {
-            throw new IllegalArgumentException("Cannot specify an FSX filesystem without storageGb.");
+            throw new IllegalArgumentException("Cannot specify an FSx filesystem without storageGb.");
         }
         this.storageGb = b.storageGb;
         this.windowsMountDrive = b.windowsMountDrive;
@@ -132,8 +132,8 @@ public abstract class AbstractFsxFilesystem extends AbstractFilesystem {
             return this;
         }
 
-        public Builder throughputCapacity(Integer throughputCapacity) {
-            this.throughputMbs = throughputCapacity;
+        public Builder throughputMbs(Integer throughputMbs) {
+            this.throughputMbs = throughputMbs;
             return this;
         }
     }

--- a/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/filesystem/FsxOntapFilesystem.java
+++ b/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/filesystem/FsxOntapFilesystem.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.amazon.aws.partners.saasfactory.saasboost.appconfig.filesystem;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+@JsonDeserialize(builder = FsxOntapFilesystem.Builder.class)
+public class FsxOntapFilesystem extends AbstractFsxFilesystem {
+
+    private Integer volumeSize;
+
+    private FsxOntapFilesystem(Builder b) {
+        super(b);
+        this.volumeSize = b.volumeSize;
+    }
+
+    public Integer getVolumeSize() {
+        return volumeSize;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        // Same reference?
+        if (this == obj) {
+            return true;
+        }
+        // Same type?
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final FsxOntapFilesystem other = (FsxOntapFilesystem) obj;
+        return super.equals(other);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    @JsonPOJOBuilder(withPrefix = "") // setters aren't named with[Property]
+    public static final class Builder extends AbstractFsxFilesystem.Builder {
+
+        private Integer volumeSize;
+
+        private Builder() {
+        }
+
+        public Builder volumeSize(Integer volumeSize) {
+            this.volumeSize = volumeSize;
+            return this;
+        }
+
+        public FsxOntapFilesystem build() {
+            return new FsxOntapFilesystem(this);
+        }
+    }
+}

--- a/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/filesystem/FsxOntapFilesystem.java
+++ b/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/filesystem/FsxOntapFilesystem.java
@@ -19,6 +19,8 @@ package com.amazon.aws.partners.saasfactory.saasboost.appconfig.filesystem;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
+import java.util.Objects;
+
 @JsonDeserialize(builder = FsxOntapFilesystem.Builder.class)
 public class FsxOntapFilesystem extends AbstractFsxFilesystem {
 
@@ -52,7 +54,7 @@ public class FsxOntapFilesystem extends AbstractFsxFilesystem {
 
     @Override
     public int hashCode() {
-        return super.hashCode();
+        return Objects.hash(super.hashCode(), volumeSize);
     }
 
     @JsonPOJOBuilder(withPrefix = "") // setters aren't named with[Property]


### PR DESCRIPTION
This commit also fixes a bug where an application configuration created
with no filesystem will fail to onboard tenants.

Co-authored-by: netapp-vedantsethia <Vedant.Sethia@netapp.com>
Co-authored-by: netapp-dhruv-tyagi <Dhruv.Tyagi@netapp.com>


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
