### PR TITLE
Add Tier to tag setting

### DIFF
--- a/resources/tenant-onboarding-app.yaml
+++ b/resources/tenant-onboarding-app.yaml
@@ -21,6 +21,10 @@ Parameters:
   TenantId:
     Description: The GUID for the tenant
     Type: String
+  Tier:
+    Description: The tier this tenant is onboading into
+    Type: String
+    Default: ''
   ServiceName:
     Description: Name for this application service
     Type: String
@@ -288,6 +292,8 @@ Resources:
       Tags:
         - Key: Tenant
           Value: !Ref TenantId
+        - Key: Tier
+          Value: !Ref Tier
   ClusterCapacityProviderAssociations:
     Type: AWS::ECS::ClusterCapacityProviderAssociations
     Condition: Ec2LaunchType
@@ -459,6 +465,8 @@ Resources:
       Tags:
         - Key: Tenant
           Value: !Ref TenantId
+        - Key: Tier
+          Value: !Ref Tier
       ContainerDefinitions:
         - Name:
             Fn::Join: ['', ['sb-', !Ref Environment, '-tenant-', !Select [0, !Split ['-', !Ref TenantId]], '-', !Ref ServiceResourceName]]
@@ -899,6 +907,8 @@ Resources:
               - Key: Tenant
                 Value:
                   !Ref TenantId
+              - Key: Tier
+                Value: !Ref Tier
   LinuxLaunchTemplate:
     Type: AWS::EC2::LaunchTemplate
     Condition: Ec2Linux
@@ -936,6 +946,8 @@ Resources:
             - Key: Tenant
               Value:
                 !Ref TenantId
+            - Key: Tier
+              Value: !Ref Tier
       LaunchTemplateData:
         ImageId: !Ref AMZNLINUX2
         InstanceType: !Ref ClusterInstanceType
@@ -967,6 +979,8 @@ Resources:
               - Key: Tenant
                 Value:
                   !Ref TenantId
+              - Key: Tier
+                Value: !Ref Tier
   ALBTargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Condition: IsPublic
@@ -998,6 +1012,8 @@ Resources:
             Fn::Join: ['', ['sb-', !Ref Environment, '-tenant-', !Select [0, !Split ['-', !Ref TenantId]], '-', !Ref ServiceResourceName]]
         - Key: Tenant
           Value: !Ref TenantId
+        - Key: Tier
+          Value: !Ref Tier
   ALBRule:
     Condition: IsPublicHttp
     Type: AWS::ElasticLoadBalancingV2::ListenerRule

--- a/resources/tenant-onboarding-app.yaml
+++ b/resources/tenant-onboarding-app.yaml
@@ -594,6 +594,8 @@ Resources:
       Tags:
         - Key: Tenant
           Value: !Ref TenantId
+        - Key: Tier
+          Value: !Ref Tier
   FsxWaitHandle:
     Condition: ProvisionFSx
     DependsOn: fsx
@@ -774,6 +776,8 @@ Resources:
             - Key: Tenant
               Value:
                 !Ref TenantId
+            - Key: Tier
+              Value: !Ref Tier
       LaunchTemplateData:
         ImageId:
           Fn::If:
@@ -1181,6 +1185,7 @@ Resources:
         ThroughputCapacity: !Ref FileSystemThroughput
         ECSSecurityGroup: !Ref ECSSecurityGroup
         OntapVolumeSize: !Ref OntapVolumeSize
+        Tier: !Ref Tier
   efs:
     Type: AWS::CloudFormation::Stack
     Condition: ProvisionEFS
@@ -1196,6 +1201,7 @@ Resources:
         ECSSecurityGroup: !Ref ECSSecurityGroup
         EncryptEFS: !Ref EncryptEFS
         EFSLifecyclePolicy: !Ref EFSLifecyclePolicy
+        Tier: !Ref Tier
   rds:
     Type: AWS::CloudFormation::Stack
     Condition: ProvisionRDS
@@ -1219,6 +1225,7 @@ Resources:
         RDSPort: !Ref RDSPort
         RDSDatabase: !Ref RDSDatabase
         RDSBootstrap: !Ref RDSBootstrap
+        Tier: !Ref Tier
 Outputs:
   RdsEndpoint:
     Condition: ProvisionRDS

--- a/resources/tenant-onboarding-efs.yaml
+++ b/resources/tenant-onboarding-efs.yaml
@@ -21,6 +21,10 @@ Parameters:
   TenantId:
     Description: The GUID for the tenant
     Type: String
+  Tier:
+    Description: The tier this tenant is onboading into
+    Type: String
+    Default: ''
   ServiceResourceName:
     Description: CloudFormation friendly version of the service name
     Type: String
@@ -87,6 +91,8 @@ Resources:
             Fn::Join: ['', ['sb-', !Ref Environment, '-tenant-', !Select [0, !Split ['-', !Ref TenantId]], '-', !Ref ServiceResourceName]]
         - Key: Tenant
           Value: !Ref TenantId
+        - Key: Tier
+          Value: !Ref Tier
   MountTargetA:
     Type: AWS::EFS::MountTarget
     Properties:

