### PR TITLE
Don't hardcode AWS partition and URL suffix

### DIFF
--- a/functions/workload-deploy/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/WorkloadDeploy.java
+++ b/functions/workload-deploy/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/WorkloadDeploy.java
@@ -248,7 +248,7 @@ public class WorkloadDeploy implements RequestHandler<Map<String, Object>, Objec
         String tag = (String) detail.get("image-tag");
         if (Utils.isNotBlank(accountId) && Utils.isNotBlank(region)
                 && Utils.isNotBlank(repo) && Utils.isNotBlank(tag)) {
-            imageUri = accountId + ".dkr.ecr." + region + "." + Utils.endpointDomain(region) + "/" + repo + ":" + tag;
+            imageUri = accountId + ".dkr.ecr." + region + "." + Utils.endpointSuffix(region) + "/" + repo + ":" + tag;
         }
         return imageUri;
     }

--- a/functions/workload-deploy/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/WorkloadDeploy.java
+++ b/functions/workload-deploy/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/WorkloadDeploy.java
@@ -248,7 +248,7 @@ public class WorkloadDeploy implements RequestHandler<Map<String, Object>, Objec
         String tag = (String) detail.get("image-tag");
         if (Utils.isNotBlank(accountId) && Utils.isNotBlank(region)
                 && Utils.isNotBlank(repo) && Utils.isNotBlank(tag)) {
-            imageUri = accountId + ".dkr.ecr." + region + ".amazonaws.com/" + repo + ":" + tag;
+            imageUri = accountId + ".dkr.ecr." + region + "." + Utils.endpointDomain(region) + "/" + repo + ":" + tag;
         }
         return imageUri;
     }

