### PR TITLE
Prevent CloudFormation parameter errors when using EFS

### DIFF
--- a/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingService.java
+++ b/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingService.java
@@ -908,7 +908,7 @@ public class OnboardingService {
                                     }
                                 }
                             }
-                            if (fileSystemType == null) {
+                            if (enableEfs || fileSystemType == null) {
                                 fileSystemType = "FSX_WINDOWS";
                             }
                         }


### PR DESCRIPTION
The CloudFormation template parameters for FSx file systems limit the FSx type to either Windows File Server or NetApp ONTAP. When we onboard a service with EFS instead of FSx, the file system type is passed through to CloudFormation and fails the parameter required values check.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
