### PR TITLE
Fix an issue in the install script where having no region set in the CLI errors unhelpfully.

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -124,6 +124,12 @@ if ([string]::IsNullOrWhiteSpace($AWS_REGION))
     echo "AWS_REGION not set, check your aws profile or set AWS_DEFAULT_REGION"
     Exit 2
 }
+aws ec2 describe-regions | Select-String -Pattern "$AWS_REGION" | Out-Null
+if (-not $?)
+{
+    Write-host "Invalid region $AWS_REGION set, please set a valid region using aws configure"
+    Exit 2
+}
 
 cd ${CURRENT_DIR}
 Write-host "Building requirements for SaaS Boost"

--- a/install.sh
+++ b/install.sh
@@ -63,7 +63,7 @@ fi
 # check for AWS region
 if [ -z $AWS_DEFAULT_REGION ]; then
 	export AWS_REGION=$(aws configure list | grep region | awk '{print $2}')
-        aws ec2 describe-regions | grep "$AWS_REGION" - 2>&1
+        aws ec2 describe-regions | grep "$AWS_REGION" - > /dev/null 2>&1
         if [ $? -ne 0 ]; then
                 echo "Invalid region set, please set a valid region using \`aws configure\`"
                 exit 2

--- a/install.sh
+++ b/install.sh
@@ -63,6 +63,11 @@ fi
 # check for AWS region
 if [ -z $AWS_DEFAULT_REGION ]; then
 	export AWS_REGION=$(aws configure list | grep region | awk '{print $2}')
+        aws ec2 describe-regions | grep "$AWS_REGION" - 2>&1
+        if [ $? -ne 0 ]; then
+                echo "Invalid region set, please set a valid region using \`aws configure\`"
+                exit 2
+        fi
 	if [ -z $AWS_REGION ]; then
 		echo "AWS_REGION environment variable not set, check your AWS profile or set AWS_DEFAULT_REGION."
 		exit 2


### PR DESCRIPTION
If you have no region set in the AWS CLI (doable by removing the 'region' line from `.aws/config`) the result of `aws configure list` will contain the string "<not set>" for the region, meaning the region is parsed incorrectly in the install script. This leads to an error when trying to run the installer that is potentially difficult for a new user to comprehend.

This commit changes the parsing in the install scripts to also check the configured region against the list of regions using `aws ec2 describe-regions`. If the configured region does not exist in that list, the installer will prompt the user to configure a valid region.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
