### PR TITLE
Default ecsLaunchType to EC2 for Windows based services

### DIFF
--- a/client/web/src/settings/ApplicationContainer.js
+++ b/client/web/src/settings/ApplicationContainer.js
@@ -209,6 +209,7 @@ export function ApplicationContainer(props) {
           name,
           windowsVersion,
           operatingSystem,
+          ecsLaunchType,
           provisionDb,
           tombstone,
           database,
@@ -235,6 +236,7 @@ export function ApplicationContainer(props) {
           ...rest,
           name,
           operatingSystem: operatingSystem === LINUX ? LINUX : windowsVersion,
+          ecsLaunchType: (!!ecsLaunchType) ? ecsLaunchType : (operatingSystem === LINUX ? "FARGATE" : "EC2"),
           database: provisionDb ? cleanedDb : null,
           tiers: cleanedTiersMap,
         }


### PR DESCRIPTION
If the `ecsLaunchType` for a service is not defined, set it to `FARGATE` when the container operating system is Linux and `EC2` when Windows

Resolves #269 

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
