### PR TITLE
Allow dash in SaaS Boost environment name

### DIFF
--- a/resources/saas-boost-svc-onboarding.yaml
+++ b/resources/saas-boost-svc-onboarding.yaml
@@ -382,6 +382,9 @@ Resources:
               - codepipeline:GetPipeline
               - codepipeline:GetPipelineState
               - codepipeline:UpdatePipeline
+              - codepipeline:TagResource
+              - codepipeline:UntagResource
+              - codepipeline:ListTagsForResource
             Resource:
               - !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:sb-${Environment}-tenant*
           - Effect: Allow

--- a/services/metrics-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/MetricServiceDAL.java
+++ b/services/metrics-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/MetricServiceDAL.java
@@ -355,9 +355,9 @@ public class MetricServiceDAL {
             String query = new StringBuilder().append("SELECT\n")
                     .append("concat(url_extract_path(request_url), '+', request_verb) AS url")
                     .append(metricCol)
-                    .append("FROM ")
+                    .append("FROM \"")
                     .append(ACCESS_LOGS_TABLE)
-                    .append("\n")
+                    .append("\"\n")
                     .append(where)
                     .append("GROUP BY concat(url_extract_path(request_url), '+', request_verb)\n")
                     .append("ORDER BY 2 DESC\n")
@@ -674,7 +674,7 @@ public class MetricServiceDAL {
                 .format(today); //"2019/08/01";
         String dateTimeFormat =  DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneId.systemDefault())
                 .format(today); //"2019-08-01";
-        String queryString = "ALTER TABLE " + ACCESS_LOGS_TABLE + " ADD IF NOT EXISTS PARTITION "
+        String queryString = "ALTER TABLE \"" + ACCESS_LOGS_TABLE + "\" ADD IF NOT EXISTS PARTITION "
                 + "(time='" + dateTimeFormat + "') LOCATION '" + ACCESS_LOGS_PATH + "/" + formatPartitionDate + "/';";
         LOGGER.info("addAthenaPartition: Query for partition: {}", queryString);
         String queryExecutionId = MetricHelper.submitAthenaQuery(

--- a/services/onboarding-service/pom.xml
+++ b/services/onboarding-service/pom.xml
@@ -216,5 +216,20 @@ limitations under the License.
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>codepipeline</artifactId>
+            <version>${aws.java.sdk.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>apache-client</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Update the onboarding service CodePipeline listener to be more precise by fetching the tenant id from the pipeline tags instead of heuristics based on the pipeline name. Also, quote the table name (which includes the SaaS Boost environment label) in the Athena SQL queries for the Metrics service.

This resolves issue #231 when the SaaS Boost environment contains a hyphen/dash character.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
