### PR TITLE
Improve UX on invalid AppConfig submission.

### DIFF
--- a/client/web/src/settings/ApplicationComponent.js
+++ b/client/web/src/settings/ApplicationComponent.js
@@ -367,16 +367,17 @@ export function ApplicationComponent(props) {
       } else {
         formik.errors.services?.forEach((service, index) => {
           if (!!service) {
-            let serviceString = formik.values?.services[index].name
+            let serviceName = formik.values?.services[index].name
+            let serviceMessage = "Service " + serviceName
             if (!!service.tiers) {
-              serviceString = serviceString.concat(": ", Object.keys(service.tiers).toString())
+              serviceMessage = serviceMessage.concat(" Tiers ", Object.keys(service.tiers).toString())
             }
-            servicesWithErrors.push(serviceString)
+            servicesWithErrors.push(serviceMessage)
           }
         })
       }
     }
-    return servicesWithErrors.join(', ')
+    return servicesWithErrors.join(" ; ")
   }
 
   return (
@@ -417,7 +418,7 @@ export function ApplicationComponent(props) {
               <>
                 {!!formik.errors && Object.keys(formik.errors).length > 0 ? (
                   <Alert variant="danger">
-                    Errors in {findServicesWithErrors(formik)}
+                    Errors in form: {findServicesWithErrors(formik)}
                   </Alert>
                 ) : null}
                 <Form>

--- a/client/web/src/settings/ApplicationComponent.js
+++ b/client/web/src/settings/ApplicationComponent.js
@@ -362,11 +362,16 @@ export function ApplicationComponent(props) {
     let servicesWithErrors = []
     if (!!formik?.errors?.services) {
       if (typeof formik.errors.services === 'string') {
+        // TODO when is formik.errors.services not an array?
         servicesWithErrors.push(formik.errors.services)
       } else {
         formik.errors.services?.forEach((service, index) => {
           if (!!service) {
-            servicesWithErrors.push(formik.values?.services[index].name)
+            let serviceString = formik.values?.services[index].name
+            if (!!service.tiers) {
+              serviceString = serviceString.concat(": ", Object.keys(service.tiers).toString())
+            }
+            servicesWithErrors.push(serviceString)
           }
         })
       }
@@ -382,7 +387,7 @@ export function ApplicationComponent(props) {
     >
       <div className="animated fadeIn">
         {hasTenants && (
-          <Alert color="primary">
+          <Alert variant="primary">
             <span>
               <i className="fa fa-info-circle" /> Note: some settings cannot be
               modified once you have deployed tenants.
@@ -391,19 +396,19 @@ export function ApplicationComponent(props) {
         )}
         {/* {loading !== "idle" && <div>Loading...</div>} */}
         {!!error && (
-          <Alert color="danger" isOpen={!!error} toggle={dismissError}>
+          <Alert variant="danger" isOpen={!!error} toggle={dismissError}>
             {error}
           </Alert>
         )}
         {!!message && (
-          <Alert color="info" isOpen={!!message} toggle={dismissMessage}>
+          <Alert variant="info" isOpen={!!message} toggle={dismissMessage}>
             {message}
           </Alert>
         )}
         <Formik
           initialValues={initialValues}
           validationSchema={validationSpecs}
-          validateOnChange={false}
+          validateOnChange={true}
           onSubmit={updateConfig}
           enableReinitialize={true}
         >
@@ -411,7 +416,7 @@ export function ApplicationComponent(props) {
             return (
               <>
                 {!!formik.errors && Object.keys(formik.errors).length > 0 ? (
-                  <Alert color="danger">
+                  <Alert variant="danger">
                     Errors in {findServicesWithErrors(formik)}
                   </Alert>
                 ) : null}
@@ -446,6 +451,7 @@ export function ApplicationComponent(props) {
                             type="Submit"
                             variant="info"
                             disabled={isSubmitting()}
+                            onClick={() => { window.scrollTo(0,0) }}
                           >
                             {isSubmitting() ? 'Saving...' : 'Submit'}
                           </Button>


### PR DESCRIPTION
This commit changes the AppConfig page on the Admin UI with three small experience changes:
1. When clicking submit, the page will scroll to the top. This makes any errors evident in the banner at the top of the page.
2. Banners have been updated to the newer Bootstrap format, meaning the error banner is now properly 'dangerous'.
3. The error banner at the top now includes not only which service has errors, but which tiers in those services as well.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
