### PR TITLE
Fix installing SaaS Boost without first running a mvn build.

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -19,6 +19,13 @@ $CURRENT_DIR = Split-Path $script:MyInvocation.MyCommand.Path
 
 Write-host "Current directory is $CURRENT_DIR"
 
+# Check for utils
+if (-not (Test-Path -Path ${CURRENT_DIR}\layers\utils -PathType Container))
+{
+    Write-Host "Directory ${CURRENT_DIR}\layers\utils not found"
+    Exit 2
+}
+
 # Check for installer
 if (-not (Test-Path -Path ${CURRENT_DIR}\installer -PathType Container))
 {
@@ -118,7 +125,35 @@ if ([string]::IsNullOrWhiteSpace($AWS_REGION))
     Exit 2
 }
 
-cd installer
+cd ${CURRENT_DIR}
+Write-host "Building requirements for SaaS Boost"
+mvn --quiet --non-recursive "-Dspotbugs.skip" install 2>&1 | Out-Null
+if (-not $?)
+{
+    Write-host "Error building parent pomfile for SaaS Boost"
+    Exit 2
+}
+
+cd ${CURRENT_DIR}\layers
+mvn --quiet --non-recursive "-Dspotbugs.skip" install 2>&1 | Out-Null
+if (-not $?)
+{
+    Write-host "Error building layers pomfile for SaaS Boost Utils"
+    Exit 2
+}
+Write-host "Requirements build completed"
+
+cd ${CURRENT_DIR}\layers\utils
+Write-host "Building Java Utils with maven"
+mvn --quiet "-Dspotbugs.skip" 2>&1 | Out-Null
+if (-not $?)
+{
+    Write-host "Error building Java Utils for SaaS Boost"
+    Exit 2
+}
+Write-host "Java Utils build completed"
+
+cd ${CURRENT_DIR}\installer
 Write-host "Building Java Installer with maven"
 mvn --quiet "-Dspotbugs.skip" 2>&1 | Out-Null
 if (-not $?)

--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,12 @@ echo "Starting SaaS Boost installation..."
 
 CURRENT_DIR=$(pwd)
 
+# Check for utils dir
+if [ ! -d "${CURRENT_DIR}/layers/utils" ]; then
+        echo "Directory ${CURRENT_DIR}/layers/utils not found."
+        exit 2
+fi
+
 # Check for installer dir
 if [ ! -d "${CURRENT_DIR}/installer" ]; then
 	echo "Directory ${CURRENT_DIR}/installer not found."
@@ -63,6 +69,29 @@ if [ -z $AWS_DEFAULT_REGION ]; then
 	fi
 else
 	export AWS_REGION=$AWS_DEFAULT_REGION
+fi
+
+cd ${CURRENT_DIR}
+echo "Building maven requirements..."
+mvn --quiet --non-recursive install -Dspotbugs.skip > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+        echo "Error building parent pomfile for SaaS Boost."
+        exit 2
+fi
+
+cd ${CURRENT_DIR}/layers
+mvn --quiet --non-recursive install -Dspotbugs.skip > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+        echo "Error building layers pomfile for SaaS Boost."
+        exit 2
+fi
+
+cd ${CURRENT_DIR}/layers/utils
+echo "Building utils..."
+mvn --quiet -Dspotbugs.skip > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+        echo "Error building utilities for SaaS Boost."
+        exit 2
 fi
 
 cd ${CURRENT_DIR}/installer

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
     </dependencyManagement>
     <!-- Warning! Do not define dependencies at this top level POM. -->
     <build>
-        <defaultGoal>clean package</defaultGoal>
+        <defaultGoal>package</defaultGoal>
         <!-- this defines default plugin configuration when referenced by all inheriting modules -->
         <pluginManagement>
             <plugins>
@@ -162,7 +162,7 @@
                 <executions>
                     <execution>
                         <id>spot-bugs</id>
-                        <phase>compile</phase>
+                        <phase>verify</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>


### PR DESCRIPTION
Recent changes to the installer brought in a dependency on the layers/utils package in SaaS Boost. Because the install scripts have always only built the installer package, this would break for those people that have never built the main parent pom, layers parent pom, and utils package itself. 

This commit adds in explicit builds into the install scripts to ensure those are built before trying to build the installer.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