--- a/resources/tenant-onboarding-fsx.yaml
+++ b/resources/tenant-onboarding-fsx.yaml
@@ -18,6 +18,10 @@ Parameters:
   Environment:
     Description: Environment (test, uat, prod, etc.)
     Type: String
+  Tier:
+    Description: The tier this tenant is onboading into
+    Type: String
+    Default: ''
   TenantId:
     Description: The GUID for the tenant
     Type: String
@@ -136,6 +140,8 @@ Resources:
             Fn::Join: ['', ['sb-', !Ref Environment, '-fsx-tenant-', !Select [0, !Split ['-', !Ref TenantId]], '-', !Ref ServiceResourceName]]
         - Key: Tenant
           Value: !Ref TenantId
+        - Key: Tier
+          Value: !Ref Tier
   FSxKeyAlias:
     Condition: CreateKey
     Type: AWS::KMS::Alias
@@ -405,6 +411,8 @@ Resources:
             Fn::Join: ['', ['sb-', !Ref Environment, '-tenant-', !Select [0, !Split ['-', !Ref TenantId]], '-', !Ref ServiceResourceName]]
         - Key: Tenant
           Value: !Ref TenantId
+        - Key: Tier
+          Value: !Ref Tier
       WindowsConfiguration: !If
         - FSxWindows
         -
@@ -457,6 +465,8 @@ Resources:
             Fn::Join: ['', ['sb-', !Ref Environment, '-tenant-', !Select [0, !Split ['-', !Ref TenantId]], '-', !Ref ServiceResourceName]]
         - Key: Tenant
           Value: !Ref TenantId
+        - Key: Tier
+          Value: !Ref Tier
   StorageVolume:
     Type: AWS::FSx::Volume
     Condition: FSxONTAP
@@ -475,6 +485,8 @@ Resources:
             Fn::Join: ['', ['sb-', !Ref Environment, '-tenant-', !Select [0, !Split ['-', !Ref TenantId]], '-', !Ref ServiceResourceName]]
         - Key: Tenant
           Value: !Ref TenantId
+        - Key: Tier
+          Value: !Ref Tier
   FsxDnsNameRole:
     Type: AWS::IAM::Role
     Properties:
@@ -557,6 +569,8 @@ Resources:
             Fn::Join: ['', ['sb-', !Ref Environment, '-tenant-', !Select [0, !Split ['-', !Ref TenantId]], '-', !Ref ServiceResourceName]]
         - Key: Tenant
           Value: !Ref TenantId
+        - Key: Tier
+          Value: !Ref Tier
   InvokeGetFsxDnsName:
     Type: Custom::CustomResource
     DependsOn:

--- a/resources/tenant-onboarding-rds.yaml
+++ b/resources/tenant-onboarding-rds.yaml
@@ -66,6 +66,10 @@ Parameters:
   RDSBootstrap:
     Description: Optional. The filename of the SQL bootstrap file.
     Type: String
+  Tier:
+    Description: The tier this tenant is onboading into
+    Type: String
+    Default: ''
 Conditions:
   Aurora:
     Fn::Or:
@@ -162,6 +166,8 @@ Resources:
             Fn::Join: ['', ['sb-', !Ref Environment, '-rds-tenant-', !Select [0, !Split ['-', !Ref TenantId]], '-', !Ref ServiceResourceName]]
         - Key: Tenant
           Value: !Ref TenantId
+        - Key: Tier
+          Value: !Ref Tier
   EncryptionKeyAlias:
     Condition: SupportsEncryption
     Type: AWS::KMS::Alias
@@ -204,6 +210,8 @@ Resources:
       Tags:
         - Key: Tenant
           Value: !Ref TenantId
+        - Key: Tier
+          Value: !Ref Tier
   RDSAuroraInstance:
     Type: AWS::RDS::DBInstance
     Condition: Aurora
@@ -216,6 +224,8 @@ Resources:
       Tags:
         - Key: Tenant
           Value: !Ref TenantId
+        - Key: Tier
+          Value: !Ref Tier
   RDSInstance:
     Type: AWS::RDS::DBInstance
     Condition: NotAurora
@@ -254,6 +264,8 @@ Resources:
       Tags:
         - Key: Tenant
           Value: !Ref TenantId
+        - Key: Tier
+          Value: !Ref Tier
   RDSBootstrapDatabaseRole:
     Type: AWS::IAM::Role
     Condition: BootstrapDatabase
@@ -354,6 +366,8 @@ Resources:
       Tags:
         - Key: Tenant
           Value: !Ref TenantId
+        - Key: Tier
+          Value: !Ref Tier
   AuroraWaitHandle:
     Type: AWS::CloudFormation::WaitConditionHandle
     Condition: Aurora

--- a/resources/tenant-onboarding.yaml
+++ b/resources/tenant-onboarding.yaml
@@ -64,12 +64,16 @@ Resources:
         - Key: Name
           Value:
             Fn::Join: ['', ['sb-', !Ref Environment, '-tenant-', !Select [0, !Split ['-', !Ref TenantId]]]]
