### PR TITLE
Fixes bug overriding user updates to billing api key. Fixes #296.

### DIFF
--- a/client/web/src/settings/BillingSubform.js
+++ b/client/web/src/settings/BillingSubform.js
@@ -45,7 +45,6 @@ export default function BillingSubform(props) {
                       label="Please enter your Stripe Secret API Key"
                       name="billing.apiKey"
                       type="password"
-                      value=""
                     />
                   </Col>
                 </Row>


### PR DESCRIPTION
Fixes #296 

We were incorrectly overriding the value of the Stripe API key to be "" no matter what was entered by the user.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
