### PR TITLE
Add UI support for selecting FSX Ontap for Windows Applications.

### DIFF
--- a/client/web/src/settings/ApplicationComponent.js
+++ b/client/web/src/settings/ApplicationComponent.js
@@ -73,7 +73,7 @@ export function ApplicationComponent(props) {
     let filesystem = {
       ...FILESYSTEM_DEFAULTS,
       ...defaultValues.filesystem,
-      ...tierValues.filesystem
+      ...splitWeeklyMaintenanceTime(tierValues.filesystem)
     }
     let defaults = Object.assign({
       min: 0,
@@ -92,7 +92,7 @@ export function ApplicationComponent(props) {
       provisionDb: !!tierValues.database,
       provisionFS: !!tierValues.filesystem,
       filesystemType: filesystemType,
-      filesystem: splitWeeklyMaintenanceTime(uncleanedInitialTierValues.filesystem),
+      filesystem: filesystem,
     }
   }
 

--- a/client/web/src/settings/ApplicationComponent.js
+++ b/client/web/src/settings/ApplicationComponent.js
@@ -26,7 +26,7 @@ import globalConfig from '../config/appConfig'
 import AppSettingsSubform from './AppSettingsSubform'
 import BillingSubform from './BillingSubform'
 import ServicesComponent from './ServicesComponent'
-import { FILESYSTEM_DEFAULTS, FILESYSTEM_TYPES } from './components/filesystem'
+import { FILESYSTEM_DEFAULTS, FILESYSTEM_TYPES, OS_TO_FS_TYPES } from './components/filesystem'
 
 import { dismissConfigError, dismissConfigMessage } from './ducks'
 
@@ -69,7 +69,7 @@ export function ApplicationComponent(props) {
     window.scrollTo(0, 0)
   }
 
-  const generateAppConfigOrDefaultInitialValuesForTier = (tierValues, defaultValues) => {
+  const generateAppConfigOrDefaultInitialValuesForTier = (tierValues, defaultValues, os) => {
     let filesystem = {
       ...FILESYSTEM_DEFAULTS,
       ...defaultValues.filesystem,
@@ -84,11 +84,14 @@ export function ApplicationComponent(props) {
       ...defaults,
       filesystem: filesystem,
     }
+
+    let filesystemType = OS_TO_FS_TYPES[os]?.filter(type => type.configId === tierValues.filesystem?.type)[0]?.id || ''
+
     return {
       ...uncleanedInitialTierValues,
       provisionDb: !!tierValues.database,
       provisionFS: !!tierValues.filesystem,
-      filesystemType: tierValues.filesystem?.type || '',
+      filesystemType: filesystemType,
       filesystem: splitWeeklyMaintenanceTime(uncleanedInitialTierValues.filesystem),
     }
   }
@@ -144,11 +147,11 @@ export function ApplicationComponent(props) {
           }
     const windowsVersion = os === WINDOWS ? thisService.operatingSystem : ''
     let defaultTierName = tiers.filter(t => t.defaultTier)[0].name
-    let defaultTierValues = generateAppConfigOrDefaultInitialValuesForTier(Object.assign({}, thisService?.tiers[defaultTierName]), {})
+    let defaultTierValues = generateAppConfigOrDefaultInitialValuesForTier(Object.assign({}, thisService?.tiers[defaultTierName]), {}, os)
     let initialTierValues = {}
     for (var i = 0; i < tiers.length; i++) {
       var tierName = tiers[i].name
-      initialTierValues[tierName] = generateAppConfigOrDefaultInitialValuesForTier(Object.assign({}, thisService?.tiers[tierName]), defaultTierValues)
+      initialTierValues[tierName] = generateAppConfigOrDefaultInitialValuesForTier(Object.assign({}, thisService?.tiers[tierName]), defaultTierValues, os)
     }
     return {
       ...thisService,

--- a/client/web/src/settings/ApplicationContainer.js
+++ b/client/web/src/settings/ApplicationContainer.js
@@ -162,11 +162,11 @@ export function ApplicationContainer(props) {
         weeklyMaintenanceTime,
         ...cleanedFs
       } = filesystem
-      cleanedFs.type = filesystemType
+      cleanedFs.type = FILESYSTEM_TYPES[filesystemType].configId
       if (weeklyMaintenanceDay && weeklyMaintenanceTime) {
         cleanedFs.weeklyMaintenanceTime = `${weeklyMaintenanceDay}:${getFormattedTime(weeklyMaintenanceTime)}`
       }
-      let wantedKeys = Object.keys(FILESYSTEM_TYPES[cleanedFs.type].defaults)
+      let wantedKeys = Object.keys(FILESYSTEM_TYPES[filesystemType].defaults)
       Object.keys(cleanedFs).forEach(k => {
         if (!wantedKeys.includes(k) && k !== 'type') {
           delete cleanedFs[k]

--- a/client/web/src/settings/ApplicationContainer.js
+++ b/client/web/src/settings/ApplicationContainer.js
@@ -146,15 +146,6 @@ export function ApplicationContainer(props) {
     updateConfiguration(formValues)
   }
 
-  const getFormattedTime = (timeString) => {
-    // Expecting timeString to be HH:MM:SS
-    let parts = timeString.split(':')
-    if (parts.length === 3) {
-      parts = parts.splice(0, 2) //Trim the trailing :00. Server doesn't need seconds
-    }
-    return parts.join(':')
-  }
-
   const cleanFilesystemForSubmittal = (provisionFS, filesystemType, filesystem) => {
     if (provisionFS) {
       let {
@@ -164,7 +155,7 @@ export function ApplicationContainer(props) {
       } = filesystem
       cleanedFs.type = FILESYSTEM_TYPES[filesystemType].configId
       if (weeklyMaintenanceDay && weeklyMaintenanceTime) {
-        cleanedFs.weeklyMaintenanceTime = `${weeklyMaintenanceDay}:${getFormattedTime(weeklyMaintenanceTime)}`
+        cleanedFs.weeklyMaintenanceTime = `${weeklyMaintenanceDay}:${weeklyMaintenanceTime}`
       }
       let wantedKeys = Object.keys(FILESYSTEM_TYPES[filesystemType].defaults)
       Object.keys(cleanedFs).forEach(k => {

--- a/client/web/src/settings/TierServiceSettingsSubform.js
+++ b/client/web/src/settings/TierServiceSettingsSubform.js
@@ -38,22 +38,24 @@ const TierServiceSettingsSubform = (props) => {
 
   const formikTierPrefix = formikServicePrefix + '.tiers[' + selectedTier + ']'
 
-  // set compute size if default exists and this tier doesn't
-  if (!!!serviceValues?.tiers[selectedTier]?.computeSize && !!serviceValues?.tiers[defaultTier]?.computeSize) {
-    // set instance to default if it doesn't exist already
-    setFieldValue(formikTierPrefix + '.computeSize', serviceValues?.tiers[defaultTier]?.computeSize)
-  }
+  if (!!serviceValues?.tiers) {
+    // set compute size if default exists and this tier doesn't
+    if (!!!serviceValues?.tiers[selectedTier]?.computeSize && !!serviceValues?.tiers[defaultTier]?.computeSize) {
+      // set instance to default if it doesn't exist already
+      setFieldValue(formikTierPrefix + '.computeSize', serviceValues?.tiers[defaultTier]?.computeSize)
+    }
 
-  // set min if default exists and this tier doesn't
-  if (!!!serviceValues?.tiers[selectedTier]?.min && !!serviceValues?.tiers[defaultTier]?.min) {
-    // set instance to default if it doesn't exist already
-    setFieldValue(formikTierPrefix + '.min', serviceValues?.tiers[defaultTier]?.min)
-  }
+    // set min if default exists and this tier doesn't
+    if (!!!serviceValues?.tiers[selectedTier]?.min && !!serviceValues?.tiers[defaultTier]?.min) {
+      // set instance to default if it doesn't exist already
+      setFieldValue(formikTierPrefix + '.min', serviceValues?.tiers[defaultTier]?.min)
+    }
 
-  // set max if default exists and this tier doesn't
-  if (!!!serviceValues?.tiers[selectedTier]?.max && !!serviceValues?.tiers[defaultTier]?.max) {
-    // set instance to default if it doesn't exist already
-    setFieldValue(formikTierPrefix + '.max', serviceValues?.tiers[defaultTier]?.max)
+    // set max if default exists and this tier doesn't
+    if (!!!serviceValues?.tiers[selectedTier]?.max && !!serviceValues?.tiers[defaultTier]?.max) {
+      // set instance to default if it doesn't exist already
+      setFieldValue(formikTierPrefix + '.max', serviceValues?.tiers[defaultTier]?.max)
+    }
   }
 
   return (
@@ -108,6 +110,7 @@ const TierServiceSettingsSubform = (props) => {
                         label="Minimum Instance Count"
                         name={formikTierPrefix + '.min'}
                         type="number"
+                        min="0"
                       />
                     </Col>
                     <Col>
@@ -116,6 +119,7 @@ const TierServiceSettingsSubform = (props) => {
                         label="Maximum Instance Count"
                         name={formikTierPrefix + '.max'}
                         type="number"
+                        min="0"
                       />
                     </Col>
                   </Row>
@@ -131,6 +135,7 @@ const TierServiceSettingsSubform = (props) => {
                       serviceValues?.tiers[selectedTier]?.provisionFS
                     }
                     containerOs={serviceValues?.operatingSystem}
+                    containerLaunchType={serviceValues?.ecsLaunchType}
                     filesystemType={serviceValues?.tiers[selectedTier]?.filesystemType}
                     setFieldValue={props.setFieldValue}
                   ></FileSystemSubform>

--- a/client/web/src/settings/components/filesystem/FileSystemSubform.js
+++ b/client/web/src/settings/components/filesystem/FileSystemSubform.js
@@ -71,9 +71,17 @@ const FilesystemType = (props) => {
     </FormGroup>)
 }
 
+class EmptyComponent extends React.Component {
+  render() {
+    return null
+  }
+}
+
 export default class FileSystemSubform extends React.Component {
   render() {
-    var FsComponent = !!this.props.filesystemType ? FILESYSTEM_TYPES[this.props.filesystemType].component : null
+    var FsComponent = (!!this.props.filesystemType && FILESYSTEM_TYPES[this.props.filesystemType]) 
+        ? FILESYSTEM_TYPES[this.props.filesystemType].component 
+        : EmptyComponent
     return (
       <Fragment>
         <Row className="mt-3">

--- a/client/web/src/settings/components/filesystem/FileSystemSubform.js
+++ b/client/web/src/settings/components/filesystem/FileSystemSubform.js
@@ -61,7 +61,7 @@ const FilesystemType = (props) => {
           id={"fs-" + fs.id + "-" + props.formikTierPrefix}
           name={props.formikTierPrefix + ".filesystemType"}
           value={fs.id}
-          disabled={props.isLocked}
+          disabled={!fs.enabled(props.containerOs, props.containerLaunchType)}
         />
         <Label className="form-check-label" check htmlFor={"fs-" + fs.id + "-" + props.formikTierPrefix}>
           <CIcon icon={fs.icon} /> {fs.name}
@@ -80,7 +80,7 @@ class EmptyComponent extends React.Component {
 export default class FileSystemSubform extends React.Component {
   render() {
     var FsComponent = (!!this.props.filesystemType && FILESYSTEM_TYPES[this.props.filesystemType]) 
-        ? FILESYSTEM_TYPES[this.props.filesystemType].component 
+        ? FILESYSTEM_TYPES[this.props.filesystemType].component
         : EmptyComponent
     return (
       <Fragment>
@@ -94,7 +94,9 @@ export default class FileSystemSubform extends React.Component {
                   name={this.props.formikTierPrefix + '.provisionFS'}
                   label="Provision a File System for the application."
                 />
-                <FilesystemType {...this.props}></FilesystemType>
+                {this.props.provisionFs && (
+                  <FilesystemType {...this.props}></FilesystemType>
+                )}
                 {this.props.provisionFs && this.props.filesystemType && (
                   <FsComponent {...this.props}></FsComponent>
                 )}
@@ -111,6 +113,7 @@ FileSystemSubform.propTypes = {
   provisionFs: PropTypes.bool,
   filesystemType: PropTypes.string,
   containerOs: PropTypes.string,
+  containerLaunchType: PropTypes.string,
   isLocked: PropTypes.bool,
   filesystem: PropTypes.object,
   formik: PropTypes.object,

--- a/client/web/src/settings/components/filesystem/FsxOntapFilesystemOptions.js
+++ b/client/web/src/settings/components/filesystem/FsxOntapFilesystemOptions.js
@@ -230,6 +230,7 @@ export default class FsxOntapFilesystemOptions extends React.Component {
                   </Row>
                   <Row>
                     <Col xs={6}>
+                      {this.props.containerOs === "WINDOWS" && (
                       <SaasBoostSelect
                         id={
                           props.formikTierPrefix + '.filesystem.windowsMountDrive'
@@ -260,6 +261,7 @@ export default class FsxOntapFilesystemOptions extends React.Component {
                         <option value="Y:">Y:</option>
                         <option value="Z:">Z:</option>
                       </SaasBoostSelect>
+                      )}
                     </Col>
                     <Col xs={6}>
                       <SaasBoostInput

--- a/client/web/src/settings/components/filesystem/FsxOntapFilesystemOptions.js
+++ b/client/web/src/settings/components/filesystem/FsxOntapFilesystemOptions.js
@@ -1,0 +1,290 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react'
+import { PropTypes } from 'prop-types'
+import {
+    Row,
+    Col,
+    Input,
+    InputGroup,
+    FormGroup,
+    Label, } from 'reactstrap'
+import {
+    SaasBoostSelect,
+    SaasBoostInput,
+} from '../../../components/FormComponents'
+import Slider from 'rc-slider'
+
+export default class FsxOntapFilesystemOptions extends React.Component {
+    render() {
+        let props = this.props
+        const fsMarks = {
+            1: '1',
+            192: '192',
+          }
+
+          const tpMarks = {
+            7: '128',
+            11: '2048',
+          }
+
+          const volMarks = {
+            1: '1',
+            100: '100',
+          }
+
+          const onStorageChange = (val) => {
+            props.setFieldValue(
+              props.formikTierPrefix + '.filesystem.storageGb',
+              val * 1024
+            )
+          }
+
+          const onThroughputChange = (val) => {
+            props.setFieldValue(
+              props.formikTierPrefix + '.filesystem.throughputMbs',
+              Math.pow(2, val)
+            )
+          }
+
+          const onVolumeChange = (val) => {
+            props.setFieldValue(
+              props.formikTierPrefix + '.filesystem.volumeSize',
+              val
+            )
+          }
+
+          const onWeeklyMaintTimeChange = (val) => {
+            props.setFieldValue(
+              props.formikTierPrefix + '.filesystem.weeklyMaintenanceTime',
+              val.target.value
+            )
+          }
+
+          const onWeeklyDayChange = (val) => {
+            props.setFieldValue(
+              props.formikTierPrefix + '.filesystem.weeklyMaintenanceDay',
+              val.target.value
+            )
+          }
+
+          return (
+              <Row>
+                <Col sm={6} className="mt-2">
+                  <SaasBoostInput
+                    key={props.formikTierPrefix + '.filesystem.mountPoint'}
+                    label="Mount point"
+                    name={props.formikTierPrefix + '.filesystem.mountPoint'}
+                    type="text"
+                    disabled={props.isLocked}
+                  />
+                  <Row>
+                    <Col xs={3}>
+                      <FormGroup>
+                        <Label htmlFor="storageVal">Storage</Label>
+                        <Input
+                          id={'storageVal' + props.formikTierPrefix}
+                          className="mb-4"
+                          type="number"
+                          value={props.filesystem?.storageGb / 1024}
+                          readOnly
+                        ></Input>
+                      </FormGroup>
+                    </Col>
+                    <Col xs={9}>
+                      <FormGroup>
+                        <Label htmlFor="storage">In TiB</Label>
+                        <Slider
+                          id={'storage' + props.formikTierPrefix}
+                          defaultValue={props.filesystem?.storageGb / 1024}
+                          onChange={onStorageChange}
+                          className="mb-4"
+                          marks={fsMarks}
+                          included={false}
+                          min={1}
+                          max={192}
+                          step={1}
+                        />
+                      </FormGroup>
+                    </Col>
+                  </Row>
+                  <Row>
+                    <Col xs={3}>
+                      <FormGroup>
+                        <Label htmlFor="throughputVal">Throughput</Label>
+                        <Input
+                          id={'throughputVal' + props.formikTierPrefix}
+                          className="mb-4"
+                          type="number"
+                          value={props.filesystem?.throughputMbs}
+                          readOnly
+                        ></Input>
+                      </FormGroup>
+                    </Col>
+                    <Col xs={9}>
+                      <FormGroup>
+                        <Label htmlFor="throughput">In MB/s</Label>
+                        <Slider
+                          id={'throughput' + props.formikTierPrefix}
+                          defaultValue={Math.log2(props.filesystem?.throughputMbs)}
+                          onChange={onThroughputChange}
+                          marks={tpMarks}
+                          className="mb-4"
+                          included={false}
+                          min={7}
+                          max={11}
+                          step={1}
+                        />
+                      </FormGroup>
+                    </Col>
+                  </Row>
+                  <Row>
+                    <Col xs={3}>
+                      <FormGroup>
+                        <Label htmlFor="volumeVal">Volume</Label>
+                        <Input
+                          id={'volumeVal' + props.formikTierPrefix}
+                          className="mb-4"
+                          type="number"
+                          value={props.filesystem?.volumeSize}
+                          readOnly
+                        ></Input>
+                      </FormGroup>
+                    </Col>
+                    <Col xs={9}>
+                      <FormGroup>
+                        <Label htmlFor="volume">In GiB</Label>
+                        <Slider
+                          id={'volume' + props.formikTierPrefix}
+                          defaultValue={props.filesystem?.volumeSize}
+                          onChange={onVolumeChange}
+                          className="mb-4"
+                          marks={volMarks}
+                          included={false}
+                          min={1}
+                          max={100}
+                          step={1}
+                        />
+                      </FormGroup>
+                    </Col>
+                  </Row>
+                </Col>
+                <Col sm={6} className="mt-2">
+                  <Row>
+                    <Col xs={6}>
+                      <SaasBoostInput
+                        key={props.formikTierPrefix + '.filesystem.dailyBackupTime'}
+                        label="Daily Backup Time (UTC)"
+                        name={
+                          props.formikTierPrefix + '.filesystem.dailyBackupTime'
+                        }
+                        type="time"
+                        disabled={props.isLocked}
+                      />
+                    </Col>
+                    <Col xs={6}>
+                      <Label>Weekly Maintenance Day/Time (UTC)</Label>
+                      <InputGroup className="mb-3">
+                        <Input
+                          type="select"
+                          onChange={onWeeklyDayChange}
+                          value={props.filesystem?.weeklyMaintenanceDay}
+                        >
+                          <option value="1">Sun</option>
+                          <option value="2">Mon</option>
+                          <option value="3">Tue</option>
+                          <option value="4">Wed</option>
+                          <option value="5">Thu</option>
+                          <option value="6">Fri</option>
+                          <option value="7">Sat</option>
+                        </Input>
+                        <Input
+                          key={
+                            props.formikTierPrefix +
+                            '.filesystem.weeklyMaintenanceTime'
+                          }
+                          onChange={onWeeklyMaintTimeChange}
+                          value={props.filesystem?.weeklyMaintenanceTime}
+                          name={
+                            props.formikTierPrefix +
+                            '.filesystem.weeklyMaintenanceTime'
+                          }
+                          type="time"
+                          disabled={props.isLocked}
+                        />
+                      </InputGroup>
+                    </Col>
+                  </Row>
+                  <Row>
+                    <Col xs={6}>
+                      <SaasBoostSelect
+                        id={
+                          props.formikTierPrefix + '.filesystem.windowsMountDrive'
+                        }
+                        label="Drive Letter Assignment"
+                        name={
+                          props.formikTierPrefix + '.filesystem.windowsMountDrive'
+                        }
+                        value={props.filesystem?.windowsMountDrive}
+                      >
+                        <option value="G:">G:</option>
+                        <option value="H:">H:</option>
+                        <option value="I:">I:</option>
+                        <option value="J:">J:</option>
+                        <option value="K:">K:</option>
+                        <option value="L:">L:</option>
+                        <option value="M:">M:</option>
+                        <option value="N:">N:</option>
+                        <option value="O:">O:</option>
+                        <option value="P:">P:</option>
+                        <option value="Q:">Q:</option>
+                        <option value="R:">R:</option>
+                        <option value="S:">S:</option>
+                        <option value="T:">T:</option>
+                        <option value="U:">U:</option>
+                        <option value="V:">V:</option>
+                        <option value="X:">X:</option>
+                        <option value="Y:">Y:</option>
+                        <option value="Z:">Z:</option>
+                      </SaasBoostSelect>
+                    </Col>
+                    <Col xs={6}>
+                      <SaasBoostInput
+                        key={
+                          props.formikTierPrefix + '.filesystem.backupRetentionDays'
+                        }
+                        label="Backup Retention (Days)"
+                        name={
+                          props.formikTierPrefix + '.filesystem.backupRetentionDays'
+                        }
+                        type="number"
+                        disabled={props.isLocked}
+                      />
+                    </Col>
+                  </Row>
+                </Col>
+              </Row>
+            )
+    }
+  }
+
+FsxOntapFilesystemOptions.propTypes = {
+    setFieldValue: PropTypes.func,
+    provisionFs: PropTypes.bool,
+    containerOs: PropTypes.string,
+    isLocked: PropTypes.bool,
+    filesystem: PropTypes.object,
+}

--- a/client/web/src/settings/components/filesystem/index.js
+++ b/client/web/src/settings/components/filesystem/index.js
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import { cibWindows, cibAmazonAws } from '@coreui/icons'
+import { cibWindows, cibAmazonAws, cilViewQuilt } from '@coreui/icons'
 import EfsFilesystemOptions from './EfsFilesystemOptions'
+import FsxOntapFilesystemOptions from './FsxOntapFilesystemOptions'
 import FsxWindowsFilesystemOptions from './FsxWindowsFilesystemOptions'
 import * as Yup from 'yup'
 
@@ -85,6 +86,53 @@ export const FILESYSTEM_TYPES = {
             windowsMountDrive: Yup.string()
                 .required('Windows mount drive is required'),
         })
+    },
+    "FSX_ONTAP": {
+        "id": "FSX_ONTAP",
+        "name": "FSX Ontap",
+        "icon": cilViewQuilt,
+        "component": FsxOntapFilesystemOptions,
+        "defaults": {
+            mountPoint: '',
+            storageGb: 1024,
+            throughputMbs: 128,
+            backupRetentionDays: 7,
+            dailyBackupTime: '01:00',
+            weeklyMaintenanceTime: '07:01:00',
+            weeklyMaintenanceDay: '1',
+            windowsMountDrive: 'G:',
+            volumeSize: 40
+        },
+        "validationSchema": Yup.object({
+            mountPoint: Yup.string()
+                .matches(
+                    /^[a-zA-Z]:\\(((?![<>:"/\\|?*]).)+((?<![ .])\\)?)*$/,
+                    'Invalid path. Ex: C:\\data'
+                )
+                .required(),
+            storageGb: Yup.number()
+                .required()
+                .min(1024, 'Storage minimum is 1024 GB')
+                .max(196608, 'Storage maximum is 196,608 GB'),
+            throughputMbs: Yup.number()
+                .required()
+                .min(128, 'Throughput minimum is 128 MB/s')
+                .max(2048, 'Throughput maximum is 2048 MB/s'),
+            backupRetentionDays: Yup.number()
+                .required()
+                .min(7, 'Minimum retention time is 7 days')
+                .max(35, 'Maximum retention time is 35 days'),
+            dailyBackupTime: Yup.string()
+                .required('Daily backup time is required'),
+            weeklyMaintenanceTime: Yup.string()
+                .required('Weekly maintenance time is required'),
+            windowsMountDrive: Yup.string()
+                .required('Windows mount drive is required'),
+            volumeSize: Yup.number()
+                .required()
+                .min(0, 'Volume Size must be a positive number')
+                .max(196608, 'Volume size maximum is 196.608 GB')
+        })
     }
 }
 
@@ -99,6 +147,7 @@ export const OS_TO_FS_TYPES = {
         FILESYSTEM_TYPES.EFS
     ],
     "WINDOWS": [
-        FILESYSTEM_TYPES.FSX_WINDOWS
+        FILESYSTEM_TYPES.FSX_WINDOWS,
+        FILESYSTEM_TYPES.FSX_ONTAP,
     ]
 }

--- a/client/web/src/settings/components/filesystem/index.js
+++ b/client/web/src/settings/components/filesystem/index.js
@@ -58,7 +58,7 @@ export const FILESYSTEM_TYPES = {
             throughputMbs: 8,
             backupRetentionDays: 7,
             dailyBackupTime: '01:00',
-            weeklyMaintenanceTime: '07:01:00',
+            weeklyMaintenanceTime: '07:01',
             weeklyMaintenanceDay: '1',
             windowsMountDrive: 'G:',
         },
@@ -102,7 +102,7 @@ export const FILESYSTEM_TYPES = {
             throughputMbs: 128,
             backupRetentionDays: 7,
             dailyBackupTime: '01:00',
-            weeklyMaintenanceTime: '07:01:00',
+            weeklyMaintenanceTime: '07:01',
             weeklyMaintenanceDay: '1',
             volumeSize: 40
         },
@@ -153,7 +153,7 @@ export const FILESYSTEM_TYPES = {
             throughputMbs: 128,
             backupRetentionDays: 7,
             dailyBackupTime: '01:00',
-            weeklyMaintenanceTime: '07:01:00',
+            weeklyMaintenanceTime: '07:01',
             weeklyMaintenanceDay: '1',
             windowsMountDrive: 'G:',
             volumeSize: 40

--- a/client/web/src/settings/components/filesystem/index.js
+++ b/client/web/src/settings/components/filesystem/index.js
@@ -26,6 +26,7 @@ export const FILESYSTEM_TYPES = {
         "name": "EFS",
         "icon": cibAmazonAws,
         "component": EfsFilesystemOptions,
+        "enabled": (os, launchType) => os === "LINUX",
         "defaults": {
             mountPoint: '',
             lifecycle: 'NEVER',
@@ -50,6 +51,7 @@ export const FILESYSTEM_TYPES = {
         "name": "FSX Windows",
         "icon": cibWindows,
         "component": FsxWindowsFilesystemOptions,
+        "enabled": (os, launchType) => os === "WINDOWS",
         "defaults": {
             mountPoint: '',
             storageGb: 32,
@@ -87,11 +89,64 @@ export const FILESYSTEM_TYPES = {
                 .required('Windows mount drive is required'),
         })
     },
-    "FSX_ONTAP": {
-        "id": "FSX_ONTAP",
+    "FSX_ONTAP_LINUX": {
+        "configId": "FSX_ONTAP",
+        "id": "FSX_ONTAP_LINUX",
         "name": "FSX Ontap",
         "icon": cilViewQuilt,
         "component": FsxOntapFilesystemOptions,
+        "enabled": (os, launchType) => os === "LINUX" && launchType === "EC2",
+        "defaults": {
+            mountPoint: '',
+            storageGb: 1024,
+            throughputMbs: 128,
+            backupRetentionDays: 7,
+            dailyBackupTime: '01:00',
+            weeklyMaintenanceTime: '07:01:00',
+            weeklyMaintenanceDay: '1',
+            volumeSize: 40
+        },
+        "validationSchema": Yup.object({
+            mountPoint: Yup.string()
+                .matches(/^(\/[a-zA-Z._-]+)*$/, 'Invalid path. Ex: /mnt')
+                .max(100, "The full path can't exceed 100 characters in length")
+                .test(
+                    'subdirectories',
+                    'The path can only include up to four subdirectories',
+                    (val) => (val?.match(/\//g) || []).length <= 4
+                )
+                .required(),
+            storageGb: Yup.number()
+                .required()
+                .min(1024, 'Storage minimum is 1024 GB')
+                .max(196608, 'Storage maximum is 196,608 GB'),
+            throughputMbs: Yup.number()
+                .required()
+                .min(128, 'Throughput minimum is 128 MB/s')
+                .max(2048, 'Throughput maximum is 2048 MB/s'),
+            backupRetentionDays: Yup.number()
+                .required()
+                .min(7, 'Minimum retention time is 7 days')
+                .max(35, 'Maximum retention time is 35 days'),
+            dailyBackupTime: Yup.string()
+                .required('Daily backup time is required'),
+            weeklyMaintenanceTime: Yup.string()
+                .required('Weekly maintenance time is required'),
+            windowsMountDrive: Yup.string()
+                .required('Windows mount drive is required'),
+            volumeSize: Yup.number()
+                .required()
+                .min(0, 'Volume Size must be a positive number')
+                .max(196608, 'Volume size maximum is 196,608 GB')
+        })
+    },
+    "FSX_ONTAP_WINDOWS": {
+        "configId": "FSX_ONTAP",
+        "id": "FSX_ONTAP_WINDOWS",
+        "name": "FSX Ontap",
+        "icon": cilViewQuilt,
+        "component": FsxOntapFilesystemOptions,
+        "enabled": (os, launchType) => os === "WINDOWS",
         "defaults": {
             mountPoint: '',
             storageGb: 1024,
@@ -131,7 +186,7 @@ export const FILESYSTEM_TYPES = {
             volumeSize: Yup.number()
                 .required()
                 .min(0, 'Volume Size must be a positive number')
-                .max(196608, 'Volume size maximum is 196.608 GB')
+                .max(196608, 'Volume size maximum is 196,608 GB')
         })
     }
 }
@@ -144,10 +199,11 @@ export const FILESYSTEM_DEFAULTS = Object.assign(Object.keys(FILESYSTEM_TYPES)
 
 export const OS_TO_FS_TYPES = {
     "LINUX": [
-        FILESYSTEM_TYPES.EFS
+        FILESYSTEM_TYPES.EFS,
+        FILESYSTEM_TYPES.FSX_ONTAP_LINUX,
     ],
     "WINDOWS": [
         FILESYSTEM_TYPES.FSX_WINDOWS,
-        FILESYSTEM_TYPES.FSX_ONTAP,
+        FILESYSTEM_TYPES.FSX_ONTAP_WINDOWS,
     ]
 }

--- a/client/web/update_local_env.sh
+++ b/client/web/update_local_env.sh
@@ -13,6 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# set -o xtrace
 myEnv="$1"
 if [ "z$myEnv" == "z" ]; then
     read -p "What environment? " myEnv
@@ -32,7 +34,8 @@ echo "REACT_APP_COGNITO_USERPOOL=$userPoolId" >> .env
 poolClientId=$(aws cognito-idp list-user-pool-clients --user-pool-id ${userPoolId} | jq '.UserPoolClients[0].ClientId' | cut -d\" -f2)
 echo "REACT_APP_CLIENT_ID=$poolClientId" >> .env
 
-publicApiGId=$(aws apigateway get-rest-apis | jq '.items[] | select (.name == "sb-test-public-api").id' | cut -d\" -f2)
+publicApiName="sb-${myEnv}-public-api"
+publicApiGId=$(aws apigateway get-rest-apis | jq --arg publicApiName "$publicApiName" '.items[] | select (.name == $publicApiName).id' | cut -d\" -f2)
 echo "REACT_APP_API_URI=https://${publicApiGId}.execute-api.${myRegion}.amazonaws.com/v1" >> .env
 
 cat .env


### PR DESCRIPTION
This commit also fixes a bug with the update_local_env.sh utility
script.

Co-authored-by: netapp-vedantsethia <Vedant.Sethia@netapp.com>
Co-authored-by: netapp-dhruv-tyagi <Dhruv.Tyagi@netapp.com>


----

![Screen Shot 2022-07-29 at 11 14 35](https://user-images.githubusercontent.com/4009272/181819953-17ab01f0-a4c3-4d13-a3ff-14dac9c2b91b.png)



*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