+        - Key: Tier
+          Value: !Ref Tier
   InternetGateway:
     Type: AWS::EC2::InternetGateway
     Properties:
       Tags:
         - Key: Tenant
           Value: !Ref TenantId
+        - Key: Tier
+          Value: !Ref Tier
   AttachGateway:
     Type: AWS::EC2::VPCGatewayAttachment
     Properties:
@@ -85,6 +89,8 @@ Resources:
         - Key: Name
           Value:
             Fn::Join: ['', ['sb-', !Ref Environment, '-public-tenant-', !Select [0, !Split ['-', !Ref TenantId]]]]
+        - Key: Tier
+          Value: !Ref Tier
   RoutePublic:
     Type: AWS::EC2::Route
     DependsOn: AttachGateway
@@ -104,6 +110,8 @@ Resources:
         - Key: Name
           Value:
             Fn::Join: ['', ['sb-', !Ref Environment, '-public-az1-tenant-', !Select [0, !Split ['-', !Ref TenantId]]]]
+        - Key: Tier
+          Value: !Ref Tier
   SubnetPublicARouteTable:
     Type: AWS::EC2::SubnetRouteTableAssociation
     Properties:
@@ -121,6 +129,8 @@ Resources:
         - Key: Name
           Value:
             Fn::Join: ['', ['sb-', !Ref Environment, '-public-az2-tenant-', !Select [0, !Split ['-', !Ref TenantId]]]]
+        - Key: Tier
+          Value: !Ref Tier
   SubnetPublicBRouteTable:
     Type: AWS::EC2::SubnetRouteTableAssociation
     Properties:
@@ -138,6 +148,8 @@ Resources:
         - Key: Name
           Value:
             Fn::Join: ['', ['sb-', !Ref Environment, '-private-az1-tenant-', !Select [0, !Split ['-', !Ref TenantId]]]]
+        - Key: Tier
+          Value: !Ref Tier
   SubnetPrivateB:
     Type: AWS::EC2::Subnet
     Properties:
@@ -150,6 +162,8 @@ Resources:
         - Key: Name
           Value:
             Fn::Join: ['', ['sb-', !Ref Environment, '-private-az2-tenant-', !Select [0, !Split ['-', !Ref TenantId]]]]
+        - Key: Tier
+          Value: !Ref Tier
   RouteTablePrivate:
     Type: AWS::EC2::RouteTable
     Properties:
@@ -160,6 +174,8 @@ Resources:
         - Key: Name
           Value:
             Fn::Join: ['', ['sb-', !Ref Environment, '-private-tenant-', !Select [0, !Split ['-', !Ref TenantId]]]]
+        - Key: Tier
+          Value: !Ref Tier
   Subnet1RouteTableAssociation:
     Type: AWS::EC2::SubnetRouteTableAssociation
     Properties:
@@ -184,6 +200,8 @@ Resources:
         - Key: Name
           Value:
             Fn::Join: ['', ['sb-', !Ref Environment, '-tenant-', !Select [0, !Split ['-', !Ref TenantId]]]]
+        - Key: Tier
+          Value: !Ref Tier
       TransitGatewayId:
         Fn::Join: ['', ['{{resolve:ssm:/saas-boost/', !Ref Environment, '/TRANSIT_GATEWAY}}']]
       VpcId: !Ref VPC
@@ -219,6 +237,8 @@ Resources:
       Tags:
         - Key: Tenant
           Value: !Ref TenantId
+        - Key: Tier
+          Value: !Ref Tier
   ALBSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -280,6 +300,8 @@ Resources:
       Tags:
         - Key: Tenant
           Value: !Ref TenantId
+        - Key: Tier
+          Value: !Ref Tier
   RecordSetAlias:
      Type: AWS::Route53::RecordSet
      Condition: CreateSubDomainAlias

--- a/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingService.java
+++ b/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingService.java
@@ -998,6 +998,7 @@ public class OnboardingService {
                         // TODO rework these last 2?
                         templateParameters.add(Parameter.builder().parameterKey("MetricsStream").parameterValue("").build());
                         templateParameters.add(Parameter.builder().parameterKey("EventBus").parameterValue(SAAS_BOOST_EVENT_BUS).build());
+                        templateParameters.add(Parameter.builder().parameterKey("Tier").parameterValue(tier).build());
                         for (Parameter p : templateParameters) {
                             LOGGER.info("{} => {}", p.parameterKey(), p.parameterValue());
                             if (p.parameterValue() == null) {


### PR DESCRIPTION
----
Cost analysis is a very important area in SaaS.
SaaS Boost supports various cost allocation tags.
However, the cost allocation tag for the tier is not supported.
Accurate cost measurement for each tier is an essential element in cost estimation.

For example, if a lower tier spends more money than a higher tier, it will adversely affect profitability. We should be able to identify this.

<img width="1483" alt="Screen Shot 2022-08-16 at 11 49 24 AM" src="https://user-images.githubusercontent.com/22234099/184787851-3061417d-ee02-43c1-88eb-3882f9f80dc5.png">


In the process of creating a tenant, a code was added to add the tier information to the tag and use it for cost estimation.

It's a simple fix, but I think it's necessary.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
