### PR TITLE
Fix installing multiple environments in one account

### DIFF
--- a/client/web/update_local_env.sh
+++ b/client/web/update_local_env.sh
@@ -20,8 +20,9 @@ if [ "z$myEnv" == "z" ]; then
     read -p "What environment? " myEnv
 fi
 
-echo "$AWS_DEFAULT_REGION $AWS_REGION" > .env
-myRegion="us-west-2"
+rm .env
+
+myRegion=$(aws configure list | grep region | awk '{print $2}')
 echo "AWS_DEFAULT_REGION=$myRegion" >> .env
 echo "REACT_APP_AWS_REGION=$myRegion" >> .env
 echo "REACT_APP_ENVIRONMENT=$myEnv" >> .env

--- a/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostInstall.java
+++ b/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostInstall.java
@@ -32,6 +32,7 @@ import software.amazon.awssdk.services.apigateway.model.RestApi;
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
 import software.amazon.awssdk.services.cloudformation.model.*;
 import software.amazon.awssdk.services.cloudformation.model.Parameter;
+import software.amazon.awssdk.services.cloudformation.model.ResourceStatus;
 import software.amazon.awssdk.services.cloudformation.model.Stack;
 import software.amazon.awssdk.services.ecr.EcrClient;
 import software.amazon.awssdk.services.ecr.model.*;
