### PR TITLE
Redirect ECR upload help instructions to Summary page from Onboarding.

### DIFF
--- a/client/web/src/dashboard/DashboardComponent.js
+++ b/client/web/src/dashboard/DashboardComponent.js
@@ -257,7 +257,7 @@ export const DashboardComponent = (props) => {
                                   ecrRepo={service.containerRepo}
                                 >
                                   <span className="text-muted">
-                                    View details{' '}
+                                    View docker image upload instructions{' '}
                                     <CIcon icon={cilExternalLink} />
                                   </span>
                                 </ECRInstructions>

--- a/client/web/src/onboarding/OnboardingListComponent.js
+++ b/client/web/src/onboarding/OnboardingListComponent.js
@@ -15,11 +15,11 @@
  */
 import { PropTypes } from 'prop-types'
 import React, { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
 import { Row, Col, Card, Button, Table, Spinner, Alert } from 'react-bootstrap'
 import CIcon from '@coreui/icons-react'
 import { cilReload, cilListRich } from '@coreui/icons'
 import OnboardingListItemComponent from './OnboardingListItemComponent'
-import ECRInstructions from '../components/ECRInstructions'
 
 const showError = (error, dismissError) => {
   return (
@@ -39,9 +39,6 @@ export const OnboardingListComponent = (props) => {
     loading,
     onboardingRequests,
     showOnboardRequestForm,
-    ecrRepository,
-    awsAccount,
-    awsRegion,
     clickTenantDetails,
   } = props
   const [isRefreshing, setIsRefreshing] = useState(false)
@@ -80,15 +77,9 @@ export const OnboardingListComponent = (props) => {
       <Row className="mb-3">
         <Col sm={12} md={8} lg={9}>
           <Alert color="light">
-            Onboarding tenants requires an application image to be uploaded. For
-            more detail, click
-            <ECRInstructions
-              awsAccount={awsAccount}
-              awsRegion={awsRegion}
-              ecrRepo={ecrRepository}
-            >
-              <span>here.</span>
-            </ECRInstructions>
+            Onboarding tenants requires an application image to be uploaded for each service. 
+            If you haven't done so, view the upload instructions for each service:
+            <Link to="/summary">here</Link>.
           </Alert>
         </Col>
         <Col sm={12} md={4} lg={3}>

--- a/client/web/src/onboarding/OnboardingListComponent.js
+++ b/client/web/src/onboarding/OnboardingListComponent.js
@@ -78,7 +78,7 @@ export const OnboardingListComponent = (props) => {
         <Col sm={12} md={8} lg={9}>
           <Alert color="light">
             Onboarding tenants requires an application image to be uploaded for each service. 
-            If you haven't done so, view the upload instructions for each service:
+            If you haven't done so, view the upload instructions for each service &nbsp;
             <Link to="/summary">here</Link>.
           </Alert>
         </Col>

--- a/client/web/src/onboarding/OnboardingListContainer.js
+++ b/client/web/src/onboarding/OnboardingListContainer.js
@@ -27,8 +27,6 @@ import {
 } from './ducks'
 import globalConfig from '../config/appConfig'
 
-import { selectSettingsById } from '../settings/ducks'
-
 import { OnboardingListComponent } from './OnboardingListComponent'
 
 const log = logger.getLogger('onboarding')
@@ -42,8 +40,6 @@ export default function OnboardingListContainer() {
   const onboardings = useSelector(selectAllOnboarding)
   const loading = useSelector(selectLoading)
   const error = useSelector(selectError)
-
-  const ecrRepository = useSelector((state) => selectSettingsById(state, 'ECR_REPO'))
 
   const showOnboardRequestForm = () => {
     history.push('/onboarding/request')
@@ -89,7 +85,6 @@ export default function OnboardingListContainer() {
       loading={loading}
       onboardingRequests={onboardings}
       showOnboardRequestForm={showOnboardRequestForm}
-      ecrRepository={ecrRepository?.value}
       awsAccount={globalConfig.awsAccount}
       awsRegion={globalConfig.region}
       showEcrPushModal={showEcrPushModal}


### PR DESCRIPTION
Since AppConfig now supports multiple services, we cannot provide a simple set of instructions for uploading images into ECR like we did previously. This change changes the help message to be clear that there are now multiple repositories you may need to upload to and redirects the user to the Summary page, where those instructions can be found.

Fixes #301 
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