--- a/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostArtifactsBucket.java
+++ b/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostArtifactsBucket.java
@@ -53,7 +53,7 @@ public class SaaSBoostArtifactsBucket {
      * @return the S3 URL the Bucket object represents
      */
     public String getBucketUrl() {
-        return String.format("https://%s.s3.%s.amazonaws.com/", bucketName, region);
+        return String.format("https://%s.s3.%s.%s/", bucketName, region, Utils.endpointDomain(region.toString()));
     }
 
     public void putFile(S3Client s3, Path localPath, Path remotePath) {

--- a/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostArtifactsBucket.java
+++ b/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostArtifactsBucket.java
@@ -53,7 +53,7 @@ public class SaaSBoostArtifactsBucket {
      * @return the S3 URL the Bucket object represents
      */
     public String getBucketUrl() {
-        return String.format("https://%s.s3.%s.%s/", bucketName, region, Utils.endpointDomain(region.toString()));
+        return String.format("https://%s.s3.%s.%s/", bucketName, region, Utils.endpointSuffix(region));
     }
 
     public void putFile(S3Client s3, Path localPath, Path remotePath) {

--- a/layers/apigw-helper/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/ApiGatewayHelper.java
+++ b/layers/apigw-helper/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/ApiGatewayHelper.java
@@ -60,7 +60,8 @@ public class ApiGatewayHelper {
             .httpClient(HTTP_CLIENT)
             .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
             .region(Region.of(AWS_REGION))
-            .endpointOverride(URI.create("https://" + StsClient.SERVICE_NAME + "." + Region.of(AWS_REGION).toString() + ".amazonaws.com"))
+            .endpointOverride(URI.create("https://" + StsClient.SERVICE_NAME + "." + AWS_REGION
+                    + "." + Utils.endpointDomain(AWS_REGION)))
             .overrideConfiguration(ClientOverrideConfiguration.builder()
                     .retryPolicy(RetryPolicy.builder()
                             .backoffStrategy(BackoffStrategy.defaultStrategy())

--- a/layers/apigw-helper/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/ApiGatewayHelper.java
+++ b/layers/apigw-helper/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/ApiGatewayHelper.java
@@ -61,7 +61,7 @@ public class ApiGatewayHelper {
             .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
             .region(Region.of(AWS_REGION))
             .endpointOverride(URI.create("https://" + StsClient.SERVICE_NAME + "." + AWS_REGION
-                    + "." + Utils.endpointDomain(AWS_REGION)))
+                    + "." + Utils.endpointSuffix(AWS_REGION)))
             .overrideConfiguration(ClientOverrideConfiguration.builder()
                     .retryPolicy(RetryPolicy.builder()
                             .backoffStrategy(BackoffStrategy.defaultStrategy())

--- a/layers/utils/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/Utils.java
+++ b/layers/utils/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/Utils.java
@@ -36,6 +36,8 @@ import software.amazon.awssdk.core.retry.backoff.BackoffStrategy;
 import software.amazon.awssdk.core.retry.conditions.RetryCondition;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.partitionmetadata.AwsCnPartitionMetadata;
+import software.amazon.awssdk.regions.partitionmetadata.AwsUsGovPartitionMetadata;
 import software.amazon.awssdk.services.eventbridge.EventBridgeClient;
 import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
 import software.amazon.awssdk.services.eventbridge.model.PutEventsResponse;
@@ -172,19 +174,27 @@ public class Utils {
     }
 
     public static boolean isChinaRegion(String region) {
-        return "cn-north-1".equalsIgnoreCase(region) || "cn-northwest-1".equalsIgnoreCase(region);
+        return isChinaRegion(Region.of(region));
+    }
+
+    public static boolean isChinaRegion(Region region) {
+        return region.metadata().partition() instanceof AwsCnPartitionMetadata;
     }
 
     public static boolean isGovCloudRegion(String region) {
-        return "us-gov-east-1".equalsIgnoreCase(region) || "us-gov-west-1".equalsIgnoreCase(region);
+        return isGovCloudRegion(Region.of(region));
+    }
+
+    public static boolean isGovCloudRegion(Region region) {
+        return region.metadata().partition() instanceof AwsUsGovPartitionMetadata;
     }
 
     public static String endpointDomain(String region) {
-        String domain = "amazonaws.com";
-        if (isChinaRegion(region)) {
-            domain = "amazonaws.com.cn";
-        }
-        return domain;
+        return endpointDomain(Region.of(region));
+    }
+
+    public static String endpointDomain(Region region) {
+        return region.metadata().partition().dnsSuffix();
     }
 
     public static <B extends AwsSyncClientBuilder<B, C> & AwsClientBuilder<?, C>, C> C sdkClient(AwsSyncClientBuilder<B, C> builder, String service) {

--- a/layers/utils/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/UtilsTest.java
+++ b/layers/utils/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/UtilsTest.java
@@ -23,6 +23,14 @@ import static org.junit.Assert.*;
 public class UtilsTest {
 
     @Test
+    public void testIsChinaRegion() {
+        assertFalse("N. Virginia is not in China", Utils.isChinaRegion("us-east-1"));
+        assertFalse("US Gov Cloud is not in China", Utils.isChinaRegion("us-gov-west-1"));
+        assertTrue("Beijing is in China", Utils.isChinaRegion("cn-north-1"));
+        assertTrue("Ningxia is in China", Utils.isChinaRegion("cn-northwest-1"));
+    }
+
+    @Test
     public void testRandomString() {
         assertThrows(IllegalArgumentException.class, () -> {Utils.randomString(0);});
         assertThrows(IllegalArgumentException.class, () -> {Utils.randomString(-1);});

--- a/resources/saas-boost-core.yaml
+++ b/resources/saas-boost-core.yaml
@@ -97,7 +97,7 @@ Resources:
             Action:
               - sts:AssumeRole
       Policies:
-        - PolicyName: !Sub sb-${Environment}-workload-deploy-policy-${AWS::Region}
+        - PolicyName: !Sub sb-${Environment}-workload-deploy-policy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -105,32 +105,32 @@ Resources:
                 Action:
                   - logs:PutLogEvents
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
               - Effect: Allow
                 Action:
                   - logs:CreateLogStream
                   - logs:DescribeLogStreams
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
               - Effect: Allow
                 Action:
                   - s3:ListBucket
                   - s3:ListBucketVersions
                   - s3:GetBucketVersioning
                 Resource:
-                  - !Sub arn:aws:s3:::${CodePipelineBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${CodePipelineBucket}
               - Effect: Allow
                 Action:
                   - s3:GetObject
                   - s3:PutObject
                   - s3:DeleteObject
                   - s3:DeleteObjectVersion
-                Resource: !Sub arn:aws:s3:::${CodePipelineBucket}/*
+                Resource: !Sub arn:${AWS::Partition}:s3:::${CodePipelineBucket}/*
               - Effect: Allow
                 Action:
                   - codepipeline:StartPipelineExecution
                 Resource:
-                  - !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:*
+                  - !Sub arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:*
               - Effect: Allow
                 Action:
                   - sts:AssumeRole
@@ -155,7 +155,7 @@ Resources:
         Variables:
           SAAS_BOOST_ENV: !Ref Environment
           API_TRUST_ROLE: !GetAtt SaaSBoostSystemRole.Arn
-          API_GATEWAY_HOST: !Sub ${SaaSBoostPrivateApi}.execute-api.${AWS::Region}.amazonaws.com
+          API_GATEWAY_HOST: !Sub ${SaaSBoostPrivateApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}
           API_GATEWAY_STAGE: !Ref PrivateApiStage
           CODE_PIPELINE_BUCKET: !Ref CodePipelineBucket
           JAVA_TOOL_OPTIONS: '-XX:+TieredCompilation -XX:TieredStopAtLevel=1'
@@ -207,7 +207,7 @@ Resources:
             Action:
               - sts:AssumeRole
       Policies:
-        - PolicyName: !Sub sb-${Environment}-onboarding-listener-${AWS::Region}
+        - PolicyName: !Sub sb-${Environment}-onboarding-listener
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -215,24 +215,24 @@ Resources:
                 Action:
                   - logs:PutLogEvents
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
               - Effect: Allow
                 Action:
                   - logs:CreateLogStream
                   - logs:DescribeLogStreams
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
               - Effect: Allow
                 Action:
                   - cloudformation:DescribeStacks
                   - cloudformation:ListStackResources
                 Resource:
-                  - !Sub arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/*
+                  - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/*
               - Effect: Allow
                 Action:
                   - events:PutEvents
                 Resource:
-                  - !Sub 'arn:aws:events:${AWS::Region}:${AWS::AccountId}:event-bus/{{resolve:ssm:/saas-boost/${Environment}/EVENT_BUS}}'
+                  - !Sub 'arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:event-bus/{{resolve:ssm:/saas-boost/${Environment}/EVENT_BUS}}'
   OnboardingStackListenerLogs:
     Type: AWS::Logs::LogGroup
     Properties:
@@ -364,9 +364,9 @@ Resources:
             Action:
               - sts:AssumeRole
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/AmazonECS_FullAccess
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonECS_FullAccess
       Policies:
-        - PolicyName: !Sub sb-${Environment}-tenant-pipeline-policy-${AWS::Region}
+        - PolicyName: !Sub sb-${Environment}-tenant-pipeline-policy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -381,18 +381,18 @@ Resources:
               - Effect: Allow
                 Action:
                   - ecr:DescribeImages
-                Resource: !Sub arn:aws:ecr:${AWS::Region}:${AWS::AccountId}:repository/*
+                Resource: !Sub arn:${AWS::Partition}:ecr:${AWS::Region}:${AWS::AccountId}:repository/*
               - Effect: Allow
                 Action:
                   - s3:ListBucket
                   - s3:GetBucketVersioning
-                Resource: !Sub arn:aws:s3:::${CodePipelineBucket}
+                Resource: !Sub arn:${AWS::Partition}:s3:::${CodePipelineBucket}
               - Effect: Allow
                 Action:
                   - s3:PutObject
                   - s3:GetObject
                   - s3:GetObjectVersion
-                Resource: !Sub arn:aws:s3:::${CodePipelineBucket}/*
+                Resource: !Sub arn:${AWS::Partition}:s3:::${CodePipelineBucket}/*
               - Effect: Allow
                 Action:
                   - lambda:ListFunctions
@@ -423,20 +423,20 @@ Resources:
             Action:
               - sts:AssumeRole
       Policies:
-        - PolicyName: !Sub sb-${Environment}-update-ecs-${AWS::Region}
+        - PolicyName: !Sub sb-${Environment}-update-ecs
           PolicyDocument:
             Version: 2012-10-17
             Statement:
               - Effect: Allow
                 Action:
                   - logs:PutLogEvents
-                Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
+                Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
               - Effect: Allow
                 Action:
                   - logs:CreateLogStream
                   - logs:DescribeLogStreams
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
               - Effect: Allow
                 Action:
                   - codepipeline:PutJobSuccessResult
@@ -447,11 +447,11 @@ Resources:
                   - ecs:DescribeServices
                   - ecs:UpdateService
                 Resource:
-                  - !Sub arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:service/*
+                  - !Sub arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:service/*
                 Condition:
                   StringLike:
                     ecs:cluster:
-                      - !Sub arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:cluster/sb-${Environment}-tenant*
+                      - !Sub arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:cluster/sb-${Environment}-tenant*
   CodePipelineUpdateEcsServiceLogs:
     Type: AWS::Logs::LogGroup
     Properties:
@@ -509,11 +509,11 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+              AWS: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:root
             Action:
               - sts:AssumeRole
       Policies:
-        - PolicyName: !Sub sb-${Environment}-private-api-trust-policy-${AWS::Region}
+        - PolicyName: !Sub sb-${Environment}-private-api-trust-policy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -521,8 +521,8 @@ Resources:
                 Action:
                   - execute-api:Invoke
                 Resource:
-                  - !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${SaaSBoostPrivateApi}/*/*/*
-                  - !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${SaaSBoostPublicApi}/*/*/*
+                  - !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${SaaSBoostPrivateApi}/*/*/*
+                  - !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${SaaSBoostPublicApi}/*/*/*
   SSMParamPrivateApiRole:
     Type: AWS::SSM::Parameter
     Properties:
@@ -544,7 +544,7 @@ Resources:
             Action:
               - sts:AssumeRole
       Policies:
-        - PolicyName: !Sub sb-${Environment}-private-api-client-policy-${AWS::Region}
+        - PolicyName: !Sub sb-${Environment}-private-api-client-policy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -552,13 +552,13 @@ Resources:
                 Action:
                   - logs:PutLogEvents
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
               - Effect: Allow
                 Action:
                   - logs:CreateLogStream
                   - logs:DescribeLogStreams
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
               - Effect: Allow
                 Action:
                   - sts:AssumeRole
@@ -587,7 +587,7 @@ Resources:
         Variables:
           SAAS_BOOST_ENV: !Ref Environment
           API_TRUST_ROLE: !GetAtt SaaSBoostSystemRole.Arn
-          API_GATEWAY_HOST: !Sub ${SaaSBoostPrivateApi}.execute-api.${AWS::Region}.amazonaws.com
+          API_GATEWAY_HOST: !Sub ${SaaSBoostPrivateApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}
           API_GATEWAY_STAGE: !Ref PrivateApiStage
           JAVA_TOOL_OPTIONS: '-XX:+TieredCompilation -XX:TieredStopAtLevel=1'
       Tags:
@@ -631,30 +631,30 @@ Resources:
             Action:
               - sts:AssumeRole
       Policies:
-        - PolicyName: !Sub sb-${Environment}-ecs-shutdown-services-${AWS::Region}
+        - PolicyName: !Sub sb-${Environment}-ecs-shutdown-services-policy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
               - Effect: Allow
                 Action:
                   - logs:PutLogEvents
-                Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
+                Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
               - Effect: Allow
                 Action:
                   - logs:CreateLogStream
                   - logs:DescribeLogStreams
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
               - Effect: Allow
                 Action:
                   - ecs:DescribeServices
                   - ecs:UpdateService
                 Resource:
-                  - !Sub arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:service/*
+                  - !Sub arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:service/*
                 Condition:
                   StringLike:
                     ecs:cluster:
-                      - !Sub arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:cluster/sb-${Environment}-tenant*
+                      - !Sub arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:cluster/sb-${Environment}-tenant*
               - Effect: Allow
                 Action:
                   - sts:AssumeRole
@@ -684,7 +684,7 @@ Resources:
         Variables:
           SAAS_BOOST_ENV: !Ref Environment
           API_TRUST_ROLE: !GetAtt SaaSBoostSystemRole.Arn
-          API_GATEWAY_HOST: !Sub ${SaaSBoostPrivateApi}.execute-api.${AWS::Region}.amazonaws.com
+          API_GATEWAY_HOST: !Sub ${SaaSBoostPrivateApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}
           API_GATEWAY_STAGE: !Ref PrivateApiStage
           JAVA_TOOL_OPTIONS: '-XX:+TieredCompilation -XX:TieredStopAtLevel=1'
       Tags:
@@ -709,30 +709,30 @@ Resources:
             Action:
               - sts:AssumeRole
       Policies:
-        - PolicyName: !Sub sb-${Environment}-ecs-startup-services-${AWS::Region}
+        - PolicyName: !Sub sb-${Environment}-ecs-startup-services-policy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
               - Effect: Allow
                 Action:
                   - logs:PutLogEvents
-                Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
+                Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
               - Effect: Allow
                 Action:
                   - logs:CreateLogStream
                   - logs:DescribeLogStreams
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
               - Effect: Allow
                 Action:
                   - ecs:DescribeServices
                   - ecs:UpdateService
                 Resource:
-                  - !Sub arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:service/*
+                  - !Sub arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:service/*
                 Condition:
                   StringLike:
                     ecs:cluster:
-                      - !Sub arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:cluster/sb-${Environment}-tenant*
+                      - !Sub arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:cluster/sb-${Environment}-tenant*
               - Effect: Allow
                 Action:
                   - sts:AssumeRole
@@ -762,7 +762,7 @@ Resources:
         Variables:
           SAAS_BOOST_ENV: !Ref Environment
           API_TRUST_ROLE: !GetAtt SaaSBoostSystemRole.Arn
-          API_GATEWAY_HOST: !Sub ${SaaSBoostPrivateApi}.execute-api.${AWS::Region}.amazonaws.com
+          API_GATEWAY_HOST: !Sub ${SaaSBoostPrivateApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}
           API_GATEWAY_STAGE: !Ref PrivateApiStage
           JAVA_TOOL_OPTIONS: '-XX:+TieredCompilation -XX:TieredStopAtLevel=1'
       Tags:
@@ -787,7 +787,7 @@ Resources:
             Action:
               - sts:AssumeRole
       Policies:
-        - PolicyName: !Sub sb-${Environment}-set-instance-protection-${AWS::Region}
+        - PolicyName: !Sub sb-${Environment}-set-instance-protection
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -795,13 +795,13 @@ Resources:
                 Action:
                   - logs:PutLogEvents
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
               - Effect: Allow
                 Action:
                   - logs:DescribeLogStreams
                   - logs:CreateLogStream
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
               - Effect: Allow
                 Action:
                   - autoscaling:DescribeAutoScalingInstances
@@ -811,7 +811,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - autoscaling:SetInstanceProtection
-                Resource: !Sub arn:aws:autoscaling:${AWS::Region}:${AWS::AccountId}:autoScalingGroup:*:autoScalingGroupName/sb-${Environment}-tenant-*
+                Resource: !Sub arn:${AWS::Partition}:autoscaling:${AWS::Region}:${AWS::AccountId}:autoScalingGroup:*:autoScalingGroupName/sb-${Environment}-tenant-*
   SetInstanceProtectionLogs:
     Type: AWS::Logs::LogGroup
     Properties:

--- a/resources/saas-boost-metering-billing.yaml
+++ b/resources/saas-boost-metering-billing.yaml
@@ -112,7 +112,7 @@ Resources:
             Action:
               - 'sts:AssumeRole'
       Policies:
-        - PolicyName: !Sub sb-${Environment}-bill-onboard-policy-${AWS::Region}
+        - PolicyName: !Sub sb-${Environment}-bill-onboard-policy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -125,13 +125,13 @@ Resources:
                 Action:
                   - logs:PutLogEvents
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
               - Effect: Allow
                 Action:
                   - logs:CreateLogStream
                   - logs:DescribeLogStreams
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
   #####
 
   # Process billing event resources
@@ -202,7 +202,7 @@ Resources:
             Action:
               - 'sts:AssumeRole'
       Policies:
-        - PolicyName: !Sub sb-${Environment}-bill-event-process-policy-${AWS::Region}
+        - PolicyName: !Sub sb-${Environment}-bill-event-process-policy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -215,13 +215,13 @@ Resources:
                 Action:
                   - logs:PutLogEvents
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
               - Effect: Allow
                 Action:
                   - logs:CreateLogStream
                   - logs:DescribeLogStreams
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
   #####
 
   # Aggregation resources
@@ -271,7 +271,7 @@ Resources:
             Action:
               - 'sts:AssumeRole'
       Policies:
-        - PolicyName: !Sub sb-${Environment}-bill-aggregate-policy-${AWS::Region}
+        - PolicyName: !Sub sb-${Environment}-bill-aggregate-policy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -298,13 +298,13 @@ Resources:
                 Action:
                   - logs:PutLogEvents
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
               - Effect: Allow
                 Action:
                   - logs:CreateLogStream
                   - logs:DescribeLogStreams
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
   #####
 
   # Publish billing data to Stripe resources
@@ -336,7 +336,7 @@ Resources:
             Action:
               - 'sts:AssumeRole'
       Policies:
-        - PolicyName: !Sub sb-${Environment}-bill-publish-event-policy-${AWS::Region}
+        - PolicyName: !Sub sb-${Environment}-bill-publish-event-policy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -403,7 +403,7 @@ Resources:
             Action:
               - 'sts:AssumeRole'
       Policies:
-        - PolicyName: !Sub sb-${Environment}-bill-publish-policy-${AWS::Region}
+        - PolicyName: !Sub sb-${Environment}-bill-publish-policy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -447,7 +447,7 @@ Resources:
           DYNAMODB_TABLE_NAME: !Ref MeteringBillingTable
           DYNAMODB_CONFIG_INDEX_NAME: !Ref TenantConfigurationIndexName
           API_TRUST_ROLE: !Sub '{{resolve:ssm:/saas-boost/${Environment}/PRIVATE_API_TRUST_ROLE}}'
-          API_GATEWAY_HOST: !Sub ${SaaSBoostPrivateApi}.execute-api.${AWS::Region}.amazonaws.com
+          API_GATEWAY_HOST: !Sub ${SaaSBoostPrivateApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}
           API_GATEWAY_STAGE: !Ref PrivateApiStage
           SAAS_BOOST_ENV: !Ref Environment
       Handler: com.amazon.aws.partners.saasfactory.metering.aggregation.StripeBillingPublish::handleRequest
@@ -481,7 +481,7 @@ Resources:
             Action:
               - 'sts:AssumeRole'
       Policies:
-        - PolicyName: !Sub sb-${Environment}-bill-publish-external-policy-${AWS::Region}
+        - PolicyName: !Sub sb-${Environment}-bill-publish-external-policy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -505,13 +505,13 @@ Resources:
                 Action:
                   - logs:PutLogEvents
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
               - Effect: Allow
                 Action:
                   - logs:CreateLogStream
                   - logs:DescribeLogStreams
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
               - Effect: Allow
                 Action:
                   - sts:AssumeRole
@@ -589,7 +589,7 @@ Resources:
         Variables:
           SAAS_BOOST_EVENT_BUS: !Ref EventBus
           API_TRUST_ROLE: !Sub '{{resolve:ssm:/saas-boost/${Environment}/PRIVATE_API_TRUST_ROLE}}'
-          API_GATEWAY_HOST: !Sub ${SaaSBoostPrivateApi}.execute-api.${AWS::Region}.amazonaws.com
+          API_GATEWAY_HOST: !Sub ${SaaSBoostPrivateApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}
           API_GATEWAY_STAGE: !Ref PrivateApiStage
           SAAS_BOOST_ENV: !Ref Environment
           BILL_PUBLISH_EVENT: !Sub sb-${Environment}-bill-publish-event
@@ -631,7 +631,7 @@ Resources:
             Action:
               - 'sts:AssumeRole'
       Policies:
-        - PolicyName: !Sub sb-${Environment}-bill-system-policy-${AWS::Region}
+        - PolicyName: !Sub sb-${Environment}-bill-system-policy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -639,13 +639,13 @@ Resources:
                 Action:
                   - logs:PutLogEvents
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
               - Effect: Allow
                 Action:
                   - logs:CreateLogStream
                   - logs:DescribeLogStreams
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
               - Effect: Allow
                 Action:
                   - events:DescribeEventBus
@@ -653,9 +653,9 @@ Resources:
                   - events:EnableRule
                   - events:DisableRule
                 Resource:
-                  - !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:event-bus/${EventBus}
-                  - !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:event-bus/default
-                  - !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/sb-${Environment}-bill-publish-event
+                  - !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:event-bus/${EventBus}
+                  - !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:event-bus/default
+                  - !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/sb-${Environment}-bill-publish-event
               - Effect: Allow
                 Action:
                   - sts:AssumeRole
@@ -695,7 +695,7 @@ Resources:
         Variables:
           SAAS_BOOST_EVENT_BUS: !Ref EventBus
           API_TRUST_ROLE: !Sub '{{resolve:ssm:/saas-boost/${Environment}/PRIVATE_API_TRUST_ROLE}}'
-          API_GATEWAY_HOST: !Sub ${SaaSBoostPrivateApi}.execute-api.${AWS::Region}.amazonaws.com
+          API_GATEWAY_HOST: !Sub ${SaaSBoostPrivateApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}
           API_GATEWAY_STAGE: !Ref PrivateApiStage
           SAAS_BOOST_ENV: !Ref Environment
           BILL_PUBLISH_EVENT: !Sub sb-${Environment}-bill-publish-event
@@ -737,7 +737,7 @@ Resources:
             Action:
               - 'sts:AssumeRole'
       Policies:
-        - PolicyName: !Sub sb-${Environment}-bill-tenant-setup-policy-${AWS::Region}
+        - PolicyName: !Sub sb-${Environment}-bill-tenant-setup-policy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -745,20 +745,20 @@ Resources:
                 Action:
                   - logs:PutLogEvents
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
               - Effect: Allow
                 Action:
                   - logs:CreateLogStream
                   - logs:DescribeLogStreams
                   - logs:CreateLogGroup
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
               - Effect: Allow
                 Action:
                   - events:DescribeEventBus
                   - events:PutEvents
                 Resource:
-                  - !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:event-bus/${EventBus}
+                  - !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:event-bus/${EventBus}
               - Effect: Allow
                 Action:
                   - sts:AssumeRole
@@ -797,7 +797,7 @@ Resources:
         Variables:
           SAAS_BOOST_EVENT_BUS: !Ref EventBus
           API_TRUST_ROLE: !Sub '{{resolve:ssm:/saas-boost/${Environment}/PRIVATE_API_TRUST_ROLE}}'
-          API_GATEWAY_HOST: !Sub ${SaaSBoostPrivateApi}.execute-api.${AWS::Region}.amazonaws.com
+          API_GATEWAY_HOST: !Sub ${SaaSBoostPrivateApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}
           API_GATEWAY_STAGE: !Ref PrivateApiStage
           SAAS_BOOST_ENV: !Ref Environment
       Handler: com.amazon.aws.partners.saasfactory.metering.onboarding.BillingIntegration::disableTenantBillingListener
@@ -838,7 +838,7 @@ Resources:
             Action:
               - 'sts:AssumeRole'
       Policies:
-        - PolicyName: !Sub sb-${Environment}-bill-tenant-setup-policy-${AWS::Region}
+        - PolicyName: !Sub sb-${Environment}-bill-tenant-setup-policy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -846,19 +846,19 @@ Resources:
                 Action:
                   - logs:PutLogEvents
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
               - Effect: Allow
                 Action:
                   - logs:CreateLogStream
                   - logs:DescribeLogStreams
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
               - Effect: Allow
                 Action:
                   - events:DescribeEventBus
                   - events:PutEvents
                 Resource:
-                  - !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:event-bus/${EventBus}
+                  - !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:event-bus/${EventBus}
               - Effect: Allow
                 Action:
                   - sts:AssumeRole

--- a/resources/saas-boost-metrics-analytics.yaml
+++ b/resources/saas-boost-metrics-analytics.yaml
@@ -275,79 +275,17 @@ Resources:
     DeletionPolicy: Delete
     UpdateReplacePolicy: Retain
     Properties:
-      Description: KMS key generated to encrypt Kinesis data.
+      Description: KMS key used to encrypt Kinesis Firehose data.
       EnableKeyRotation: true
       KeyPolicy:
         Id: !Sub sb-${Environment}-kms-metrics-policy
         Version: '2012-10-17'
         Statement:
-          - Sid: Enable IAM User Permissions
-            Effect: Allow
+          - Effect: Allow
             Principal:
-              AWS:
-                - !Join
-                  - ''
-                  - - 'arn:aws:iam::'
-                    - !Ref 'AWS::AccountId'
-                    - :root
+              AWS: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:root
             Action: kms:*
             Resource: '*'
-          - Sid: Allow access for Key Administrators
-            Effect: Allow
-            Principal:
-              AWS:
-                - !Join
-                  - ''
-                  - - 'arn:aws:iam::'
-                    - !Ref 'AWS::AccountId'
-                    - :root
-            Action:
-              - kms:Create*
-              - kms:Describe*
-              - kms:Enable*
-              - kms:List*
-              - kms:Put*
-              - kms:Update*
-              - kms:Revoke*
-              - kms:Disable*
-              - kms:Get*
-              - kms:Delete*
-              - kms:ScheduleKeyDeletion
-              - kms:CancelKeyDeletion
-            Resource: '*'
-          - Sid: Allow use of the key
-            Effect: Allow
-            Principal:
-              AWS:
-                - !Join
-                  - ''
-                  - - 'arn:aws:iam::'
-                    - !Ref 'AWS::AccountId'
-                    - :root
-            Action:
-              - kms:Encrypt
-              - kms:Decrypt
-              - kms:ReEncrypt*
-              - kms:GenerateDataKey*
-              - kms:DescribeKey
-            Resource: '*'
-          - Sid: Allow attachment of persistent resources
-            Effect: Allow
-            Principal:
-              AWS:
-                - !Join
-                  - ''
-                  - - 'arn:aws:iam::'
-                    - !Ref 'AWS::AccountId'
-                    - :root
-            Action:
-              - kms:CreateGrant
-              - kms:ListGrants
-              - kms:RevokeGrant
-            Resource: '*'
-            Condition:
-              Bool:
-                kms:GrantIsForAWSResource: true
   KMSAlias:
     Type: AWS::KMS::Alias
     Properties:
@@ -381,8 +319,8 @@ Resources:
             Action: s3:*
             Principal: '*'
             Resource:
-              - !Sub arn:aws:s3:::${MetricsBucket}/*
-              - !Sub arn:aws:s3:::${MetricsBucket}
+              - !Sub arn:${AWS::Partition}:s3:::${MetricsBucket}/*
+              - !Sub arn:${AWS::Partition}:s3:::${MetricsBucket}
             Condition:
               Bool: { 'aws:SecureTransport': false }
   RedshiftCluster:
@@ -402,12 +340,7 @@ Resources:
         - !GetAtt RedshiftClusterRole.Arn
       MasterUsername:
         Ref: MetricUser
-      MasterUserPassword:
-        Fn::Join:
-          - ''
-          - - '{{resolve:ssm-secure:'
-            - !Ref MetricUserPasswordSSMParameter
-            - '}}'
+      MasterUserPassword: !Sub '{{resolve:ssm-secure:${MetricUserPasswordSSMParameter}}}'
       ClusterParameterGroupName:
         Ref: RedshiftClusterParameterGroup
       VpcSecurityGroupIds:
@@ -485,7 +418,7 @@ Resources:
               StringEquals:
                 sts:ExternalId: !Ref 'AWS::AccountId'
       Policies:
-        - PolicyName: !Sub sb-${Environment}-redshift-policy-${AWS::Region}
+        - PolicyName: !Sub sb-${Environment}-redshift-policy
           PolicyDocument:
             Version: '2012-10-17'
             Statement:
@@ -499,12 +432,12 @@ Resources:
                   - s3:GetBucketAcl
                   - s3:ListAllMyBuckets
                 Resource:
-                  - !Sub arn:aws:s3:::${MetricsBucket}
-                  - !Sub arn:aws:s3:::${MetricsBucket}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${MetricsBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${MetricsBucket}/*
   FirehoseDeliveryRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub sb-${Environment}-firehose-name-${AWS::Region}
+      RoleName: !Sub sb-${Environment}-firehose-role-${AWS::Region}
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -518,12 +451,11 @@ Resources:
               StringEquals:
                 sts:ExternalId: !Ref 'AWS::AccountId'
       Policies:
-        - PolicyName: !Sub sb-${Environment}-firehose-delivery-${AWS::Region}
+        - PolicyName: !Sub sb-${Environment}-firehose
           PolicyDocument:
             Version: '2012-10-17'
             Statement:
-              - Sid: ''
-                Effect: Allow
+              - Effect: Allow
                 Action:
                   - s3:AbortMultipartUpload
                   - s3:GetBucketLocation
@@ -534,52 +466,28 @@ Resources:
                   - s3:GetBucketAcl
                   - s3:ListAllMyBuckets
                 Resource:
-                  - !Join
-                    - ''
-                    - - 'arn:aws:s3:::'
-                      - !Ref 'MetricsBucket'
-                  - !Join
-                    - ''
-                    - - 'arn:aws:s3:::'
-                      - !Ref 'MetricsBucket'
-                      - /*
-              - Sid: ''
-                Effect: Allow
+                  - !Sub arn:${AWS::Partition}:s3:::${MetricsBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${MetricsBucket}/*
+              - Effect: Allow
                 Action:
                   - kms:Decrypt
                   - kms:GenerateDataKey
                 Resource:
                   - !If
                     - NoEncryption
-                    - !Join
-                      - ''
-                      - - 'arn:aws:kms:'
-                        - !Ref 'AWS::Region'
-                        - ':'
-                        - !Ref 'AWS::AccountId'
-                        - :key/placeholder-kms-id
+                    - !Sub arn:${AWS::Partition}:kms:${AWS::AccountId}:key/placeholder-kms-id
                     - !GetAtt 'EncryptionKey.Arn'
                 Condition:
                   StringEquals:
-                    kms:ViaService: !Join
-                      - ''
-                      - - s3.
-                        - !Ref 'AWS::Region'
-                        - .amazonaws.com
+                    kms:ViaService: !Sub s3.${AWS::Region}.amazonaws.com
                   StringLike:
-                    kms:EncryptionContext:aws:s3:arn: !Join
-                      - ''
-                      - - 'arn:aws:s3:::'
-                        - !Ref 'MetricsBucket'
-                        - /RedshiftDelivery/*
-              - Sid: ''
-                Effect: Allow
+                    kms:EncryptionContext:aws:s3:arn: !Sub arn:${AWS::Partition}:s3:::${MetricsBucket}/RedshiftDelivery/*
+              - Effect: Allow
                 Action:
                   - logs:PutLogEvents
                 Resource:
                   - '*'
-              - Sid: ''
-                Effect: Allow
+              - Effect: Allow
                 Action:
                   - kinesis:Get*
                   - kinesis:Describe*
@@ -596,30 +504,17 @@ Resources:
       RedshiftDestinationConfiguration:
         ClusterJDBCURL: !Sub "jdbc:redshift://${RedshiftCluster.Endpoint.Address}:${RedshiftCluster.Endpoint.Port}/${DatabaseName}"
         CopyCommand:
-          CopyOptions: !Join
-                        - ''
-                        - - "gzip compupdate off STATUPDATE ON TIMEFORMAT 'epochsecs' "
-                          - "json 's3://"
-                          - !Ref 'MetricsBucket'
-                          - "/metrics_redshift_jsonpath.json'"
+          CopyOptions: !Sub "GZIP COMPUPDATE OFF STATUPDATE ON TIMEFORMAT 'epochsecs' JSON s3://${MetricsBucket}/metrics_redshift_jsonpath.json"
           DataTableName: !Ref 'MetricsTableName'
         Username: !Ref 'MetricUser'
-        Password:
-          Fn::Join:
-            - ''
-            - - '{{resolve:ssm-secure:'
-              - !Ref MetricUserPasswordSSMParameter
-              - '}}'
+        Password: !Sub '{{resolve:ssm-secure:${MetricUserPasswordSSMParameter}}}'
         CloudWatchLoggingOptions:
           Enabled: true
           LogGroupName: !Ref RSCloudwatchLogsGroup
           LogStreamName: !Ref RSLogStream
         RoleARN: !GetAtt 'FirehoseDeliveryRole.Arn'
         S3Configuration:
-          BucketARN: !Join
-            - ''
-            - - 'arn:aws:s3:::'
-              - !Ref 'MetricsBucket'
+          BucketARN: !Sub arn:${AWS::Partition}:s3:::${MetricsBucket}
           RoleARN: !GetAtt 'FirehoseDeliveryRole.Arn'
           BufferingHints:
             IntervalInSeconds: !Ref 'KinesisBufferInterval'
@@ -667,7 +562,7 @@ Resources:
             Action:
               - sts:AssumeRole
       Policies:
-        - PolicyName: !Sub sb-${Environment}-redshift-exec-policy-${AWS::Region}
+        - PolicyName: !Sub sb-${Environment}-redshift-exec-policy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -675,14 +570,14 @@ Resources:
                 Action:
                   - logs:PutLogEvents
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
               - Effect: Allow
                 Action:
                   - logs:DescribeLogGroups
                   - logs:DescribeLogStreams
                   - logs:CreateLogStream
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
               - Effect: Allow
                 Action:
                   - ec2:CreateNetworkInterface
@@ -692,7 +587,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - ssm:GetParameter
-                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/saas-boost/${Environment}/REDSHIFT_MASTER_PASSWORD
+                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/saas-boost/${Environment}/REDSHIFT_MASTER_PASSWORD
   LambdaSG:
     Type: AWS::EC2::SecurityGroup
     Properties:

--- a/resources/saas-boost-metrics-analytics.yaml
+++ b/resources/saas-boost-metrics-analytics.yaml
@@ -475,11 +475,11 @@ Resources:
                 Resource:
                   - !If
                     - NoEncryption
-                    - !Sub arn:${AWS::Partition}:kms:${AWS::AccountId}:key/placeholder-kms-id
+                    - !Sub arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/placeholder-kms-id
                     - !GetAtt 'EncryptionKey.Arn'
                 Condition:
                   StringEquals:
-                    kms:ViaService: !Sub s3.${AWS::Region}.amazonaws.com
+                    kms:ViaService: !Sub s3.${AWS::Region}.${AWS::URLSuffix}
                   StringLike:
                     kms:EncryptionContext:aws:s3:arn: !Sub arn:${AWS::Partition}:s3:::${MetricsBucket}/RedshiftDelivery/*
               - Effect: Allow

--- a/resources/saas-boost-private-api.yaml
+++ b/resources/saas-boost-private-api.yaml
@@ -71,7 +71,7 @@ Resources:
             Action:
               - sts:AssumeRole
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
   ApiGatewayLoggingAccount:
     Type: AWS::ApiGateway::Account
     Properties:
@@ -98,7 +98,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${QuotasServiceCheck}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${QuotasServiceCheck}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
       MethodResponses:
         - StatusCode: '200'
@@ -111,7 +111,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref QuotasServiceCheck
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PrivateApi}/*/GET/quotas/check
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PrivateApi}/*/GET/quotas/check
   QuotaServiceCheckResourceCORS:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -165,7 +165,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${TenantServiceById}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${TenantServiceById}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
         RequestParameters: {integration.request.path.id: 'method.request.path.id'}
       MethodResponses:
@@ -179,7 +179,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref TenantServiceById
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PrivateApi}/*/GET/tenants/{id}
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PrivateApi}/*/GET/tenants/{id}
   TenantServiceGetAllMethod:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -190,7 +190,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${TenantServiceGetAll}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${TenantServiceGetAll}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
       MethodResponses:
         - StatusCode: '200'
@@ -203,7 +203,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref TenantServiceGetAll
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PrivateApi}/*/GET/tenants
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PrivateApi}/*/GET/tenants
   TenantServiceDeleteMethod:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -215,7 +215,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${TenantServiceDelete}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${TenantServiceDelete}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
         RequestParameters: {integration.request.path.id: 'method.request.path.id'}
       MethodResponses:
@@ -229,7 +229,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref TenantServiceDelete
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PrivateApi}/*/DELETE/tenants/{id}
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PrivateApi}/*/DELETE/tenants/{id}
   TenantServiceInsertMethod:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -240,7 +240,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${TenantServiceInsert}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${TenantServiceInsert}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
       MethodResponses:
         - StatusCode: '200'
@@ -253,7 +253,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref TenantServiceInsert
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PrivateApi}/*/POST/tenants
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PrivateApi}/*/POST/tenants
   TenantServiceResourceCORS:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -348,7 +348,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SettingsServiceGetAll}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SettingsServiceGetAll}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
       MethodResponses:
         - StatusCode: '200'
@@ -361,7 +361,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref SettingsServiceGetAll
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PrivateApi}/*/GET/settings
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PrivateApi}/*/GET/settings
   SettingsServiceResourceCORS:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -403,7 +403,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SettingsServiceGetSecret}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SettingsServiceGetSecret}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
         RequestParameters: {integration.request.path.id: 'method.request.path.id'}
       MethodResponses:
@@ -417,7 +417,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref SettingsServiceGetSecret
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PrivateApi}/*/GET/settings/{id}/secret
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PrivateApi}/*/GET/settings/{id}/secret
   SettingsServiceSecretResourceCORS:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -458,7 +458,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SettingsServiceGetAppConfig}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SettingsServiceGetAppConfig}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
       MethodResponses:
         - StatusCode: '200'
@@ -471,7 +471,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref SettingsServiceGetAppConfig
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PrivateApi}/*/GET/settings/config
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PrivateApi}/*/GET/settings/config
   SettingsServiceDeleteAppConfigMethod:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -482,7 +482,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SettingsServiceDeleteAppConfig}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SettingsServiceDeleteAppConfig}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
       MethodResponses:
         - StatusCode: '200'
@@ -495,7 +495,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref SettingsServiceDeleteAppConfig
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PrivateApi}/*/DELETE/settings/config
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PrivateApi}/*/DELETE/settings/config
   SettingsServiceConfigResourceCORS:
     Type: AWS::ApiGateway::Method
     Properties:

--- a/resources/saas-boost-public-api.yaml
+++ b/resources/saas-boost-public-api.yaml
@@ -140,7 +140,7 @@ Resources:
             Action:
               - sts:AssumeRole
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
   ApiGatewayLoggingAccount:
     Type: AWS::ApiGateway::Account
     Properties:
@@ -152,7 +152,7 @@ Resources:
       RestApiId: !Ref PublicApi
       Type: COGNITO_USER_POOLS
       ProviderARNs:
-        - !Sub arn:aws:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/${CognitoUserPoolId}
+        - !Sub arn:${AWS::Partition}:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/${CognitoUserPoolId}
       IdentitySource: method.request.header.Authorization
   BillingServiceResource:
     Type: AWS::ApiGateway::Resource
@@ -209,7 +209,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${BillingServiceGetPlans}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${BillingServiceGetPlans}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
       MethodResponses:
         - StatusCode: '200'
@@ -222,7 +222,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref BillingServiceGetPlans
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/GET/billing/plans
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/GET/billing/plans
   MetricsServiceResource:
     Type: AWS::ApiGateway::Resource
     Properties:
@@ -278,7 +278,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MetricsServiceQuery}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MetricsServiceQuery}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
       MethodResponses:
         - StatusCode: '200'
@@ -291,7 +291,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref MetricsServiceQuery
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/POST/metrics/query
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/POST/metrics/query
   MetricsServiceQueryResourceCORS:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -335,7 +335,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MetricsServiceDatasets}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MetricsServiceDatasets}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
       MethodResponses:
         - StatusCode: '200'
@@ -348,7 +348,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref MetricsServiceDatasets
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/GET/metrics/datasets
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/GET/metrics/datasets
   MetricsServiceDatasetsResourceCORS:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -395,7 +395,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MetricsServiceAlbQuery}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MetricsServiceAlbQuery}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
         RequestParameters:
           integration.request.path.metric: 'method.request.path.metric'
@@ -411,7 +411,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref MetricsServiceAlbQuery
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/GET/metrics/alb/{metric}/{timerange}
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/GET/metrics/alb/{metric}/{timerange}
   MetricsServiceAlbQueryResourceCORS:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -459,7 +459,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MetricsServiceAlbQuery}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MetricsServiceAlbQuery}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
         RequestParameters:
           integration.request.path.metric: 'method.request.path.metric'
@@ -476,7 +476,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref MetricsServiceAlbQuery
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/GET/metrics/alb/{metric}/{timerange}/{id}
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/GET/metrics/alb/{metric}/{timerange}/{id}
   MetricsServiceAlbQueryByTenantIdResourceCORS:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -532,7 +532,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${OnboardingServiceGetAll}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${OnboardingServiceGetAll}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
       MethodResponses:
         - StatusCode: '200'
@@ -545,7 +545,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref OnboardingServiceGetAll
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/GET/onboarding
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/GET/onboarding
   OnboardingServiceStartMethod:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -559,7 +559,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${OnboardingServiceStart}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${OnboardingServiceStart}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
       MethodResponses:
         - StatusCode: '200'
@@ -572,7 +572,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref OnboardingServiceStart
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/POST/onboarding
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/POST/onboarding
   OnboardingServiceResourceCORS:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -617,7 +617,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${OnboardingServiceById}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${OnboardingServiceById}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
         RequestParameters: {integration.request.path.id: 'method.request.path.id'}
       MethodResponses:
@@ -631,7 +631,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref OnboardingServiceById
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/GET/onboarding/{id}
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/GET/onboarding/{id}
   OnboardingServiceByIdResourceCORS:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -699,7 +699,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SettingsServiceGetAll}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SettingsServiceGetAll}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
       MethodResponses:
         - StatusCode: '200'
@@ -712,7 +712,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref SettingsServiceGetAll
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/GET/settings
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/GET/settings
   SettingsServiceResourceCORS:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -756,7 +756,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SettingsServiceOptions}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SettingsServiceOptions}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
       MethodResponses:
         - StatusCode: '200'
@@ -769,7 +769,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref SettingsServiceOptions
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/GET/settings/options
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/GET/settings/options
   SettingsServiceOptionsResourceCORS:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -813,7 +813,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SettingsServiceGetAppConfig}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SettingsServiceGetAppConfig}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
       MethodResponses:
         - StatusCode: '200'
@@ -826,7 +826,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref SettingsServiceGetAppConfig
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/GET/settings/config
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/GET/settings/config
   SettingsServiceUpdateAppConfigMethod:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -840,7 +840,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SettingsServiceUpdateAppConfig}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SettingsServiceUpdateAppConfig}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
       MethodResponses:
         - StatusCode: '200'
@@ -853,7 +853,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref SettingsServiceUpdateAppConfig
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/PUT/settings/config
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/PUT/settings/config
   SettingsServiceConfigResourceCORS:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -898,7 +898,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SettingsServiceById}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SettingsServiceById}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
         RequestParameters: {integration.request.path.id: 'method.request.path.id'}
       MethodResponses:
@@ -912,7 +912,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref SettingsServiceById
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/GET/settings/{id}
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/GET/settings/{id}
   SettingsServiceByIdResourceCORS:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -980,7 +980,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${TenantServiceGetAll}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${TenantServiceGetAll}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
       MethodResponses:
         - StatusCode: '200'
@@ -993,7 +993,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref TenantServiceGetAll
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/GET/tenants
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/GET/tenants
   TenantServiceResourceCORS:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -1038,7 +1038,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${TenantServiceById}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${TenantServiceById}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
         RequestParameters: {integration.request.path.id: 'method.request.path.id'}
       MethodResponses:
@@ -1052,7 +1052,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref TenantServiceById
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/GET/tenants/{id}
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/GET/tenants/{id}
   TenantServiceUpdateMethod:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -1067,7 +1067,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${TenantServiceUpdate}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${TenantServiceUpdate}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
         RequestParameters: {integration.request.path.id: 'method.request.path.id'}
       MethodResponses:
@@ -1081,7 +1081,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref TenantServiceUpdate
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/PUT/tenants/{id}
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/PUT/tenants/{id}
   TenantServiceDeleteMethod:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -1096,7 +1096,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${TenantServiceDelete}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${TenantServiceDelete}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
         RequestParameters: {integration.request.path.id: 'method.request.path.id'}
       MethodResponses:
@@ -1110,7 +1110,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref TenantServiceDelete
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/DELETE/tenants/{id}
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/DELETE/tenants/{id}
   TenantServiceByIdResourceCORS:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -1155,7 +1155,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${TenantServiceEnable}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${TenantServiceEnable}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
         RequestParameters: {integration.request.path.id: 'method.request.path.id'}
       MethodResponses:
@@ -1169,7 +1169,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref TenantServiceEnable
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/PATCH/tenants/{id}/enable
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/PATCH/tenants/{id}/enable
   TenantServiceEnableResourceCORS:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -1214,7 +1214,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${TenantServiceDisable}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${TenantServiceDisable}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
         RequestParameters: {integration.request.path.id: 'method.request.path.id'}
       MethodResponses:
@@ -1228,7 +1228,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref TenantServiceDisable
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/PATCH/tenants/{id}/disable
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/PATCH/tenants/{id}/disable
   TenantServiceDisableResourceCORS:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -1345,7 +1345,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${TierServiceGetAll}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${TierServiceGetAll}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
         RequestParameters: {integration.request.path.id: 'method.request.path.id'}
       MethodResponses:
@@ -1359,7 +1359,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref TierServiceGetAll
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/GET/tiers
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/GET/tiers
   TierServiceCreateMethod:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -1374,7 +1374,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${TierServiceCreate}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${TierServiceCreate}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
         RequestParameters: {integration.request.path.id: 'method.request.path.id'}
       MethodResponses:
@@ -1388,7 +1388,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref TierServiceCreate
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/POST/tiers
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/POST/tiers
   TierServiceGetByIdMethod:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -1403,7 +1403,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${TierServiceGetById}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${TierServiceGetById}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
         RequestParameters: {integration.request.path.id: 'method.request.path.id'}
       MethodResponses:
@@ -1417,7 +1417,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref TierServiceGetById
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/GET/tiers/{id}
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/GET/tiers/{id}
   TierServiceUpdateMethod:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -1432,7 +1432,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${TierServiceUpdate}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${TierServiceUpdate}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
         RequestParameters: {integration.request.path.id: 'method.request.path.id'}
       MethodResponses:
@@ -1446,7 +1446,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref TierServiceUpdate
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/PUT/tiers/{id}
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/PUT/tiers/{id}
   TierServiceDeleteMethod:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -1461,7 +1461,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${TierServiceDelete}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${TierServiceDelete}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
         RequestParameters: {integration.request.path.id: 'method.request.path.id'}
       MethodResponses:
@@ -1475,7 +1475,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref TierServiceDelete
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/DELETE/tiers/{id}
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/DELETE/tiers/{id}
   UserServiceResource:
     Type: AWS::ApiGateway::Resource
     Properties:
@@ -1519,7 +1519,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${UserServiceGetAll}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${UserServiceGetAll}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
       MethodResponses:
         - StatusCode: '200'
@@ -1532,7 +1532,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref UserServiceGetAll
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/GET/users
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/GET/users
   UserServiceInsertMethod:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -1546,7 +1546,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${UserServiceInsert}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${UserServiceInsert}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
       MethodResponses:
         - StatusCode: '200'
@@ -1559,7 +1559,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref UserServiceInsert
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/POST/users
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/POST/users
   UserServiceResourceCORS:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -1604,7 +1604,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${UserServiceById}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${UserServiceById}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
         RequestParameters: {integration.request.path.id: 'method.request.path.id'}
       MethodResponses:
@@ -1618,7 +1618,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref UserServiceById
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/GET/users/{id}
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/GET/users/{id}
   UserServiceUpdateMethod:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -1633,7 +1633,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${UserServiceUpdate}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${UserServiceUpdate}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
         RequestParameters: {integration.request.path.id: 'method.request.path.id'}
       MethodResponses:
@@ -1647,7 +1647,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref UserServiceUpdate
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/PUT/users/{id}
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/PUT/users/{id}
   UserServiceDeleteMethod:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -1662,7 +1662,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${UserServiceDelete}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${UserServiceDelete}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
         RequestParameters: {integration.request.path.id: 'method.request.path.id'}
       MethodResponses:
@@ -1676,7 +1676,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref UserServiceDelete
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/DELETE/users/{id}
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/DELETE/users/{id}
   UserServiceByIdResourceCORS:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -1721,7 +1721,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${UserServiceEnable}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${UserServiceEnable}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
         RequestParameters: {integration.request.path.id: 'method.request.path.id'}
       MethodResponses:
@@ -1735,7 +1735,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref UserServiceEnable
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/PATCH/users/{id}/enable
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/PATCH/users/{id}/enable
   UserServiceEnableResourceCORS:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -1780,7 +1780,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${UserServiceDisable}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${UserServiceDisable}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
         RequestParameters: {integration.request.path.id: 'method.request.path.id'}
       MethodResponses:
@@ -1794,7 +1794,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref UserServiceDisable
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/PATCH/users/{id}/disable
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/PATCH/users/{id}/disable
   UserServiceDisableResourceCORS:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -1835,7 +1835,7 @@ Resources:
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${UserServiceToken}/invocations
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${UserServiceToken}/invocations
         PassthroughBehavior: WHEN_NO_MATCH
       MethodResponses:
         - StatusCode: '200'
@@ -1848,7 +1848,7 @@ Resources:
       Principal: apigateway.amazonaws.com
       Action: lambda:InvokeFunction
       FunctionName: !Ref UserServiceToken
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/POST/users/token
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PublicApi}/*/POST/users/token
   UserServiceTokenResourceCORS:
     Type: AWS::ApiGateway::Method
     Properties:
@@ -1946,7 +1946,7 @@ Resources:
 Outputs:
   PublicApiGatewayEndpoint:
     Description: SaaS Boost Admin PI Gateway Invoke URL
-    Value: !Sub 'https://${PublicApi}.execute-api.${AWS::Region}.amazonaws.com/${ApiStage}'
+    Value: !Sub 'https://${PublicApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/${ApiStage}'
     Export:
       Name: !Sub saas-boost::${Environment}-${AWS::Region}:publicApiUrl
 ...

--- a/resources/saas-boost-svc-billing.yaml
+++ b/resources/saas-boost-svc-billing.yaml
@@ -46,7 +46,7 @@ Resources:
             Action:
               - sts:AssumeRole
       Policies:
-        - PolicyName: !Sub sb-${Environment}-billing-service-policy-${AWS::Region}
+        - PolicyName: !Sub sb-${Environment}-billing-service-policy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -54,13 +54,13 @@ Resources:
                 Action:
                   - logs:PutLogEvents
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
               - Effect: Allow
                 Action:
                   - logs:CreateLogStream
                   - logs:DescribeLogStreams
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
   BillingServiceGetPlansLogs:
     Type: AWS::Logs::LogGroup
     Properties:

--- a/resources/saas-boost-svc-metrics.yaml
+++ b/resources/saas-boost-svc-metrics.yaml
@@ -104,15 +104,15 @@ Resources:
             Effect: Allow
             Principal:
               AWS:
-                Fn::Join: ['', ['arn:aws:iam::', !FindInMap [Region2ELBAccountId, !Ref 'AWS::Region', 'AccountId'], ':root']]
+                Fn::Join: ['', ['arn:', !Ref 'AWS::Partition', ':iam::', !FindInMap [Region2ELBAccountId, !Ref 'AWS::Region', 'AccountId'], ':root']]
             Action: s3:PutObject
-            Resource: !Sub arn:aws:s3:::${AccessLogs}/access-logs/AWSLogs/${AWS::AccountId}/*
+            Resource: !Sub arn:${AWS::Partition}:s3:::${AccessLogs}/access-logs/AWSLogs/${AWS::AccountId}/*
           - Sid: AWSLogDeliveryWrite
             Effect: Allow
             Principal:
               Service: delivery.logs.amazonaws.com
             Action: s3:PutObject
-            Resource: !Sub arn:aws:s3:::${AccessLogs}/access-logs/AWSLogs/${AWS::AccountId}/*
+            Resource: !Sub arn:${AWS::Partition}:s3:::${AccessLogs}/access-logs/AWSLogs/${AWS::AccountId}/*
             Condition:
               StringEquals:
                 s3:x-amz-acl: bucket-owner-full-control
@@ -121,14 +121,14 @@ Resources:
             Principal:
               Service: delivery.logs.amazonaws.com
             Action: s3:GetBucketAcl
-            Resource: !Sub arn:aws:s3:::${AccessLogs}
+            Resource: !Sub arn:${AWS::Partition}:s3:::${AccessLogs}
           - Sid: DenyNonHttps
             Effect: Deny
             Action: s3:*
             Principal: '*'
             Resource:
-              - !Sub arn:aws:s3:::${AccessLogs}/*
-              - !Sub arn:aws:s3:::${AccessLogs}
+              - !Sub arn:${AWS::Partition}:s3:::${AccessLogs}/*
+              - !Sub arn:${AWS::Partition}:s3:::${AccessLogs}
             Condition:
               Bool: { 'aws:SecureTransport': false }
   AccessLogsDatabase:
@@ -238,7 +238,7 @@ Resources:
             Action:
               - sts:AssumeRole
       Policies:
-        - PolicyName: !Sub sb-${Environment}-metrics-svc-policy-${AWS::Region}
+        - PolicyName: !Sub sb-${Environment}-metrics-svc-policy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -246,13 +246,13 @@ Resources:
                 Action:
                   - logs:PutLogEvents
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
               - Effect: Allow
                 Action:
                   - logs:CreateLogStream
                   - logs:DescribeLogStreams
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
               - Effect: Allow
                 Action:
                   - athena:ListDataCatalogs
@@ -267,8 +267,8 @@ Resources:
                   - s3:ListBucket
                   - s3:ListBucketMultipartUploads
                 Resource:
-                  - !Sub arn:aws:s3:::${AthenaOutput}
-                  - !Sub arn:aws:s3:::${AccessLogs}
+                  - !Sub arn:${AWS::Partition}:s3:::${AthenaOutput}
+                  - !Sub arn:${AWS::Partition}:s3:::${AccessLogs}
               - Effect: Allow
                 Action:
                   - s3:AbortMultipartUpload
@@ -276,23 +276,23 @@ Resources:
                   - s3:ListMultipartUploadParts
                   - s3:PutObject
                 Resource:
-                  - !Sub arn:aws:s3:::${AthenaOutput}/*
-                  - !Sub arn:aws:s3:::${AccessLogs}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${AthenaOutput}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${AccessLogs}/*
               - Effect: Allow
                 Action:
                   - glue:GetTable
                   - glue:GetDatabase
                   - glue:GetPartitions
                 Resource:
-                  - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:database/${AccessLogsDatabase}
-                  - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:table/${AccessLogsDatabase}/${AccessLogsTable}
-                  - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:catalog
-                  - !Sub arn:aws:athena:${AWS::Region}:${AWS::AccountId}:workgroup/primary
+                  - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:database/${AccessLogsDatabase}
+                  - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:table/${AccessLogsDatabase}/${AccessLogsTable}
+                  - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:catalog
+                  - !Sub arn:${AWS::Partition}:athena:${AWS::Region}:${AWS::AccountId}:workgroup/primary
               - Effect: Allow
                 Action:
                   - athena:*
                 Resource:
-                  - !Sub arn:aws:athena:${AWS::Region}:${AWS::AccountId}:workgroup/primary
+                  - !Sub arn:${AWS::Partition}:athena:${AWS::Region}:${AWS::AccountId}:workgroup/primary
               - Effect: Allow
                 Action:
                   - sts:AssumeRole
@@ -421,7 +421,7 @@ Resources:
           S3_ATHENA_OUTPUT_PATH: !Sub s3://${AthenaOutput}/query-results/
           ACCESS_LOGS_TABLE: !Ref AccessLogsTable
           API_TRUST_ROLE: !Sub '{{resolve:ssm:/saas-boost/${Environment}/PRIVATE_API_TRUST_ROLE}}'
-          API_GATEWAY_HOST: !Sub ${SaaSBoostPrivateApi}.execute-api.${AWS::Region}.amazonaws.com
+          API_GATEWAY_HOST: !Sub ${SaaSBoostPrivateApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}
           API_GATEWAY_STAGE: !Ref PrivateApiStage
       Tags:
         - Key: "Application"
@@ -489,7 +489,7 @@ Resources:
           S3_ATHENA_OUTPUT_PATH: !Sub s3://${AthenaOutput}/query-results/
           ACCESS_LOGS_TABLE: !Ref AccessLogsTable
           API_TRUST_ROLE: !Sub '{{resolve:ssm:/saas-boost/${Environment}/PRIVATE_API_TRUST_ROLE}}'
-          API_GATEWAY_HOST: !Sub ${SaaSBoostPrivateApi}.execute-api.${AWS::Region}.amazonaws.com
+          API_GATEWAY_HOST: !Sub ${SaaSBoostPrivateApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}
           API_GATEWAY_STAGE: !Ref PrivateApiStage
       Tags:
         - Key: "Application"

--- a/resources/saas-boost-svc-onboarding.yaml
+++ b/resources/saas-boost-svc-onboarding.yaml
@@ -347,7 +347,7 @@ Resources:
             Action:
               - sns:Publish
             Resource:
-              - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:sb-*
+              - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:sb-${Environment}-onboarding*
           - Effect: Allow
             Action:
               - ssm:GetParameter*

--- a/resources/saas-boost-svc-onboarding.yaml
+++ b/resources/saas-boost-svc-onboarding.yaml
@@ -172,26 +172,26 @@ Resources:
             Action:
               - sts:AssumeRole
       Policies:
-        - PolicyName: !Sub sb-${Environment}-populate-ddb-policy-${AWS::Region}
+        - PolicyName: !Sub sb-${Environment}-populate-ddb-policy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
               - Effect: Allow
                 Action:
                   - logs:PutLogEvents
-                Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
+                Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
               - Effect: Allow
                 Action:
                   - logs:CreateLogStream
                   - logs:DescribeLogStreams
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
               - Effect: Allow
                 Action:
                   - dynamodb:Scan
                   - dynamodb:BatchWriteItem
                 Resource:
-                  - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${CidrBlockTable}
+                  - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${CidrBlockTable}
   PopulateDynamoDBLogs:
     Type: AWS::Logs::LogGroup
     Properties:
@@ -233,14 +233,14 @@ Resources:
             Action:
               - logs:PutLogEvents
             Resource:
-              - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
+              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
           - Effect: Allow
             Action:
               - logs:DescribeLogGroups
               - logs:DescribeLogStreams
               - logs:CreateLogStream
             Resource:
-              - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
           - Effect: Allow
             Action:
               - dynamodb:DescribeTable
@@ -251,27 +251,27 @@ Resources:
               - dynamodb:Query
               - dynamodb:UpdateItem
             Resource:
-              - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${OnboardingTable}
-              - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${CidrBlockTable}
+              - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${OnboardingTable}
+              - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${CidrBlockTable}
           - Effect: Allow
             Action:
               - s3:ListBucket
             Resource:
-              - !Sub arn:aws:s3:::${SaaSBoostBucket}
-              - !Sub arn:aws:s3:::${ResourcesBucket}
+              - !Sub arn:${AWS::Partition}:s3:::${SaaSBoostBucket}
+              - !Sub arn:${AWS::Partition}:s3:::${ResourcesBucket}
           - Effect: Allow
             Action:
               - s3:Get*
               - s3:PutObject
               - s3:DeleteObject
             Resource:
-              - !Sub arn:aws:s3:::${SaaSBoostBucket}/*
-              - !Sub arn:aws:s3:::${ResourcesBucket}/*
+              - !Sub arn:${AWS::Partition}:s3:::${SaaSBoostBucket}/*
+              - !Sub arn:${AWS::Partition}:s3:::${ResourcesBucket}/*
           - Effect: Allow
             Action:
               - events:PutEvents
             Resource:
-              - !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:event-bus/${SaaSBoostEventBus}
+              - !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:event-bus/${SaaSBoostEventBus}
           - Effect: Allow
             Action:
               - events:DescribeRule
@@ -280,7 +280,7 @@ Resources:
               - events:PutTargets
               - events:RemoveTargets
             Resource:
-              - !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/*
+              - !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/*
           - Effect: Allow
             Action:
               - sqs:SendMessage
@@ -308,12 +308,12 @@ Resources:
               - ecr:CreateRepository
               - ecr:DeleteRepository
             Resource:
-              - !Sub arn:aws:ecr:${AWS::Region}:${AWS::AccountId}:repository/*
+              - !Sub arn:${AWS::Partition}:ecr:${AWS::Region}:${AWS::AccountId}:repository/*
           - Effect: Allow
             Action:
               - apigateway:GET
             Resource:
-              - arn:aws:apigateway:*::/restapis/*/resources
+              - !Sub arn:${AWS::Partition}:apigateway:*::/restapis/*/resources
           - Effect: Allow
             Action:
               - lambda:AddPermission
@@ -322,8 +322,8 @@ Resources:
               - lambda:GetFunction
               - lambda:GetFunctionConfiguration
             Resource:
-              - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:*deploy*
-              - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:saas-boost-app-services-macro
+              - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:*deploy*
+              - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:saas-boost-app-services-macro
   OnboardingServiceTenantProvisionPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
@@ -340,41 +340,41 @@ Resources:
               - cloudformation:DeleteStack
               - cloudformation:DescribeStacks
             Resource:
-              - !Sub arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sb-${Environment}*
-              - !Sub arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:transform/saas-boost-app-services-macro
+              - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sb-${Environment}*
+              - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:transform/saas-boost-app-services-macro
           - Effect: Allow
             Action:
               - sns:Publish
             Resource:
-              - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:sb-*
+              - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:sb-*
           - Effect: Allow
             Action:
               - ssm:GetParameter*
               - ssm:PutParameter
               - ssm:DeleteParameter
             Resource:
-              - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/saas-boost/${Environment}/*
+              - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/saas-boost/${Environment}/*
           - Effect: Allow
             Action:
               - secretsmanager:GetSecretValue
             Resource:
-              - !Sub arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/saas-boost/${Environment}/*
+              - !Sub arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/saas-boost/${Environment}/*
           - Effect: Allow
             Action:
               - ssm:GetParameters
             Resource:
-              - arn:aws:ssm:*:*:parameter/aws/service/ami-windows-latest/*
-              - arn:aws:ssm:*:*:parameter/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/*
+              - !Sub arn:${AWS::Partition}:ssm:*:*:parameter/aws/service/ami-windows-latest/*
+              - !Sub arn:${AWS::Partition}:ssm:*:*:parameter/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/*
           - Effect: Allow
             Action:
               - ssm:AddTagsToResource
-            Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*
+            Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*
           - Effect: Allow
             Action:
               - ecs:DescribeClusters
               - ecs:DeleteCluster
             Resource:
-              - !Sub arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:cluster/sb-${Environment}-tenant*
+              - !Sub arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:cluster/sb-${Environment}-tenant*
           - Effect: Allow
             Action:
               - codepipeline:CreatePipeline
@@ -386,7 +386,7 @@ Resources:
               - codepipeline:UntagResource
               - codepipeline:ListTagsForResource
             Resource:
-              - !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:sb-${Environment}-tenant*
+              - !Sub arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:sb-${Environment}-tenant*
           - Effect: Allow
             Action:
               - kms:TagResource
@@ -399,8 +399,8 @@ Resources:
               - kms:ScheduleKeyDeletion
               - kms:Get*
             Resource:
-              - !Sub arn:aws:kms:*:${AWS::AccountId}:alias/*
-              - !Sub arn:aws:kms:*:${AWS::AccountId}:key/*
+              - !Sub arn:${AWS::Partition}:kms:*:${AWS::AccountId}:alias/*
+              - !Sub arn:${AWS::Partition}:kms:*:${AWS::AccountId}:key/*
           - Effect: Allow
             Action:
               - route53:GetHostedZone
@@ -410,12 +410,12 @@ Resources:
               - route53:ListQueryLoggingConfigs
               - route53:DeleteHostedZone
             Resource:
-              - arn:aws:route53:::hostedzone/*
+              - !Sub arn:${AWS::Partition}:route53:::hostedzone/*
           - Effect: Allow
             Action:
               - route53:GetChange
             Resource:
-              - arn:aws:route53:::change/*
+              - !Sub arn:${AWS::Partition}:route53:::change/*
           - Effect: Allow
             Action:
               - route53:ListHostedZonesByName
@@ -458,27 +458,27 @@ Resources:
               - logs:CreateLogGroup
               - logs:PutRetentionPolicy
             Resource:
-              - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/ecs/sb-${Environment}-tenant*
-              - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sb-${Environment}-tenant*
+              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/ecs/sb-${Environment}-tenant*
+              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sb-${Environment}-tenant*
           - Effect: Allow
             Action:
               - ec2:CreateTags
               - ec2:DeleteTags
             Resource:
-              - !Sub arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*
-              - !Sub arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:launch-template/*
-              - !Sub arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:internet-gateway/*
-              - !Sub arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:vpc/*
-              - !Sub arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:route-table/*
-              - !Sub arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:subnet/*
-              - !Sub arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:transit-gateway/*
-              - !Sub arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:transit-gateway-attachment/*
+              - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:instance/*
+              - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:launch-template/*
+              - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:internet-gateway/*
+              - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:vpc/*
+              - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:route-table/*
+              - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:subnet/*
+              - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:transit-gateway/*
+              - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:transit-gateway-attachment/*
           - Effect: Allow
             Action:
               - ec2:CreateLaunchTemplate
               - ec2:DeleteLaunchTemplate
             Resource:
-              - !Sub arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:launch-template/*
+              - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:launch-template/*
           - Effect: Allow
             Action:
               - ec2:AuthorizeSecurityGroupIngress
@@ -486,22 +486,22 @@ Resources:
               - ec2:AuthorizeSecurityGroupEgress
               - ec2:RevokeSecurityGroupEgress
             Resource:
-              - !Sub arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:security-group/*
+              - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:security-group/*
           - Effect: Allow
             Action:
               - ec2:CreateRoute
               - ec2:DeleteRoute
             Resource:
-              - !Sub arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:route-table/*
+              - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:route-table/*
           - Effect: Allow
             Action:
               - ec2:CreateTransitGatewayVpcAttachment
               - ec2:DeleteTransitGatewayVpcAttachment
             Resource:
-              - !Sub arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:vpc/*
-              - !Sub arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:subnet/*
-              - !Sub arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:transit-gateway/*
-              - !Sub arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:transit-gateway-attachment/*
+              - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:vpc/*
+              - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:subnet/*
+              - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:transit-gateway/*
+              - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:transit-gateway-attachment/*
           - Effect: Allow
             Action:
               - ec2:CreateTransitGatewayRoute
@@ -509,15 +509,15 @@ Resources:
               - ec2:AssociateTransitGatewayRouteTable
               - ec2:DisassociateTransitGatewayRouteTable
             Resource:
-              - !Sub arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:transit-gateway-route-table/*
-              - !Sub arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:transit-gateway-attachment/*
+              - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:transit-gateway-route-table/*
+              - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:transit-gateway-attachment/*
           - Effect: Allow
             Action:
               - elasticloadbalancing:CreateTargetGroup
               - elasticloadbalancing:ModifyTargetGroupAttributes
               - elasticloadbalancing:DeleteTargetGroup
             Resource:
-              - !Sub arn:aws:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:targetgroup/*/*
+              - !Sub arn:${AWS::Partition}:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:targetgroup/*/*
           - Effect: Allow
             Action:
               - elasticloadbalancing:CreateLoadBalancer
@@ -525,8 +525,8 @@ Resources:
               - elasticloadbalancing:ModifyLoadBalancerAttributes
               - elasticloadbalancing:CreateListener
             Resource:
-              - !Sub arn:aws:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:loadbalancer/app/*/*
-              - !Sub arn:aws:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:loadbalancer/net/*/*
+              - !Sub arn:${AWS::Partition}:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:loadbalancer/app/*/*
+              - !Sub arn:${AWS::Partition}:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:loadbalancer/net/*/*
           - Effect: Allow
             Action:
               - elasticloadbalancing:CreateRule
@@ -534,16 +534,16 @@ Resources:
               - elasticloadbalancing:DeleteRule
               - elasticloadbalancing:DeleteListener
             Resource:
-              - !Sub arn:aws:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:listener/app/*/*
-              - !Sub arn:aws:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:listener-rule/app/*
-              - !Sub arn:aws:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:listener/net/*/*
-              - !Sub arn:aws:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:listener-rule/net/*
+              - !Sub arn:${AWS::Partition}:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:listener/app/*/*
+              - !Sub arn:${AWS::Partition}:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:listener-rule/app/*
+              - !Sub arn:${AWS::Partition}:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:listener/net/*/*
+              - !Sub arn:${AWS::Partition}:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:listener-rule/net/*
           - Effect: Allow
             Action:
               - iam:CreateServiceLinkedRole
               - iam:DeleteServiceLinkedRole
             Resource:
-              - !Sub arn:aws:iam::${AWS::AccountId}:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService
             Condition:
               StringLike:
                 iam:AWSServiceName:
@@ -552,7 +552,7 @@ Resources:
             Action:
               - iam:PassRole
             Resource:
-              - !Sub arn:aws:iam::${AWS::AccountId}:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService
           - Effect: Allow
             Action:
               - iam:GetRole
@@ -565,7 +565,7 @@ Resources:
               - iam:DeleteRolePolicy
               - iam:PassRole
             Resource:
-              - !Sub arn:aws:iam::${AWS::AccountId}:role/sb-${Environment}-*tenant*
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sb-${Environment}-*tenant*
           - Effect: Allow
             Action:
               - iam:GetInstanceProfile
@@ -574,15 +574,15 @@ Resources:
               - iam:AddRoleToInstanceProfile
               - iam:RemoveRoleFromInstanceProfile
             Resource:
-              - !Sub arn:aws:iam::${AWS::AccountId}:instance-profile/sb-${Environment}-tenant*
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/sb-${Environment}-tenant*
           - Effect: Allow
             Action:
               - ecs:PutClusterCapacityProviders
               - ecs:DescribeCapacityProviders
               - ecs:DeleteCapacityProvider
             Resource:
-              - !Sub arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:capacity-provider/sb-${Environment}-tenant*
-              - !Sub arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:cluster/sb-${Environment}-tenant*
+              - !Sub arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:capacity-provider/sb-${Environment}-tenant*
+              - !Sub arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:cluster/sb-${Environment}-tenant*
           - Effect: Allow
             Action:
               - ecs:CreateService
@@ -590,19 +590,19 @@ Resources:
               - ecs:UpdateService
               - ecs:DeleteService
             Resource:
-              - !Sub arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:service/sb-${Environment}-tenant*
+              - !Sub arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:service/sb-${Environment}-tenant*
           - Effect: Allow
             Action:
               - servicediscovery:CreateService
               - servicediscovery:DeleteNamespace
             Resource:
-              - !Sub arn:aws:servicediscovery:${AWS::Region}:${AWS::AccountId}:namespace/*
+              - !Sub arn:${AWS::Partition}:servicediscovery:${AWS::Region}:${AWS::AccountId}:namespace/*
           - Effect: Allow
             Action:
               - servicediscovery:GetService
               - servicediscovery:DeleteService
             Resource:
-              - !Sub arn:aws:servicediscovery:${AWS::Region}:${AWS::AccountId}:service/*
+              - !Sub arn:${AWS::Partition}:servicediscovery:${AWS::Region}:${AWS::AccountId}:service/*
           - Effect: Allow
             Action:
               - autoscaling:CreateAutoScalingGroup
@@ -613,12 +613,12 @@ Resources:
               - autoscaling:CreateOrUpdateTags
               - autoscaling:DeleteTags
             Resource:
-              - !Sub arn:aws:autoscaling:${AWS::Region}:${AWS::AccountId}:autoScalingGroup:*:autoScalingGroupName/sb-${Environment}-tenant*
+              - !Sub arn:${AWS::Partition}:autoscaling:${AWS::Region}:${AWS::AccountId}:autoScalingGroup:*:autoScalingGroupName/sb-${Environment}-tenant*
           - Effect: Allow
             Action:
               - lambda:InvokeFunction
             Resource:
-              - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:sb-${Environment}-set-instance-protection
+              - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sb-${Environment}-set-instance-protection
           - Effect: Allow
             Action:
               - servicediscovery:CreatePrivateDnsNamespace
@@ -653,7 +653,7 @@ Resources:
               - logs:PutRetentionPolicy
               - logs:DeleteLogGroup
             Resource:
-              - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
           - Effect: Allow
             Action:
               - rds:AddTagsToResource
@@ -661,39 +661,39 @@ Resources:
               - rds:CreateDBCluster
               - rds:CreateDBInstance
             Resource:
-              - !Sub arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:sb-${Environment}-*tenant*
-              - !Sub arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster-pg:*
-              - !Sub arn:aws:rds:${AWS::Region}:${AWS::AccountId}:subgrp:sb-${Environment}-*tenant*
-              - !Sub arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*
+              - !Sub arn:${AWS::Partition}:rds:${AWS::Region}:${AWS::AccountId}:cluster:sb-${Environment}-*tenant*
+              - !Sub arn:${AWS::Partition}:rds:${AWS::Region}:${AWS::AccountId}:cluster-pg:*
+              - !Sub arn:${AWS::Partition}:rds:${AWS::Region}:${AWS::AccountId}:subgrp:sb-${Environment}-*tenant*
+              - !Sub arn:${AWS::Partition}:rds:${AWS::Region}:${AWS::AccountId}:db:*
           - Effect: Allow
             Action:
               - rds:CreateDBSnapshot
               - rds:CreateDBClusterSnapshot
               - rds:DescribeDBClusterSnapshots
             Resource:
-              - !Sub arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*
-              - !Sub arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:sb-${Environment}-*tenant*
-              - !Sub arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster-snapshot:*
+              - !Sub arn:${AWS::Partition}:rds:${AWS::Region}:${AWS::AccountId}:db:*
+              - !Sub arn:${AWS::Partition}:rds:${AWS::Region}:${AWS::AccountId}:cluster:sb-${Environment}-*tenant*
+              - !Sub arn:${AWS::Partition}:rds:${AWS::Region}:${AWS::AccountId}:cluster-snapshot:*
           - Effect: Allow
             Action:
               - rds:DescribeDBClusters
               - rds:DeleteDBCluster
             Resource:
-              - !Sub arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:sb-${Environment}-*tenant*
-              - !Sub arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster-snapshot:*
+              - !Sub arn:${AWS::Partition}:rds:${AWS::Region}:${AWS::AccountId}:cluster:sb-${Environment}-*tenant*
+              - !Sub arn:${AWS::Partition}:rds:${AWS::Region}:${AWS::AccountId}:cluster-snapshot:*
           - Effect: Allow
             Action:
               - rds:DescribeDBSubnetGroups
               - rds:CreateDBSubnetGroup
               - rds:DeleteDBSubnetGroup
             Resource:
-              - !Sub arn:aws:rds:${AWS::Region}:${AWS::AccountId}:subgrp:sb-${Environment}-*tenant*
+              - !Sub arn:${AWS::Partition}:rds:${AWS::Region}:${AWS::AccountId}:subgrp:sb-${Environment}-*tenant*
           - Effect: Allow
             Action:
               - rds:DescribeDBInstances
               - rds:DeleteDBInstance
             Resource:
-              - !Sub arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*
+              - !Sub arn:${AWS::Partition}:rds:${AWS::Region}:${AWS::AccountId}:db:*
           - Effect: Allow
             Action:
               - iam:GetRole
@@ -704,7 +704,7 @@ Resources:
               - iam:DeleteRolePolicy
               - iam:PassRole
             Resource:
-              - !Sub arn:aws:iam::${AWS::AccountId}:role/sb-${Environment}-rds-bootstrap-tenant*
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sb-${Environment}-rds-bootstrap-tenant*
           - Effect: Allow
             Action:
               - lambda:GetFunction
@@ -714,7 +714,7 @@ Resources:
               - lambda:TagResource
               - lambda:UntagResource
             Resource:
-              - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:sb-${Environment}-rds-bootstrap-tenant-*
+              - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sb-${Environment}-rds-bootstrap-tenant-*
           - Effect: Allow
             Action:
               - lambda:GetLayerVersion
@@ -739,7 +739,7 @@ Resources:
               - elasticfilesystem:DeleteFileSystemPolicy
               - elasticfilesystem:PutLifecycleConfiguration
             Resource:
-              - !Sub arn:aws:elasticfilesystem:${AWS::Region}:${AWS::AccountId}:file-system/*
+              - !Sub arn:${AWS::Partition}:elasticfilesystem:${AWS::Region}:${AWS::AccountId}:file-system/*
           - Effect: Allow
             Action:
               - fsx:CreateFileSystem
@@ -747,20 +747,20 @@ Resources:
               - fsx:TagResource
               - fsx:UntagResource
             Resource:
-              - !Sub arn:aws:fsx:${AWS::Region}:${AWS::AccountId}:file-system/*
+              - !Sub arn:${AWS::Partition}:fsx:${AWS::Region}:${AWS::AccountId}:file-system/*
           - Effect: Allow
             Action:
               - fsx:CreateStorageVirtualMachine
             Resource:
-              - !Sub arn:aws:fsx:${AWS::Region}:${AWS::AccountId}:storage-virtual-machine/*
-              - !Sub arn:aws:fsx:${AWS::Region}:${AWS::AccountId}:file-system/*
+              - !Sub arn:${AWS::Partition}:fsx:${AWS::Region}:${AWS::AccountId}:storage-virtual-machine/*
+              - !Sub arn:${AWS::Partition}:fsx:${AWS::Region}:${AWS::AccountId}:file-system/*
           - Effect: Allow
             Action:
               - fsx:TagResource
               - fsx:UntagResource
               - fsx:DeleteStorageVirtualMachine
             Resource:
-              - !Sub arn:aws:fsx:${AWS::Region}:${AWS::AccountId}:storage-virtual-machine/*
+              - !Sub arn:${AWS::Partition}:fsx:${AWS::Region}:${AWS::AccountId}:storage-virtual-machine/*
           - Effect: Allow
             Action:
               - fsx:TagResource
@@ -768,8 +768,8 @@ Resources:
               - fsx:CreateVolume
               - fsx:DeleteVolume
             Resource:
-              - !Sub arn:aws:fsx:${AWS::Region}:${AWS::AccountId}:volume/*/*
-              - !Sub arn:aws:fsx:${AWS::Region}:${AWS::AccountId}:storage-virtual-machine/*/*
+              - !Sub arn:${AWS::Partition}:fsx:${AWS::Region}:${AWS::AccountId}:volume/*/*
+              - !Sub arn:${AWS::Partition}:fsx:${AWS::Region}:${AWS::AccountId}:storage-virtual-machine/*/*
           - Effect: Allow
             Action:
               - elasticfilesystem:CreateFileSystem
@@ -790,7 +790,7 @@ Resources:
               - iam:DeleteRolePolicy
               - iam:PassRole
             Resource:
-              - !Sub arn:aws:iam::${AWS::AccountId}:role/sb-${Environment}-fsx-dns-tenant*
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sb-${Environment}-fsx-dns-tenant*
           - Effect: Allow
             Action:
               - lambda:GetFunction
@@ -800,7 +800,7 @@ Resources:
               - lambda:TagResource
               - lambda:UntagResource
             Resource:
-              - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:sb-${Environment}-fsx-dns-tenant-*
+              - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sb-${Environment}-fsx-dns-tenant-*
           - Effect: Allow
             Action:
               - lambda:GetLayerVersion
@@ -812,13 +812,13 @@ Resources:
               # This is for the AD stack -- need to figure out why update DNS wants to delete its SSM params
               - ssm:DeleteParameter
             Resource:
-              - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/saas-boost/${Environment}/*
+              - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/saas-boost/${Environment}/*
           # This is for the AD stack -- need to figure out why update DNS wants to delete the directory
           - Effect: Allow
             Action:
               - ds:DeleteDirectory
             Resource:
-              - !Sub arn:aws:ds:${AWS::Region}:${AWS::AccountId}:directory/*
+              - !Sub arn:${AWS::Partition}:ds:${AWS::Region}:${AWS::AccountId}:directory/*
   OnboardingServiceExecutionRole:
     Type: AWS::IAM::Role
     Properties:
@@ -1021,7 +1021,7 @@ Resources:
           ONBOARDING_TABLE: !Ref OnboardingTable
           CIDR_BLOCK_TABLE: !Ref CidrBlockTable
           API_TRUST_ROLE: !Sub '{{resolve:ssm:/saas-boost/${Environment}/PRIVATE_API_TRUST_ROLE}}'
-          API_GATEWAY_HOST: !Sub ${SaaSBoostPrivateApi}.execute-api.${AWS::Region}.amazonaws.com
+          API_GATEWAY_HOST: !Sub ${SaaSBoostPrivateApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}
           API_GATEWAY_STAGE: !Ref PrivateApiStage
           SAAS_BOOST_BUCKET: !Ref SaaSBoostBucket
           SAAS_BOOST_EVENT_BUS: !Ref SaaSBoostEventBus
@@ -1062,7 +1062,7 @@ Resources:
           ONBOARDING_TABLE: !Ref OnboardingTable
           CIDR_BLOCK_TABLE: !Ref CidrBlockTable
           API_TRUST_ROLE: !Sub '{{resolve:ssm:/saas-boost/${Environment}/PRIVATE_API_TRUST_ROLE}}'
-          API_GATEWAY_HOST: !Sub ${SaaSBoostPrivateApi}.execute-api.${AWS::Region}.amazonaws.com
+          API_GATEWAY_HOST: !Sub ${SaaSBoostPrivateApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}
           API_GATEWAY_STAGE: !Ref PrivateApiStage
           SAAS_BOOST_BUCKET: !Ref SaaSBoostBucket
           SAAS_BOOST_EVENT_BUS: !Ref SaaSBoostEventBus
@@ -1108,7 +1108,7 @@ Resources:
           ONBOARDING_TABLE: !Ref OnboardingTable
           CIDR_BLOCK_TABLE: !Ref CidrBlockTable
           API_TRUST_ROLE: !Sub '{{resolve:ssm:/saas-boost/${Environment}/PRIVATE_API_TRUST_ROLE}}'
-          API_GATEWAY_HOST: !Sub ${SaaSBoostPrivateApi}.execute-api.${AWS::Region}.amazonaws.com
+          API_GATEWAY_HOST: !Sub ${SaaSBoostPrivateApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}
           API_GATEWAY_STAGE: !Ref PrivateApiStage
           SAAS_BOOST_BUCKET: !Ref SaaSBoostBucket
           SAAS_BOOST_EVENT_BUS: !Ref SaaSBoostEventBus

--- a/resources/saas-boost-svc-quota.yaml
+++ b/resources/saas-boost-svc-quota.yaml
@@ -46,7 +46,7 @@ Resources:
             Action:
               - sts:AssumeRole
       Policies:
-        - PolicyName: !Sub sb-${Environment}-quotas-service-policy-${AWS::Region}
+        - PolicyName: !Sub sb-${Environment}-quotas-service-policy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -54,13 +54,13 @@ Resources:
                 Action:
                   - logs:PutLogEvents
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
               - Effect: Allow
                 Action:
                   - logs:CreateLogStream
                   - logs:DescribeLogStreams
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
               - Effect: Allow
                 Action:
                   - ec2:DescribeInternetGateways

--- a/resources/saas-boost-svc-settings.yaml
+++ b/resources/saas-boost-svc-settings.yaml
@@ -75,7 +75,7 @@ Resources:
             Action:
               - sts:AssumeRole
       Policies:
-        - PolicyName: !Sub sb-${Environment}-rds-options-policy-${AWS::Region}
+        - PolicyName: !Sub sb-${Environment}-rds-options-policy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -83,14 +83,14 @@ Resources:
                 Action:
                   - logs:PutLogEvents
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
               - Effect: Allow
                 Action:
                   - logs:DescribeLogGroups
                   - logs:DescribeLogStreams
                   - logs:CreateLogStream
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
               - Effect: Allow
                 Action:
                   - dynamodb:DescribeTable
@@ -98,7 +98,7 @@ Resources:
                   - dynamodb:Scan
                   - dynamodb:UpdateItem
                 Resource:
-                  - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${RdsOptionsTable}
+                  - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${RdsOptionsTable}
               - Effect: Allow
                 Action:
                   - rds:DescribeOrderableDBInstanceOptions
@@ -153,20 +153,20 @@ Resources:
             Action:
               - sts:AssumeRole
       Policies:
-        - PolicyName: !Sub sb-${Environment}-settings-svc-policy-${AWS::Region}
+        - PolicyName: !Sub sb-${Environment}-settings-svc-policy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
               - Effect: Allow
                 Action:
                   - logs:PutLogEvents
-                Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
+                Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
               - Effect: Allow
                 Action:
                   - logs:CreateLogStream
                   - logs:DescribeLogStreams
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
               - Effect: Allow
                 Action:
                   - ssm:GetParameter
@@ -176,7 +176,7 @@ Resources:
                   - ssm:DeleteParameter
                   - ssm:DeleteParameters
                 Resource:
-                  - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*
+                  - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*
               - Effect: Allow
                 Action:
                   - dynamodb:DescribeTable
@@ -184,17 +184,17 @@ Resources:
                   - dynamodb:Scan
                   - dynamodb:Query
                 Resource:
-                  - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${RdsOptionsTable}
+                  - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${RdsOptionsTable}
               - Effect: Allow
                 Action:
                   - events:PutEvents
                 Resource:
-                  - !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:event-bus/${SaaSBoostEventBus}
+                  - !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:event-bus/${SaaSBoostEventBus}
               - Effect: Allow
                 Action:
                   - s3:PutObject
                 Resource:
-                  - !Sub arn:aws:s3:::${ResourcesBucket}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${ResourcesBucket}/*
               - Effect: Allow
                 Action:
                   - sts:AssumeRole
@@ -348,7 +348,7 @@ Resources:
           SAAS_BOOST_ENV: !Ref Environment
           SAAS_BOOST_EVENT_BUS: !Ref SaaSBoostEventBus
           API_TRUST_ROLE: !Sub '{{resolve:ssm:/saas-boost/${Environment}/PRIVATE_API_TRUST_ROLE}}'
-          API_GATEWAY_HOST: !Sub ${SaaSBoostPrivateApi}.execute-api.${AWS::Region}.amazonaws.com
+          API_GATEWAY_HOST: !Sub ${SaaSBoostPrivateApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}
           API_GATEWAY_STAGE: !Ref PrivateApiStage
           RESOURCES_BUCKET: !Ref ResourcesBucket
           JAVA_TOOL_OPTIONS: '-XX:+TieredCompilation -XX:TieredStopAtLevel=1'

--- a/resources/saas-boost-svc-tenant.yaml
+++ b/resources/saas-boost-svc-tenant.yaml
@@ -68,20 +68,20 @@ Resources:
             Action:
               - sts:AssumeRole
       Policies:
-        - PolicyName: !Sub sb-${Environment}-tenant-svc-policy-${AWS::Region}
+        - PolicyName: !Sub sb-${Environment}-tenant-svc-policy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
               - Effect: Allow
                 Action:
                   - logs:PutLogEvents
-                Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
+                Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
               - Effect: Allow
                 Action:
                   - logs:CreateLogStream
                   - logs:DescribeLogStreams
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
               - Effect: Allow
                 Action:
                   - dynamodb:DescribeTable
@@ -91,12 +91,12 @@ Resources:
                   - dynamodb:Scan
                   - dynamodb:Query
                   - dynamodb:UpdateItem
-                Resource: !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${TenantsTable}
+                Resource: !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${TenantsTable}
               - Effect: Allow
                 Action:
                   - events:PutEvents
                 Resource:
-                  - !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:event-bus/${SaaSBoostEventBus}
+                  - !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:event-bus/${SaaSBoostEventBus}
   TenantServiceGetByIdLogs:
     Type: AWS::Logs::LogGroup
     Properties:

--- a/resources/saas-boost-svc-tier.yaml
+++ b/resources/saas-boost-svc-tier.yaml
@@ -59,20 +59,20 @@ Resources:
             Action:
               - sts:AssumeRole
       Policies:
-        - PolicyName: !Sub sb-${Environment}-tier-svc-policy-${AWS::Region}
+        - PolicyName: !Sub sb-${Environment}-tier-svc-policy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
               - Effect: Allow
                 Action:
                   - logs:PutLogEvents
-                Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
+                Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
               - Effect: Allow
                 Action:
                   - logs:CreateLogStream
                   - logs:DescribeLogStreams
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
               - Effect: Allow
                 Action:
                   - dynamodb:DescribeTable
@@ -82,7 +82,7 @@ Resources:
                   - dynamodb:DeleteItem
                   - dynamodb:UpdateItem
                 Resource:
-                  - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${TiersTable}
+                  - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${TiersTable}
   TierServiceGetAllLogs:
     Type: AWS::Logs::LogGroup
     Properties:

--- a/resources/saas-boost-svc-user.yaml
+++ b/resources/saas-boost-svc-user.yaml
@@ -46,20 +46,20 @@ Resources:
             Action:
               - sts:AssumeRole
       Policies:
-        - PolicyName: !Sub sb-${Environment}-user-svc-policy-${AWS::Region}
+        - PolicyName: !Sub sb-${Environment}-user-svc-policy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
               - Effect: Allow
                 Action:
                   - logs:PutLogEvents
-                Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
+                Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
               - Effect: Allow
                 Action:
                   - logs:CreateLogStream
                   - logs:DescribeLogStreams
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
               - Effect: Allow
                 Action:
                   - cognito-idp:AdminCreateUser
@@ -72,7 +72,7 @@ Resources:
                   - cognito-idp:AdminInitiateAuth
                   - cognito-idp:ListUserPoolClients
                 Resource:
-                  - !Sub arn:aws:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/${CognitoUserPoolId}
+                  - !Sub arn:${AWS::Partition}:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/${CognitoUserPoolId}
   UserServiceGetByIdLogs:
     Type: AWS::Logs::LogGroup
     Properties:

--- a/resources/saas-boost-web.yaml
+++ b/resources/saas-boost-web.yaml
@@ -43,7 +43,7 @@ Resources:
         IPV6Enabled: false
         HttpVersion: http2
         Origins:
-          - DomainName: !Sub ${WebS3Bucket}.s3.${AWS::Region}.amazonaws.com
+          - DomainName: !Sub ${WebS3Bucket}.s3.${AWS::Region}.${AWS::URLSuffix}
             Id: !Sub sb-${Environment}-s3-website
             S3OriginConfig:
               OriginAccessIdentity: !Sub origin-access-identity/cloudfront/${ConsoleOriginAccessIdentity}
@@ -182,13 +182,13 @@ Resources:
               CanonicalUser:
                 !GetAtt ConsoleOriginAccessIdentity.S3CanonicalUserId
             Action: s3:GetObject
-            Resource: !Sub arn:aws:s3:::${WebS3Bucket}/*
+            Resource: !Sub arn:${AWS::Partition}:s3:::${WebS3Bucket}/*
           - Effect: Deny
             Action: s3:*
             Principal: '*'
             Resource:
-              - !Sub arn:aws:s3:::${WebS3Bucket}/*
-              - !Sub arn:aws:s3:::${WebS3Bucket}
+              - !Sub arn:${AWS::Partition}:s3:::${WebS3Bucket}/*
+              - !Sub arn:${AWS::Partition}:s3:::${WebS3Bucket}
             Condition:
               Bool: {'aws:SecureTransport': false}
 Outputs:

--- a/resources/saas-boost.yaml
+++ b/resources/saas-boost.yaml
@@ -126,8 +126,8 @@ Resources:
             Action: s3:*
             Principal: '*'
             Resource:
-              - !Sub arn:aws:s3:::${Logging}/*
-              - !Sub arn:aws:s3:::${Logging}
+              - !Sub arn:${AWS::Partition}:s3:::${Logging}/*
+              - !Sub arn:${AWS::Partition}:s3:::${Logging}
             Condition:
               Bool: { 'aws:SecureTransport': false }
   # Bucket needed for CodePipeline to drive tenant deployment workflow
@@ -162,8 +162,8 @@ Resources:
             Action: s3:*
             Principal: '*'
             Resource:
-              - !Sub arn:aws:s3:::${Pipelines}/*
-              - !Sub arn:aws:s3:::${Pipelines}
+              - !Sub arn:${AWS::Partition}:s3:::${Pipelines}/*
+              - !Sub arn:${AWS::Partition}:s3:::${Pipelines}
             Condition:
               Bool: { 'aws:SecureTransport': false }
   # Bucket for Access Logs for ALBs for Tenants
@@ -226,8 +226,8 @@ Resources:
             Action: s3:*
             Principal: '*'
             Resource:
-              - !Sub arn:aws:s3:::${AthenaOutput}/*
-              - !Sub arn:aws:s3:::${AthenaOutput}
+              - !Sub arn:${AWS::Partition}:s3:::${AthenaOutput}/*
+              - !Sub arn:${AWS::Partition}:s3:::${AthenaOutput}
             Condition:
               Bool: { 'aws:SecureTransport': false }
   # Bucket to host the admin console web application
@@ -318,20 +318,20 @@ Resources:
             Action:
               - sts:AssumeRole
       Policies:
-        - PolicyName: !Sub sb-${Environment}-clear-bucket-policy-${AWS::Region}
+        - PolicyName: !Sub sb-${Environment}-clear-bucket-policy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
               - Effect: Allow
                 Action:
                   - logs:PutLogEvents
-                Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
+                Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
               - Effect: Allow
                 Action:
                   - logs:CreateLogStream
                   - logs:DescribeLogStreams
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
               - Effect: Allow
                 Action:
                   - s3:ListBucket
@@ -340,13 +340,13 @@ Resources:
                 # We know all S3 buckets will have auto-generated names that are prefixed with the stack name
                 # Using this wildcard instead of Fn::Ref to the bucket resources avoids circular dependencies
                 Resource:
-                  - !Sub arn:aws:s3:::${AWS::StackName}-*
+                  - !Sub arn:${AWS::Partition}:s3:::${AWS::StackName}-*
               - Effect: Allow
                 Action:
                   - s3:DeleteObject
                   - s3:DeleteObjectVersion
                 Resource:
-                  - !Sub arn:aws:s3:::${AWS::StackName}-*/*
+                  - !Sub arn:${AWS::Partition}:s3:::${AWS::StackName}-*/*
   ClearBucketLogs:
     Type: AWS::Logs::LogGroup
     Properties:
@@ -431,13 +431,13 @@ Resources:
               - Effect: Allow
                 Action:
                   - logs:PutLogEvents
-                Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
+                Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
               - Effect: Allow
                 Action:
                   - logs:CreateLogStream
                   - logs:DescribeLogStreams
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
   ApplicationServicesMacroLogs:
     Type: AWS::Logs::LogGroup
     Condition: ShouldCreateMacroResources
@@ -512,7 +512,7 @@ Resources:
             Action:
               - sts:AssumeRole
       Policies:
-        - PolicyName: !Sub sb-${Environment}-core-stack-listener-${AWS::Region}
+        - PolicyName: !Sub sb-${Environment}-core-stack-listener
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -520,29 +520,29 @@ Resources:
                 Action:
                   - logs:PutLogEvents
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
               - Effect: Allow
                 Action:
                   - logs:CreateLogStream
                   - logs:DescribeLogStreams
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
               - Effect: Allow
                 Action:
                   - cloudformation:DescribeStacks
                   - cloudformation:ListStackResources
                 Resource:
-                  - !Sub arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/*
+                  - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/*
               - Effect: Allow
                 Action:
                   - events:PutEvents
                 Resource:
-                  - !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:event-bus/${SaaSBoostEventBus}
+                  - !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:event-bus/${SaaSBoostEventBus}
               - Effect: Allow
                 Action:
                   - ecr:ListTagsForResource
                 Resource:
-                  - !Sub arn:aws:ecr:${AWS::Region}:${AWS::AccountId}:repository/sb-${Environment}-core-*
+                  - !Sub arn:${AWS::Partition}:ecr:${AWS::Region}:${AWS::AccountId}:repository/sb-${Environment}-core-*
   CoreStackListenerLogs:
     Type: AWS::Logs::LogGroup
     Properties:
@@ -596,14 +596,14 @@ Resources:
   network:
     Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL: !Sub https://${SaaSBoostBucket}.s3.amazonaws.com/saas-boost-network.yaml
+      TemplateURL: !Sub https://${SaaSBoostBucket}.s3.${AWS::URLSuffix}/saas-boost-network.yaml
       Parameters:
         Environment: !Ref Environment
   ad:
     Type: AWS::CloudFormation::Stack
     Condition: ProvisionManagedAD
     Properties:
-      TemplateURL: !Sub https://${SaaSBoostBucket}.s3.amazonaws.com/saas-boost-managed-ad.yaml
+      TemplateURL: !Sub https://${SaaSBoostBucket}.s3.${AWS::URLSuffix}/saas-boost-managed-ad.yaml
       Parameters:
         Environment: !Ref Environment
         Subnets:
@@ -620,7 +620,7 @@ Resources:
     # delete the bucket
     DependsOn: InvokeClearLoggingBucket
     Properties:
-      TemplateURL: !Sub https://${SaaSBoostBucket}.s3.amazonaws.com/saas-boost-web.yaml
+      TemplateURL: !Sub https://${SaaSBoostBucket}.s3.${AWS::URLSuffix}/saas-boost-web.yaml
       Parameters:
         Environment: !Ref Environment
         AdminEmailAddress: !Ref AdminEmailAddress
@@ -631,7 +631,7 @@ Resources:
       - network
       - MacroWaitCondition
     Properties:
-      TemplateURL: !Sub https://${SaaSBoostBucket}.s3.amazonaws.com/saas-boost-core.yaml
+      TemplateURL: !Sub https://${SaaSBoostBucket}.s3.${AWS::URLSuffix}/saas-boost-core.yaml
       Parameters:
         Environment: !Ref Environment
         SaaSBoostBucket: !Ref SaaSBoostBucket
@@ -652,7 +652,7 @@ Resources:
     Type: AWS::CloudFormation::Stack
     DependsOn: core
     Properties:
-      TemplateURL: !Sub https://${SaaSBoostBucket}.s3.amazonaws.com/saas-boost-svc-billing.yaml
+      TemplateURL: !Sub https://${SaaSBoostBucket}.s3.${AWS::URLSuffix}/saas-boost-svc-billing.yaml
       Parameters:
         Environment: !Ref Environment
         SaaSBoostBucket: !Ref SaaSBoostBucket
@@ -663,7 +663,7 @@ Resources:
   metering:
     Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL: !Sub https://${SaaSBoostBucket}.s3.amazonaws.com/saas-boost-metering-billing.yaml
+      TemplateURL: !Sub https://${SaaSBoostBucket}.s3.${AWS::URLSuffix}/saas-boost-metering-billing.yaml
       Parameters:
         Environment: !Ref Environment
         SaaSBoostBucket: !Ref SaaSBoostBucket
@@ -681,7 +681,7 @@ Resources:
       - InvokeClearAthenaBucket
       - InvokeClearAccessLogsBucket
     Properties:
-      TemplateURL: !Sub https://${SaaSBoostBucket}.s3.amazonaws.com/saas-boost-svc-metrics.yaml
+      TemplateURL: !Sub https://${SaaSBoostBucket}.s3.${AWS::URLSuffix}/saas-boost-svc-metrics.yaml
       Parameters:
         Environment: !Ref Environment
         SaaSBoostBucket: !Ref SaaSBoostBucket
@@ -695,7 +695,7 @@ Resources:
   onboarding:
     Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL: !Sub https://${SaaSBoostBucket}.s3.amazonaws.com/saas-boost-svc-onboarding.yaml
+      TemplateURL: !Sub https://${SaaSBoostBucket}.s3.${AWS::URLSuffix}/saas-boost-svc-onboarding.yaml
       Parameters:
         Environment: !Ref Environment
         SaaSBoostBucket: !Ref SaaSBoostBucket
@@ -711,7 +711,7 @@ Resources:
     Type: AWS::CloudFormation::Stack
     DependsOn: core
     Properties:
-      TemplateURL: !Sub https://${SaaSBoostBucket}.s3.amazonaws.com/saas-boost-svc-quota.yaml
+      TemplateURL: !Sub https://${SaaSBoostBucket}.s3.${AWS::URLSuffix}/saas-boost-svc-quota.yaml
       Parameters:
         Environment: !Ref Environment
         SaaSBoostBucket: !Ref SaaSBoostBucket
@@ -721,7 +721,7 @@ Resources:
   settings:
     Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL: !Sub https://${SaaSBoostBucket}.s3.amazonaws.com/saas-boost-svc-settings.yaml
+      TemplateURL: !Sub https://${SaaSBoostBucket}.s3.${AWS::URLSuffix}/saas-boost-svc-settings.yaml
       Parameters:
         Environment: !Ref Environment
         SaaSBoostBucket: !Ref SaaSBoostBucket
@@ -735,7 +735,7 @@ Resources:
   tenant:
     Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL: !Sub https://${SaaSBoostBucket}.s3.amazonaws.com/saas-boost-svc-tenant.yaml
+      TemplateURL: !Sub https://${SaaSBoostBucket}.s3.${AWS::URLSuffix}/saas-boost-svc-tenant.yaml
       Parameters:
         Environment: !Ref Environment
         SaaSBoostBucket: !Ref SaaSBoostBucket
@@ -747,7 +747,7 @@ Resources:
   tier:
     Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL: !Sub https://${SaaSBoostBucket}.s3.amazonaws.com/saas-boost-svc-tier.yaml
+      TemplateURL: !Sub https://${SaaSBoostBucket}.s3.${AWS::URLSuffix}/saas-boost-svc-tier.yaml
       Parameters:
         Environment: !Ref Environment
         SaaSBoostBucket: !Ref SaaSBoostBucket
@@ -759,7 +759,7 @@ Resources:
     DependsOn:
       - core
     Properties:
-      TemplateURL: !Sub https://${SaaSBoostBucket}.s3.amazonaws.com/saas-boost-svc-user.yaml
+      TemplateURL: !Sub https://${SaaSBoostBucket}.s3.${AWS::URLSuffix}/saas-boost-svc-user.yaml
       Parameters:
         Environment: !Ref Environment
         SaaSBoostBucket: !Ref SaaSBoostBucket
@@ -769,7 +769,7 @@ Resources:
   publicapi:
     Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL: !Sub https://${SaaSBoostBucket}.s3.amazonaws.com/saas-boost-public-api.yaml
+      TemplateURL: !Sub https://${SaaSBoostBucket}.s3.${AWS::URLSuffix}/saas-boost-public-api.yaml
       Parameters:
         Environment: !Ref Environment
         PublicApi: !GetAtt core.Outputs.SaaSBoostPublicApi
@@ -810,7 +810,7 @@ Resources:
   privateapi:
     Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL: !Sub https://${SaaSBoostBucket}.s3.amazonaws.com/saas-boost-private-api.yaml
+      TemplateURL: !Sub https://${SaaSBoostBucket}.s3.${AWS::URLSuffix}/saas-boost-private-api.yaml
       Parameters:
         Environment: !Ref Environment
         PrivateApi: !GetAtt core.Outputs.SaaSBoostPrivateApi

--- a/resources/tenant-onboarding-app.yaml
+++ b/resources/tenant-onboarding-app.yaml
@@ -811,8 +811,8 @@ Resources:
                 Start-Transcript -Path "C:\UserData.log" -Append
                 Write-Output ("Download and install the CloudWatch agent")
                 $cloudWatchAgentInstaller = "https://s3.${AWS::Region}.${AWS::URLSuffix}/amazoncloudwatch-agent-${AWS::Region}/windows/amd64/latest/amazon-cloudwatch-agent.msi"
-                If ('${AWS::Region}' -eq 'cn-north-1' -or '${AWS::Region}' -eq 'cn-northwest-1') {
-                    # MSI is not hosted in the Ningxia region
+                If ('${AWS::Partition}' -eq 'aws-cn') {
+                    # CloudWatch Agent installer is not hosted in the Ningxia region
                     $cloudWatchAgentInstaller = "https://s3.cn-north-1.${AWS::URLSuffix}/amazoncloudwatch-agent/windows/amd64/latest/amazon-cloudwatch-agent.msi"
                 }
                 Invoke-WebRequest $cloudWatchAgentInstaller -OutFile c:\Windows\Temp\amazon-cloudwatch-agent.msi
@@ -883,8 +883,8 @@ Resources:
                 Start-Transcript -Path "C:\UserData.log" -Append
                 Write-Output ("Download and install the CloudWatch agent")
                 $cloudWatchAgentInstaller = "https://s3.${AWS::Region}.${AWS::URLSuffix}/amazoncloudwatch-agent-${AWS::Region}/windows/amd64/latest/amazon-cloudwatch-agent.msi"
-                If ('${AWS::Region}' -eq 'cn-north-1' -or '${AWS::Region}' -eq 'cn-northwest-1') {
-                    # MSI is not hosted in the Ningxia region
+                If ('${AWS::Partition}' -eq 'aws-cn') {
+                    # CloudWatch Agent installer is not hosted in the Ningxia region
                     $cloudWatchAgentInstaller = "https://s3.cn-north-1.${AWS::URLSuffix}/amazoncloudwatch-agent/windows/amd64/latest/amazon-cloudwatch-agent.msi"
                 }
                 Invoke-WebRequest $cloudWatchAgentInstaller -OutFile c:\Windows\Temp\amazon-cloudwatch-agent.msi

--- a/resources/tenant-onboarding-app.yaml
+++ b/resources/tenant-onboarding-app.yaml
@@ -810,7 +810,12 @@ Resources:
                 <powershell>
                 Start-Transcript -Path "C:\UserData.log" -Append
                 Write-Output ("Download and install the CloudWatch agent")
-                Invoke-WebRequest https://s3.${AWS::Region}.${AWS::URLSuffix}/amazoncloudwatch-agent-${AWS::Region}/windows/amd64/latest/amazon-cloudwatch-agent.msi -OutFile c:\Windows\Temp\amazon-cloudwatch-agent.msi
+                $cloudWatchAgentInstaller = "https://s3.${AWS::Region}.${AWS::URLSuffix}/amazoncloudwatch-agent-${AWS::Region}/windows/amd64/latest/amazon-cloudwatch-agent.msi"
+                If ('${AWS::Region}' -eq 'cn-north-1' -or '${AWS::Region}' -eq 'cn-northwest-1') {
+                    # MSI is not hosted in the Ningxia region
+                    $cloudWatchAgentInstaller = "https://s3.cn-north-1.${AWS::URLSuffix}/amazoncloudwatch-agent/windows/amd64/latest/amazon-cloudwatch-agent.msi"
+                }
+                Invoke-WebRequest $cloudWatchAgentInstaller -OutFile c:\Windows\Temp\amazon-cloudwatch-agent.msi
 
                 Start-Process msiexec.exe -Wait -ArgumentList '/I c:\Windows\Temp\amazon-cloudwatch-agent.msi /quiet'
 
@@ -877,7 +882,12 @@ Resources:
                 <powershell>
                 Start-Transcript -Path "C:\UserData.log" -Append
                 Write-Output ("Download and install the CloudWatch agent")
-                Invoke-WebRequest https://s3.${AWS::Region}.${AWS::URLSuffix}/amazoncloudwatch-agent-${AWS::Region}/windows/amd64/latest/amazon-cloudwatch-agent.msi -OutFile c:\Windows\Temp\amazon-cloudwatch-agent.msi
+                $cloudWatchAgentInstaller = "https://s3.${AWS::Region}.${AWS::URLSuffix}/amazoncloudwatch-agent-${AWS::Region}/windows/amd64/latest/amazon-cloudwatch-agent.msi"
+                If ('${AWS::Region}' -eq 'cn-north-1' -or '${AWS::Region}' -eq 'cn-northwest-1') {
+                    # MSI is not hosted in the Ningxia region
+                    $cloudWatchAgentInstaller = "https://s3.cn-north-1.${AWS::URLSuffix}/amazoncloudwatch-agent/windows/amd64/latest/amazon-cloudwatch-agent.msi"
+                }
+                Invoke-WebRequest $cloudWatchAgentInstaller -OutFile c:\Windows\Temp\amazon-cloudwatch-agent.msi
 
                 Start-Process msiexec.exe -Wait -ArgumentList '/I c:\Windows\Temp\amazon-cloudwatch-agent.msi /quiet'
 

--- a/resources/tenant-onboarding-app.yaml
+++ b/resources/tenant-onboarding-app.yaml
@@ -321,7 +321,7 @@ Resources:
     DependsOn:
       - ECSService
     Properties:
-      ServiceToken: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:sb-${Environment}-set-instance-protection
+      ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sb-${Environment}-set-instance-protection
       AutoScalingGroup: !Ref ECSAutoScalingGroup
       Enable: 'false'
   ECSTaskExecutionRole:
@@ -349,19 +349,19 @@ Resources:
                 Action:
                   - logs:PutLogEvents
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
               - Effect: Allow
                 Action:
                   - logs:CreateLogStream
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
               - Effect: Allow
                 Action:
                   - ecr:BatchCheckLayerAvailability
                   - ecr:GetDownloadUrlForLayer
                   - ecr:BatchGetImage
                 Resource:
-                  - !Sub arn:aws:ecr:${AWS::Region}:${AWS::AccountId}:repository/${ContainerRepository}
+                  - !Sub arn:${AWS::Partition}:ecr:${AWS::Region}:${AWS::AccountId}:repository/${ContainerRepository}
               - Effect: Allow
                 Action:
                   - ecr:GetAuthorizationToken
@@ -370,22 +370,22 @@ Resources:
                 Action:
                   - ssm:GetParameters
                 Resource:
-                  - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${RDSPasswordParam}
+                  - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter${RDSPasswordParam}
               - Effect: Allow
                 Action:
                   - s3:GetObject
                 Resource:
-                  - !Sub 'arn:aws:s3:::{{resolve:ssm:/saas-boost/${Environment}/RESOURCES_BUCKET}}/tenants/${TenantId}/ServiceDiscovery.env'
+                  - !Sub 'arn:${AWS::Partition}:s3:::{{resolve:ssm:/saas-boost/${Environment}/RESOURCES_BUCKET}}/tenants/${TenantId}/ServiceDiscovery.env'
               - Effect: Allow
                 Action:
                   - s3:GetBucketLocation
                 Resource:
-                  - !Sub 'arn:aws:s3:::{{resolve:ssm:/saas-boost/${Environment}/RESOURCES_BUCKET}}'
+                  - !Sub 'arn:${AWS::Partition}:s3:::{{resolve:ssm:/saas-boost/${Environment}/RESOURCES_BUCKET}}'
               - Effect: Allow
                 Action:
                   - fsx:DescribeFileSystems
                 Resource:
-                  - !Sub arn:aws:fsx:${AWS::Region}:${AWS::AccountId}:file-system/*
+                  - !Sub arn:${AWS::Partition}:fsx:${AWS::Region}:${AWS::AccountId}:file-system/*
   ECSLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
@@ -418,19 +418,19 @@ Resources:
                   - firehose:PutRecord
                   - firehose:PutRecordBatch
                 Resource:
-                  - !Sub arn:aws:firehose:${AWS::Region}:${AWS::AccountId}:deliverystream/${MetricsStream}
+                  - !Sub arn:${AWS::Partition}:firehose:${AWS::Region}:${AWS::AccountId}:deliverystream/${MetricsStream}
               - Effect: Allow
                 Action:
                   - events:DescribeEventBus
                   - events:PutEvents
                 Resource:
-                  - !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:event-bus/${EventBus}
+                  - !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:event-bus/${EventBus}
               - Effect: Allow
                 Action:
                   - s3:GetObject
                   - s3:GetObjectVersion
                 Resource:
-                  - !Sub arn:aws:s3:::{{resolve:ssm:/saas-boost/${Environment}/RESOURCES_BUCKET}}/tenants/${TenantId}/*
+                  - !Sub arn:${AWS::Partition}:s3:::{{resolve:ssm:/saas-boost/${Environment}/RESOURCES_BUCKET}}/tenants/${TenantId}/*
   ECSTaskDefinition:
     Type: AWS::ECS::TaskDefinition
     Properties:
@@ -470,7 +470,7 @@ Resources:
       ContainerDefinitions:
         - Name:
             Fn::Join: ['', ['sb-', !Ref Environment, '-tenant-', !Select [0, !Split ['-', !Ref TenantId]], '-', !Ref ServiceResourceName]]
-          Image: !Sub ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${ContainerRepository}:${ContainerRepositoryTag}
+          Image: !Sub ${AWS::AccountId}.dkr.ecr.${AWS::Region}.${AWS::URLSuffix}/${ContainerRepository}:${ContainerRepositoryTag}
           Cpu: !If [Ec2LaunchType, !Ref TaskCPU, !Ref 'AWS::NoValue']
           Memory: !If [Ec2LaunchType, !Ref TaskMemory, !Ref 'AWS::NoValue']
           PortMappings:
@@ -518,7 +518,7 @@ Resources:
                   Value: !Ref MetricsStream
           EnvironmentFiles:
             - Type: s3
-              Value: !Sub 'arn:aws:s3:::{{resolve:ssm:/saas-boost/${Environment}/RESOURCES_BUCKET}}/tenants/${TenantId}/ServiceDiscovery.env'
+              Value: !Sub 'arn:${AWS::Partition}:s3:::{{resolve:ssm:/saas-boost/${Environment}/RESOURCES_BUCKET}}/tenants/${TenantId}/ServiceDiscovery.env'
           MountPoints:
             Fn::If:
               - ProvisionEFS
@@ -538,7 +538,7 @@ Resources:
             Fn::If:
               - ProvisionRDS
               - - Name: DB_PASSWORD
-                  ValueFrom: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${RDSPasswordParam}
+                  ValueFrom: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter${RDSPasswordParam}
               - !Ref 'AWS::NoValue'
   CodePipeline:
     Type: AWS::CodePipeline::Pipeline
@@ -662,8 +662,8 @@ Resources:
             Action:
               - sts:AssumeRole
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
-        - arn:aws:iam::aws:policy/AmazonSSMDirectoryServiceAccess
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMDirectoryServiceAccess
       Policies:
         - PolicyName:
             Fn::Join: ['', ['sb-', !Ref Environment, '-ecs-instance-tenant-', !Select [0, !Split ['-', !Ref TenantId]]]]
@@ -674,12 +674,12 @@ Resources:
                 Action:
                   - logs:PutLogEvents
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
               - Effect: Allow
                 Action:
                   - logs:CreateLogStream
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
               - Effect: Allow
                 Action:
                   - ec2:DescribeTags
@@ -691,7 +691,7 @@ Resources:
                   - ecr:GetDownloadUrlForLayer
                   - ecr:BatchGetImage
                 Resource:
-                  - !Sub arn:aws:ecr:${AWS::Region}:${AWS::AccountId}:repository/${ContainerRepository}
+                  - !Sub arn:${AWS::Partition}:ecr:${AWS::Region}:${AWS::AccountId}:repository/${ContainerRepository}
               - Effect: Allow
                 Action:
                   - ecr:GetAuthorizationToken
@@ -704,17 +704,17 @@ Resources:
                   - ecs:SubmitContainerStateChange
                   - ecs:SubmitTaskStateChange
                 Resource:
-                  - !Sub arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:cluster/${ECSCluster}
+                  - !Sub arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:cluster/${ECSCluster}
               - Effect: Allow
                 Action:
                   - ecs:Poll
                   - ecs:StartTelemetrySession
                 Resource:
-                  - !Sub arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:container-instance/*
+                  - !Sub arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:container-instance/*
                 Condition:
                   StringLike:
                     ecs:cluster:
-                      - !Sub arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:cluster/${ECSCluster}
+                      - !Sub arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:cluster/${ECSCluster}
               - Effect: Allow
                 Action:
                   - ecs:DiscoverPollEndpoint
@@ -724,14 +724,14 @@ Resources:
                   - ssm:GetParameter
                   - ssm:GetParameters
                 Resource:
-                  - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/saas-boost/${Environment}/ACTIVE_DIRECTORY_USER
-                  - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/saas-boost/${Environment}/ACTIVE_DIRECTORY_PASSWORD
-                  - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/saas-boost/${Environment}/ACTIVE_DIRECTORY_DNS_IPS
-                  - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/saas-boost/${Environment}/ACTIVE_DIRECTORY_DNS_NAME
+                  - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/saas-boost/${Environment}/ACTIVE_DIRECTORY_USER
+                  - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/saas-boost/${Environment}/ACTIVE_DIRECTORY_PASSWORD
+                  - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/saas-boost/${Environment}/ACTIVE_DIRECTORY_DNS_IPS
+                  - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/saas-boost/${Environment}/ACTIVE_DIRECTORY_DNS_NAME
               - Effect: Allow
                 Action:
                   - kms:Decrypt
-                Resource: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/alias/aws/ssm
+                Resource: !Sub arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/alias/aws/ssm
   ECSInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Condition: Ec2LaunchType
@@ -810,7 +810,7 @@ Resources:
                 <powershell>
                 Start-Transcript -Path "C:\UserData.log" -Append
                 Write-Output ("Download and install the CloudWatch agent")
-                Invoke-WebRequest https://s3.${AWS::Region}.amazonaws.com/amazoncloudwatch-agent-${AWS::Region}/windows/amd64/latest/amazon-cloudwatch-agent.msi -OutFile c:\Windows\Temp\amazon-cloudwatch-agent.msi
+                Invoke-WebRequest https://s3.${AWS::Region}.${AWS::URLSuffix}/amazoncloudwatch-agent-${AWS::Region}/windows/amd64/latest/amazon-cloudwatch-agent.msi -OutFile c:\Windows\Temp\amazon-cloudwatch-agent.msi
 
                 Start-Process msiexec.exe -Wait -ArgumentList '/I c:\Windows\Temp\amazon-cloudwatch-agent.msi /quiet'
 
@@ -877,7 +877,7 @@ Resources:
                 <powershell>
                 Start-Transcript -Path "C:\UserData.log" -Append
                 Write-Output ("Download and install the CloudWatch agent")
-                Invoke-WebRequest https://s3.${AWS::Region}.amazonaws.com/amazoncloudwatch-agent-${AWS::Region}/windows/amd64/latest/amazon-cloudwatch-agent.msi -OutFile c:\Windows\Temp\amazon-cloudwatch-agent.msi
+                Invoke-WebRequest https://s3.${AWS::Region}.${AWS::URLSuffix}/amazoncloudwatch-agent-${AWS::Region}/windows/amd64/latest/amazon-cloudwatch-agent.msi -OutFile c:\Windows\Temp\amazon-cloudwatch-agent.msi
 
                 Start-Process msiexec.exe -Wait -ArgumentList '/I c:\Windows\Temp\amazon-cloudwatch-agent.msi /quiet'
 
@@ -1130,7 +1130,7 @@ Resources:
     Type: AWS::ApplicationAutoScaling::ScalableTarget
     Properties:
       ResourceId: !Sub service/${ECSCluster}/${ECSService.Name}
-      RoleARN: !Sub arn:aws:iam::${AWS::AccountId}:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService
+      RoleARN: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService
       ServiceNamespace: ecs
       ScalableDimension: ecs:service:DesiredCount
       MaxCapacity: !Ref MaxTaskCount
@@ -1165,7 +1165,7 @@ Resources:
     Type: AWS::CloudFormation::Stack
     Condition: ProvisionFSx
     Properties:
-      TemplateURL: !Sub 'https://{{resolve:ssm:/saas-boost/${Environment}/SAAS_BOOST_BUCKET}}.s3.${AWS::Region}.amazonaws.com/tenant-onboarding-fsx.yaml'
+      TemplateURL: !Sub 'https://{{resolve:ssm:/saas-boost/${Environment}/SAAS_BOOST_BUCKET}}.s3.${AWS::Region}.${AWS::URLSuffix}/tenant-onboarding-fsx.yaml'
       Parameters:
         Environment: !Ref Environment
         TenantId: !Ref TenantId
@@ -1190,7 +1190,7 @@ Resources:
     Type: AWS::CloudFormation::Stack
     Condition: ProvisionEFS
     Properties:
-      TemplateURL: !Sub 'https://{{resolve:ssm:/saas-boost/${Environment}/SAAS_BOOST_BUCKET}}.s3.${AWS::Region}.amazonaws.com/tenant-onboarding-efs.yaml'
+      TemplateURL: !Sub 'https://{{resolve:ssm:/saas-boost/${Environment}/SAAS_BOOST_BUCKET}}.s3.${AWS::Region}.${AWS::URLSuffix}/tenant-onboarding-efs.yaml'
       Parameters:
         Environment: !Ref Environment
         TenantId: !Ref TenantId
@@ -1206,7 +1206,7 @@ Resources:
     Type: AWS::CloudFormation::Stack
     Condition: ProvisionRDS
     Properties:
-      TemplateURL: !Sub 'https://{{resolve:ssm:/saas-boost/${Environment}/SAAS_BOOST_BUCKET}}.s3.${AWS::Region}.amazonaws.com/tenant-onboarding-rds.yaml'
+      TemplateURL: !Sub 'https://{{resolve:ssm:/saas-boost/${Environment}/SAAS_BOOST_BUCKET}}.s3.${AWS::Region}.${AWS::URLSuffix}/tenant-onboarding-rds.yaml'
       Parameters:
         Environment: !Ref Environment
         SaaSBoostBucket: !Sub '{{resolve:ssm:/saas-boost/${Environment}/SAAS_BOOST_BUCKET}}'

--- a/resources/tenant-onboarding-fsx.yaml
+++ b/resources/tenant-onboarding-fsx.yaml
@@ -115,7 +115,7 @@ Resources:
           - Effect: Allow
             Principal:
               AWS:
-                - !Sub arn:aws:iam::${AWS::AccountId}:root
+                - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:root
             Action: kms:*
             Resource: '*'
           - Effect: Allow
@@ -504,7 +504,7 @@ Resources:
               - sts:AssumeRole
       Policies:
         - PolicyName:
-            Fn::Join: ['', ['sb-', !Ref Environment, '-fsx-dns-tenant-', !Select [0, !Split ['-', !Ref TenantId]], '-', !Ref ServiceResourceName, '-', !Ref AWS::Region]]
+            Fn::Join: ['', ['sb-', !Ref Environment, '-fsx-dns-tenant-', !Select [0, !Split ['-', !Ref TenantId]], '-', !Ref ServiceResourceName]]
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -512,14 +512,14 @@ Resources:
                 Action:
                   - logs:PutLogEvents
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
               - Effect: Allow
                 Action:
                   - logs:DescribeLogGroups
                   - logs:DescribeLogStreams
                   - logs:CreateLogStream
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
               - Effect: Allow
                 Action:
                   - ec2:CreateNetworkInterface

--- a/resources/tenant-onboarding-rds.yaml
+++ b/resources/tenant-onboarding-rds.yaml
@@ -141,7 +141,7 @@ Resources:
           - Effect: Allow
             Principal:
               AWS:
-                - !Sub arn:aws:iam::${AWS::AccountId}:root
+                - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:root
             Action: kms:*
             Resource: '*'
           - Effect: Allow
@@ -284,7 +284,7 @@ Resources:
               - sts:AssumeRole
       Policies:
         - PolicyName:
-            Fn::Join: ['', ['sb-', !Ref Environment, '-rds-bootstrap-tenant-', !Select [0, !Split ['-', !Ref TenantId]], '-', !Ref ServiceResourceName, '-', !Ref AWS::Region]]
+            Fn::Join: ['', ['sb-', !Ref Environment, '-rds-bootstrap-tenant-', !Select [0, !Split ['-', !Ref TenantId]], '-', !Ref ServiceResourceName]]
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -292,14 +292,14 @@ Resources:
                 Action:
                   - logs:PutLogEvents
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
               - Effect: Allow
                 Action:
                   - logs:DescribeLogGroups
                   - logs:DescribeLogStreams
                   - logs:CreateLogStream
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
               - Effect: Allow
                 Action:
                   - ec2:CreateNetworkInterface
@@ -310,16 +310,16 @@ Resources:
                 Action:
                   - s3:GetObject
                 Resource:
-                  - !Sub 'arn:aws:s3:::{{resolve:ssm:/saas-boost/${Environment}/RESOURCES_BUCKET}}/services/*'
+                  - !Sub 'arn:${AWS::Partition}:s3:::{{resolve:ssm:/saas-boost/${Environment}/RESOURCES_BUCKET}}/services/*'
               - Effect: Allow
                 Action:
                   - ssm:GetParameter
                 Resource:
-                  - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${RDSPasswordParam}
+                  - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter${RDSPasswordParam}
               - Effect: Allow
                 Action:
                   - kms:Decrypt
-                Resource: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*
+                Resource: !Sub arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/*
                 Condition:
                   StringEquals:
                     kms:ViaService:

--- a/samples/dotnet-framework/build.ps1
+++ b/samples/dotnet-framework/build.ps1
@@ -33,7 +33,12 @@ $SERVICE_JSON = (aws ssm get-parameter --name "/saas-boost/$SAAS_BOOST_ENV/app/$
 $ECR_REPO = ($SERVICE_JSON | ConvertFrom-Json).containerRepo
 $TAG = ($SERVICE_JSON | ConvertFrom-Json).containerTag
 
-$DOCKER_REPO = "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$ECR_REPO"
+If ("$AWS_REGION" -eq "cn-northwest-1" -or "$AWS_REGION" -eq "cn-north-1") {
+    $DOCKER_REPO = "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com.cn/$ECR_REPO"
+}
+Else {
+    $DOCKER_REPO = "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$ECR_REPO"
+}
 $DOCKER_TAG = "{0}:{1}" -f $DOCKER_REPO, $TAG
 
 #Write-Output $DOCKER_TAG

--- a/samples/java/build.sh
+++ b/samples/java/build.sh
@@ -48,7 +48,12 @@ if [ -z "$ECR_REPO" ]; then
     echo "Something went wrong: can't get ECR repo from Parameter Store. Exiting."
     exit 1
 fi
-DOCKER_REPO="$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$ECR_REPO"
+
+if [ "$AWS_REGION" = "cn-northwest-1" ] || [ "$AWS_REGION" = "cn-north-1" ]; then
+	DOCKER_REPO="$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com.cn/$ECR_REPO"
+else
+	DOCKER_REPO="$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$ECR_REPO"
+fi
 DOCKER_TAG="$DOCKER_REPO:latest"
 
 AWS_CLI_VERSION=$(aws --version 2>&1 | awk -F / '{print $2}' | cut -c 1)

--- a/services/metrics-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/MetricServiceDAL.java
+++ b/services/metrics-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/MetricServiceDAL.java
@@ -57,7 +57,7 @@ public class MetricServiceDAL {
     private final ApplicationAutoScalingClient autoScaling;
     private final CloudWatchClient cloudWatch;
     private final S3Client s3;
-    private final S3Presigner s3Presigner;
+    private final S3Presigner presigner;
     private final AthenaClient athenaClient;
     private final Map<String, MetricDimension> dataQueryDimMap = new LinkedHashMap<>();
 
@@ -82,10 +82,14 @@ public class MetricServiceDAL {
         this.cloudWatch = Utils.sdkClient(CloudWatchClient.builder(), CloudWatchClient.SERVICE_NAME);
         this.autoScaling = Utils.sdkClient(ApplicationAutoScalingClient.builder(), ApplicationAutoScalingClient.SERVICE_NAME);
         try {
-            this.s3Presigner = S3Presigner.builder()
+            String presignerEndpoint = "https://" + s3.serviceName() + "."
+                + Region.of(AWS_REGION)
+                + "."
+                + Utils.endpointDomain(AWS_REGION);
+            this.presigner = S3Presigner.builder()
                     .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
                     .region(Region.of(AWS_REGION))
-                    .endpointOverride(new URI("https://" + s3.serviceName() + "." + Region.of(AWS_REGION) + ".amazonaws.com")) // will break in China regions
+                    .endpointOverride(new URI(presignerEndpoint))
                     .build();
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);
@@ -724,7 +728,7 @@ public class MetricServiceDAL {
 
         // Generate the presigned request
         LOGGER.info("Generating presigned S3 URL for {}{}", S3_ATHENA_BUCKET, key);
-        PresignedGetObjectRequest presignedGetObjectRequest = s3Presigner.presignGetObject(getObjectPresignRequest);
+        PresignedGetObjectRequest presignedGetObjectRequest = presigner.presignGetObject(getObjectPresignRequest);
         URL url;
         if (presignedGetObjectRequest.isBrowserExecutable()) {
             url = presignedGetObjectRequest.url();

--- a/services/metrics-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/MetricServiceDAL.java
+++ b/services/metrics-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/MetricServiceDAL.java
@@ -85,7 +85,7 @@ public class MetricServiceDAL {
             String presignerEndpoint = "https://" + s3.serviceName() + "."
                 + Region.of(AWS_REGION)
                 + "."
-                + Utils.endpointDomain(AWS_REGION);
+                + Utils.endpointSuffix(AWS_REGION);
             this.presigner = S3Presigner.builder()
                     .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
                     .region(Region.of(AWS_REGION))

--- a/services/onboarding-service/pom.xml
+++ b/services/onboarding-service/pom.xml
@@ -33,7 +33,7 @@ limitations under the License.
     </licenses>
 
     <properties>
-        <checkstyle.maxAllowedViolations>148</checkstyle.maxAllowedViolations>
+        <checkstyle.maxAllowedViolations>146</checkstyle.maxAllowedViolations>
     </properties>
 
     <build>

--- a/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingService.java
+++ b/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingService.java
@@ -2240,6 +2240,7 @@ public class OnboardingService {
                 String domainName, 
                 CloudFormationClient cfnClient, // separate out clients for testability
                 Route53Client route53Client) {
+        LOGGER.debug("Locating SaaS Boost provisioned Hosted Zone for domain {}", domainName);
         if (Utils.isNotBlank(domainName)) {
             final String hostedZoneCfnName = "PublicDomainHostedZone";
             // need to find the core stack to find whether we already created a hostedZone
@@ -2271,6 +2272,7 @@ public class OnboardingService {
             }
 
             if (!saasBoostOwnsHostedZone) {
+                LOGGER.debug("Found SaaS Boost provisioned Hosted Zone in CloudFormation");
                 String existingHostedZone = getExistingHostedZone(domainName, route53Client);
                 if (Utils.isNotBlank(existingHostedZone)) {
                     /*
@@ -2280,6 +2282,7 @@ public class OnboardingService {
                     return existingHostedZone;
                 }
             } else {
+                LOGGER.debug("No SaaS Boost provisioned Hosted Zone in CloudFormation");
                 /*
                  * If there exists a hostedZone and we DO own it, we don't want to pass the hostedZone
                  * name to the stack, since the condition to create the hostedZone will evaluate to 

--- a/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingService.java
+++ b/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingService.java
@@ -103,7 +103,7 @@ public class OnboardingService {
             String presignerEndpoint = "https://" + s3.serviceName() + "."
                     + Region.of(AWS_REGION)
                     + "."
-                    + Utils.endpointDomain(AWS_REGION);
+                    + Utils.endpointSuffix(AWS_REGION);
             this.presigner = S3Presigner.builder()
                     .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
                     .region(Region.of(AWS_REGION))
@@ -590,7 +590,7 @@ public class OnboardingService {
                 // Now run the onboarding stack to provision the infrastructure for this tenant
                 LOGGER.info("OnboardingService::provisionTenant create stack " + stackName);
                 String templateUrl = "https://" + SAAS_BOOST_BUCKET + ".s3." + AWS_REGION
-                        + "." + Utils.endpointDomain(AWS_REGION) + "/tenant-onboarding.yaml";
+                        + "." + Utils.endpointSuffix(AWS_REGION) + "/tenant-onboarding.yaml";
                 String stackId;
                 try {
                     CreateStackResponse cfnResponse = cfn.createStack(CreateStackRequest.builder()
@@ -1026,7 +1026,7 @@ public class OnboardingService {
                         // Now run the onboarding stack to provision the infrastructure for this application service
                         LOGGER.info("OnboardingService::provisionApplication create stack " + stackName);
                         String templateUrl = "https://" + SAAS_BOOST_BUCKET + ".s3." + AWS_REGION
-                                + "." + Utils.endpointDomain(AWS_REGION) + "/tenant-onboarding-app.yaml";
+                                + "." + Utils.endpointSuffix(AWS_REGION) + "/tenant-onboarding-app.yaml";
                         String stackId;
                         try {
                             CreateStackResponse cfnResponse = cfn.createStack(CreateStackRequest.builder()
@@ -1597,7 +1597,7 @@ public class OnboardingService {
             Map<String, Object> settings = fetchSettingsForTenantUpdate(context);
             final String lambdaSourceFolder = (String) settings.get("SAAS_BOOST_LAMBDAS_FOLDER");
             final String templateUrl = "https://" + settings.get("SAAS_BOOST_BUCKET") + ".s3."
-                    + Utils.endpointDomain(AWS_REGION) + "/" + settings.get("ONBOARDING_TEMPLATE");
+                    + Utils.endpointSuffix(AWS_REGION) + "/" + settings.get("ONBOARDING_TEMPLATE");
 
             List<Parameter> templateParameters = new ArrayList<>();
             templateParameters.add(Parameter.builder().parameterKey("TenantId").usePreviousValue(Boolean.TRUE).build());

--- a/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SettingsService.java
+++ b/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SettingsService.java
@@ -88,7 +88,7 @@ public class SettingsService implements RequestHandler<Map<String, Object>, APIG
             String presignerEndpoint = "https://" + s3.serviceName() + "."
                     + Region.of(AWS_REGION)
                     + "."
-                    + Utils.endpointDomain(AWS_REGION);
+                    + Utils.endpointSuffix(AWS_REGION);
             this.presigner = S3Presigner.builder()
                     .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
                     .region(Region.of(AWS_REGION))

--- a/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SettingsService.java
+++ b/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SettingsService.java
@@ -85,10 +85,14 @@ public class SettingsService implements RequestHandler<Map<String, Object>, APIG
         this.eventBridge = Utils.sdkClient(EventBridgeClient.builder(), EventBridgeClient.SERVICE_NAME);
         this.s3 = Utils.sdkClient(S3Client.builder(), S3Client.SERVICE_NAME);
         try {
+            String presignerEndpoint = "https://" + s3.serviceName() + "."
+                    + Region.of(AWS_REGION)
+                    + "."
+                    + Utils.endpointDomain(AWS_REGION);
             this.presigner = S3Presigner.builder()
                     .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
                     .region(Region.of(AWS_REGION))
-                    .endpointOverride(new URI("https://" + s3.serviceName() + "." + Region.of(AWS_REGION) + ".amazonaws.com")) // will break in China regions
+                    .endpointOverride(new URI(presignerEndpoint))
                     .build();
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);

--- a/services/settings-service/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/SettingsServiceDALTest.java
+++ b/services/settings-service/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/SettingsServiceDALTest.java
@@ -19,10 +19,6 @@ package com.amazon.aws.partners.saasfactory.saasboost;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import software.amazon.awssdk.awscore.endpoint.DefaultServiceEndpointBuilder;
-import software.amazon.awssdk.regions.*;
-import software.amazon.awssdk.regions.internal.util.ServiceMetadataUtils;
-import software.amazon.awssdk.regions.partitionmetadata.AwsPartitionMetadata;
 import software.amazon.awssdk.services.ssm.model.Parameter;
 import software.amazon.awssdk.services.ssm.model.ParameterType;
 

--- a/services/settings-service/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/SettingsServiceDALTest.java
+++ b/services/settings-service/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/SettingsServiceDALTest.java
@@ -19,6 +19,10 @@ package com.amazon.aws.partners.saasfactory.saasboost;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import software.amazon.awssdk.awscore.endpoint.DefaultServiceEndpointBuilder;
+import software.amazon.awssdk.regions.*;
+import software.amazon.awssdk.regions.internal.util.ServiceMetadataUtils;
+import software.amazon.awssdk.regions.partitionmetadata.AwsPartitionMetadata;
 import software.amazon.awssdk.services.ssm.model.Parameter;
 import software.amazon.awssdk.services.ssm.model.ParameterType;
 


### PR DESCRIPTION
Update SaaS Boost to variably refer to the AWS partition and the AWS URL suffix to support running in non US commercial regions. This includes both using the AWS::Partition and AWS::URLSuffix pseudo parameters in CloudFormation as well as updating the Utils library to properly create SDK clients with the correct service endpoints.

Also updating inline IAM policies created as part of an IAM role to drop the AWS region name since inline policies are encompassed by the containing role so their names do not need to be unique as long as the role names are unique.

Co-authored-by: amliuyong <yonmzn@amazon.com>
Co-authored-by: PoeppingT <poeppt@amazon.com>


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