@@ -1486,6 +1487,7 @@ public class SaaSBoostInstall {
         templateParameters.add(Parameter.builder().parameterKey("Version").parameterValue(VERSION).build());
         templateParameters.add(Parameter.builder().parameterKey("DeployActiveDirectory").parameterValue(useActiveDirectory.toString()).build());
         templateParameters.add(Parameter.builder().parameterKey("ADPasswordParam").parameterValue(activeDirectoryPasswordParam).build());
+        templateParameters.add(Parameter.builder().parameterKey("CreateMacroResources").parameterValue(Boolean.toString(!doesCfnMacroResourceExist())).build());
 
         LOGGER.info("createSaaSBoostStack::create stack " + stackName);
         String stackId = null;
@@ -2022,6 +2024,43 @@ public class SaaSBoostInstall {
         } else {
             LOGGER.info("Bucket " + bucket + " is empty. No objects to clean up.");
         }
+    }
+
+    private boolean doesCfnMacroResourceExist() {
+        // this assumes that the macro resource exists in CloudFormation IFF all requisite resources also exist,
+        // e.g. the macro Lambda function, execution role, and log group. this should always be true, since the
+        // macro resource will never be deleted unless each of the others are deleted thanks to CloudFormation
+        // dependency analysis
+        List<String> stackNamesToCheck = new ArrayList<>();
+        String paginationToken = null;
+        do {
+            ListStacksResponse listStacksResponse = cfn.listStacks(
+                ListStacksRequest.builder().nextToken(paginationToken).build());
+            stackNamesToCheck.addAll(listStacksResponse.stackSummaries().stream()
+                .filter(summary -> summary.stackStatus() != StackStatus.DELETE_COMPLETE 
+                                && summary.stackStatus() != StackStatus.DELETE_IN_PROGRESS)
+                .map(summary -> summary.stackName())
+                .collect(Collectors.toList()));
+            paginationToken = listStacksResponse.nextToken();
+        } while(paginationToken == null);
+        // for each stack, look for Macro Resource (either by listing all or getResource by logical id)
+        for (String stackName : stackNamesToCheck) {
+            try {
+                StackResourceDetail stackResourceDetail = cfn.describeStackResource(request -> request
+                    .stackName(stackName)
+                    .logicalResourceId("ApplicationServicesMacro")).stackResourceDetail();
+                if (stackResourceDetail.resourceStatus() != ResourceStatus.DELETE_COMPLETE) {
+                    LOGGER.debug("Found the ApplicationServicesMacro resource in {}", stackName);
+                    return true;
+                }
+            } catch (CloudFormationException cfne) {
+                if (cfne.getMessage().contains("Stack '" + stackName + "' does not exist")) {
+                    // if stacks are being deleted
+                }
+            }
+        }
+        LOGGER.debug("Could not find any ApplicationServicesMacro resource");
+        return false;
     }
 
     public static String getFullStackTrace(Exception e) {

--- a/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostInstall.java
+++ b/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostInstall.java
@@ -2027,8 +2027,8 @@ public class SaaSBoostInstall {
     }
 
     private boolean doesCfnMacroResourceExist() {
-        // this assumes that the macro resource exists in CloudFormation IFF all requisite resources also exist,
-        // e.g. the macro Lambda function, execution role, and log group. this should always be true, since the
+        // this assumes that the macro resource exists in CloudFormation if and only if all requisite resources also 
+        // exist, i.e. the macro Lambda function, execution role, and log group. this should always be true, since the
         // macro resource will never be deleted unless each of the others are deleted thanks to CloudFormation
         // dependency analysis
         List<String> stackNamesToCheck = new ArrayList<>();

--- a/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostInstall.java
+++ b/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostInstall.java
@@ -2042,7 +2042,7 @@ public class SaaSBoostInstall {
                 .map(summary -> summary.stackName())
                 .collect(Collectors.toList()));
             paginationToken = listStacksResponse.nextToken();
-        } while(paginationToken == null);
+        } while(paginationToken != null);
         // for each stack, look for Macro Resource (either by listing all or getResource by logical id)
         for (String stackName : stackNamesToCheck) {
             try {

--- a/resources/saas-boost.yaml
+++ b/resources/saas-boost.yaml
@@ -475,6 +475,18 @@ Resources:
       # Can't use a parameter as part of a macro name when you include it in another template
       Name: saas-boost-app-services-macro
       FunctionName: !GetAtt ApplicationServicesMacroFunction.Arn
+  CreateMacroWaitHandle:
+    Condition: ShouldCreateMacroResources
+    DependsOn: ApplicationServicesMacro
+    Type: AWS::CloudFormation::WaitConditionHandle
+  NoCreateMacroWaitHandle:
+    Type: AWS::CloudFormation::WaitConditionHandle
+  MacroWaitCondition:
+    Type: AWS::CloudFormation::WaitCondition
+    Properties:
+      Handle: !If [ShouldCreateMacroResources, !Ref CreateMacroWaitHandle, !Ref NoCreateMacroWaitHandle]
+      Timeout: '1'
+      Count: 0
   SaaSBoostEventBus:
     Type: AWS::Events::EventBus
     Properties:
@@ -617,7 +629,7 @@ Resources:
     Type: AWS::CloudFormation::Stack
     DependsOn:
       - network
-      - ApplicationServicesMacro
+      - MacroWaitCondition
     Properties:
       TemplateURL: !Sub https://${SaaSBoostBucket}.s3.amazonaws.com/saas-boost-core.yaml
       Parameters:

--- a/resources/saas-boost.yaml
+++ b/resources/saas-boost.yaml
@@ -68,7 +68,7 @@ Parameters:
     Description: Whether to create the Lambda, ExecutionRole, LogGroup, and CloudFormation macro for SaaS Boost environments
     Type: String
     AllowedValues: ['true', 'false']
-    Default: 'true'
+    Default: 'false'
 Conditions:
   ProvisionManagedAD: !Equals [!Ref DeployActiveDirectory, 'true']
   ShouldCreateMacroResources: !Equals [!Ref CreateMacroResources, 'true']

--- a/resources/saas-boost.yaml
+++ b/resources/saas-boost.yaml
@@ -412,7 +412,7 @@ Resources:
     DependsOn:
       - ApplicationServicesMacroLogs
     Properties:
-      RoleName: saas-boost-app-services-macro
+      RoleName: !Sub saas-boost-app-services-macro-${AWS::Region}
       Path: '/'
       AssumeRolePolicyDocument:
         Version: 2012-10-17

--- a/resources/saas-boost.yaml
+++ b/resources/saas-boost.yaml
@@ -65,7 +65,7 @@ Parameters:
     Type: String
     Default: ''
   CreateMacroResources:
-    Description: Whether to create the Lambda, LogGroup, and CloudFormation macro for SaaS Boost environments
+    Description: Whether to create the Lambda, ExecutionRole, LogGroup, and CloudFormation macro for SaaS Boost environments
     Type: String
     AllowedValues: ['true', 'false']
     Default: 'true'

--- a/resources/saas-boost.yaml
+++ b/resources/saas-boost.yaml
@@ -64,8 +64,14 @@ Parameters:
     Description: Comma separated list of application service names to create ECR repositories for
     Type: String
     Default: ''
+  CreateMacroResources:
+    Description: Whether to create the Lambda, LogGroup, and CloudFormation macro for SaaS Boost environments
+    Type: String
+    AllowedValues: ['true', 'false']
+    Default: 'true'
 Conditions:
   ProvisionManagedAD: !Equals [!Ref DeployActiveDirectory, 'true']
+  ShouldCreateMacroResources: !Equals [!Ref CreateMacroResources, 'true']
 Resources:
   SSMSaaSBoostEnvironment:
     Type: AWS::SSM::Parameter
@@ -402,6 +408,7 @@ Resources:
       Bucket: !Ref Resources
   ApplicationServicesMacroExecutionRole:
     Type: AWS::IAM::Role
+    Condition: ShouldCreateMacroResources
     DependsOn:
       - ApplicationServicesMacroLogs
     Properties:
@@ -433,11 +440,13 @@ Resources:
                   - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
   ApplicationServicesMacroLogs:
     Type: AWS::Logs::LogGroup
+    Condition: ShouldCreateMacroResources
     Properties:
       LogGroupName: /aws/lambda/saas-boost-app-services-macro
       RetentionInDays: 30
   ApplicationServicesMacroFunction:
     Type: AWS::Lambda::Function
+    Condition: ShouldCreateMacroResources
     DependsOn: ApplicationServicesMacroLogs
     Properties:
       FunctionName: saas-boost-app-services-macro
@@ -461,6 +470,7 @@ Resources:
           Value: !Ref Environment
   ApplicationServicesMacro:
     Type: AWS::CloudFormation::Macro
+    Condition: ShouldCreateMacroResources
     Properties:
       # Can't use a parameter as part of a macro name when you include it in another template
       Name: saas-boost-app-services-macro

--- a/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingService.java
+++ b/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingService.java
@@ -1800,7 +1800,8 @@ public class OnboardingService {
                             Parameter.builder().parameterKey("DomainName").parameterValue(domainName).build(),
                             Parameter.builder().parameterKey("HostedZone").parameterValue(hostedZone).build(),
                             Parameter.builder().parameterKey("ApplicationServices").parameterValue(
-                                    String.join(",", services.keySet())).build()
+                                    String.join(",", services.keySet())).build(),
+                            Parameter.builder().parameterKey("CreateMacroResources").usePreviousValue(Boolean.TRUE).build()
                     )
                     .build()
             );


### PR DESCRIPTION
With the addition of the multicontainer feature and the usage of the CloudFormation macro to control updates according to Application Services, the ability to install multiple environments in a single account (typically for testing purposes) was broken.

This commit fixes that bug by adding a Parameter to the base stack that will only create those CloudFormation macro resources if they do not already exist.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
