### PR TITLE
Fix bug deleting SaaS Boost created Route53 Hosted Zone on AppConfig …

### DIFF
--- a/resources/saas-boost-svc-onboarding.yaml
+++ b/resources/saas-boost-svc-onboarding.yaml
@@ -339,6 +339,7 @@ Resources:
               - cloudformation:CreateChangeSet
               - cloudformation:DeleteStack
               - cloudformation:DescribeStacks
+              - cloudformation:DescribeStackResource
             Resource:
               - !Sub arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sb-${Environment}*
               - !Sub arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:transform/saas-boost-app-services-macro

--- a/services/onboarding-service/pom.xml
+++ b/services/onboarding-service/pom.xml
@@ -33,7 +33,7 @@ limitations under the License.
     </licenses>
 
     <properties>
-        <checkstyle.maxAllowedViolations>200</checkstyle.maxAllowedViolations>
+        <checkstyle.maxAllowedViolations>148</checkstyle.maxAllowedViolations>
     </properties>
 
     <build>

--- a/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingService.java
+++ b/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingService.java
@@ -1767,8 +1767,9 @@ public class OnboardingService {
 
         Map<String, Object> appConfig = getAppConfig(context);
         Map<String, Object> services = (Map<String, Object>) appConfig.get("services");
+
         String domainName = (String) appConfig.getOrDefault("domainName", "");
-        String hostedZone = getExistingHostedZone(domainName);
+        String hostedZone = chooseHostedZoneParameter(stackName, domainName, cfn, route53);
 
         // If there's an existing hosted zone, we need to tell the AppConfig about it
         // Otherwise, if there's a domain name, CloudFormation will create a hosted zone
@@ -2185,14 +2186,15 @@ public class OnboardingService {
         return pathPriority;
     }
 
-    protected String getExistingHostedZone(String domainName) {
+    // separate out route53 client for testability
+    protected static String getExistingHostedZone(String domainName, Route53Client route53Client) {
         String existingHostedZone = "";
         if (Utils.isNotEmpty(domainName)) {
             String nextDnsName = null;
             String nextHostedZone = null;
             ListHostedZonesByNameResponse response;
             do {
-                response = route53.listHostedZonesByName(ListHostedZonesByNameRequest.builder()
+                response = route53Client.listHostedZonesByName(ListHostedZonesByNameRequest.builder()
                         .dnsName(nextDnsName)
                         .hostedZoneId(nextHostedZone)
                         .maxItems("100")
@@ -2223,5 +2225,65 @@ public class OnboardingService {
             } while (response.isTruncated());
         }
         return existingHostedZone;
+    }
+
+    protected static String chooseHostedZoneParameter(
+                String stackName, 
+                String domainName, 
+                CloudFormationClient cfnClient, // separate out clients for testability
+                Route53Client route53Client) {
+        if (Utils.isNotBlank(domainName)) {
+            final String hostedZoneCfnName = "PublicDomainHostedZone";
+            // need to find the core stack to find whether we already created a hostedZone
+            // this call might throw a CloudFormationException if the stack or the core resource does not exist
+            // in either case, we couldn't possibly continue with our updateInfrastructure operation, so allow
+            // it to bubble up into the logs. unfortunately there's currently no way to percolate a serious fatal
+            // state error through the system
+            final StackResourceDetail coreStackResourceDetail = cfnClient.describeStackResource(
+                    DescribeStackResourceRequest.builder()
+                            .stackName(stackName)
+                            .logicalResourceId("core")
+                            .build())
+                    .stackResourceDetail();
+            boolean saasBoostOwnsHostedZone = false;
+            try {
+                cfnClient.describeStackResource(DescribeStackResourceRequest.builder()
+                        .stackName(coreStackResourceDetail.physicalResourceId())
+                        .logicalResourceId(hostedZoneCfnName)
+                        .build());
+                // because we didn't throw, the resource must exist. so saasBoost has created
+                // a hostedZone for this environment
+                saasBoostOwnsHostedZone = true;
+            } catch (CloudFormationException cfne) {
+                // if the exception is that the resource does not exist, that means that we have not created
+                // a hosted zone in this environment. any other exception is unexpected and should be rethrown
+                if (!cfne.getMessage().contains("Resource " + hostedZoneCfnName + " does not exist")) {
+                    throw new RuntimeException(cfne);
+                }
+            }
+
+            if (!saasBoostOwnsHostedZone) {
+                String existingHostedZone = getExistingHostedZone(domainName, route53Client);
+                if (Utils.isNotBlank(existingHostedZone)) {
+                    /*
+                     * If there exists a hostedZone and we don't own it, we want to pass that hostedZone
+                     * name to the stack, since that means it won't be created
+                     */
+                    return existingHostedZone;
+                }
+            } else {
+                /*
+                 * If there exists a hostedZone and we DO own it, we don't want to pass the hostedZone
+                 * name to the stack, since the condition to create the hostedZone will evaluate to 
+                 * false and the owned hostedZone will be deleted
+                 * 
+                 * If there does not exist a hostedZone we won't own it (because it doesn't exist) but
+                 * either way we would not want to pass a hostedZone name in so that the stack
+                 * creates one. This might be happening on an initial configuration of domainName in
+                 * AppConfig.
+                 */
+            }
+        }
+        return "";
     }
 }

--- a/services/onboarding-service/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingServiceTest.java
+++ b/services/onboarding-service/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingServiceTest.java
@@ -16,16 +16,30 @@
 
 package com.amazon.aws.partners.saasfactory.saasboost;
 
-import com.amazonaws.services.lambda.runtime.events.SQSEvent;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
+import org.mockito.ArgumentMatcher;
+import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
+import software.amazon.awssdk.services.cloudformation.model.CloudFormationException;
+import software.amazon.awssdk.services.cloudformation.model.DescribeStackResourceRequest;
+import software.amazon.awssdk.services.cloudformation.model.DescribeStackResourceResponse;
+import software.amazon.awssdk.services.cloudformation.model.StackResourceDetail;
+import software.amazon.awssdk.services.route53.Route53Client;
+import software.amazon.awssdk.services.route53.model.HostedZone;
+import software.amazon.awssdk.services.route53.model.HostedZoneConfig;
+import software.amazon.awssdk.services.route53.model.ListHostedZonesByNameRequest;
+import software.amazon.awssdk.services.route53.model.ListHostedZonesByNameResponse;
 
 import java.io.InputStream;
 import java.util.*;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 public class OnboardingServiceTest {
 
@@ -101,5 +115,100 @@ public class OnboardingServiceTest {
         expected.keySet().stream().forEach(key -> {
             assertEquals("Value mismatch for '" + key + "'", expected.get(key), actual.get(key));
         });
+    }
+
+    @Test
+    public void testChooseHostedZoneParameter_blankDomainName() {
+        // blank domain name returns ""
+        assertEquals("", OnboardingService.chooseHostedZoneParameter("", "", null, null));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testChooseHostedZoneParameter_baseStackNotExist() {
+        // mock cfn. exception on looking for core is rethrown
+        final String stackName = "nostack";
+        final String domainName = "test.exampleDomain.saasBoost";
+        CloudFormationClient mockCfn = mock(CloudFormationClient.class);
+        CloudFormationException toThrow = (CloudFormationException) CloudFormationException.builder()
+                .message("Stack '" + stackName + "' does not exist").build();
+        doThrow(toThrow).when(mockCfn).describeStackResource(any(DescribeStackResourceRequest.class));
+        OnboardingService.chooseHostedZoneParameter(stackName, domainName, mockCfn, null);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testChooseHostedZoneParameter_coreResourceNotExist() {
+        // mock cfn. exception on looking for core is rethrown
+        final String stackName = "nostack";
+        final String domainName = "test.exampleDomain.saasBoost";
+        CloudFormationClient mockCfn = mock(CloudFormationClient.class);
+        CloudFormationException toThrow = (CloudFormationException) CloudFormationException.builder()
+                .message("Resource core does not exist for stack " + stackName).build();
+        doThrow(toThrow).when(mockCfn).describeStackResource(any(DescribeStackResourceRequest.class));
+        OnboardingService.chooseHostedZoneParameter(stackName, domainName, mockCfn, null);
+    }
+
+    @Test
+    public void testChooseHostedZoneParameter_hostedZoneResourceNotExist() {
+        // mock cfn and route53. exception on looking for PublicDomainHostedZone returns "". no calls to route53
+        final String stackName = "nostack";
+        final String domainName = "test.exampleDomain.saasBoost";
+        CloudFormationClient mockCfn = mock(CloudFormationClient.class);
+        Route53Client mockR53 = mock(Route53Client.class);
+        DescribeStackResourceResponse validResponse = DescribeStackResourceResponse.builder()
+                .stackResourceDetail(StackResourceDetail.builder().physicalResourceId("example").build())
+                .build();
+        doReturn(validResponse).when(mockCfn).describeStackResource(argThat(
+            new ArgumentMatcher<DescribeStackResourceRequest>() {
+                @Override
+                public boolean matches(DescribeStackResourceRequest request) {
+                    return request.logicalResourceId().equals("core");
+                }
+            }));
+        // by not throwing an exception when chooseHostedZoneParameter looks for PublicDomainHostedZone, we imply
+        // that the resource does exist as part of the core stack.
+        OnboardingService.chooseHostedZoneParameter(stackName, domainName, mockCfn, mockR53);
+        // since SaaS Boost owns the HostedZone (because we didn't throw when looking for the HostedZone resource)
+        // we have no reason to go to Route53, since we don't want to include the HostedZone parameter when updating
+        verify(mockR53, never());
+    }
+
+    @Test
+    public void testChooseHostedZoneParameter_hostedZoneResourceExist() {
+        // mock cfn and route53. success looking for PublicDomainHostedZone returns the foundHostedZone mocked (none or some)
+        final String stackName = "nostack";
+        final String domainName = "test.exampleDomain.saasBoost";
+        final String hostedZoneCfnLogicalId = "PublicDomainHostedZone";
+        CloudFormationClient mockCfn = mock(CloudFormationClient.class);
+        Route53Client mockR53 = mock(Route53Client.class);
+        CloudFormationException toThrow = (CloudFormationException) CloudFormationException.builder()
+                .message("Resource " + hostedZoneCfnLogicalId + " does not exist for stack " + stackName).build();
+        doThrow(toThrow).when(mockCfn).describeStackResource(argThat(
+            new ArgumentMatcher<DescribeStackResourceRequest>() {
+                @Override
+                public boolean matches(DescribeStackResourceRequest request) {
+                    return request.logicalResourceId().equals(hostedZoneCfnLogicalId);
+                }
+            }));
+        DescribeStackResourceResponse validResponse = DescribeStackResourceResponse.builder()
+                .stackResourceDetail(StackResourceDetail.builder().physicalResourceId("example").build())
+                .build();
+        doReturn(validResponse).when(mockCfn).describeStackResource(argThat(
+            new ArgumentMatcher<DescribeStackResourceRequest>() {
+                @Override
+                public boolean matches(DescribeStackResourceRequest request) {
+                    return request.logicalResourceId().equals("core");
+                }
+            }));
+        final String testBoostId = "ABCDEFGHIJKL123";
+        final HostedZoneConfig boostCreatedHostedZoneConfig = HostedZoneConfig.builder()
+                .privateZone(false).comment(domainName + " Public DNS zone").build();
+        final HostedZone boostCreatedHostedZone = HostedZone.builder()
+                .name(domainName + ".").config(boostCreatedHostedZoneConfig).id("/hostedzone/" + testBoostId).build();
+
+        doReturn(ListHostedZonesByNameResponse.builder()
+                .isTruncated(false)
+                .hostedZones(boostCreatedHostedZone)
+                .build()).when(mockR53).listHostedZonesByName(any(ListHostedZonesByNameRequest.class));
+        assertEquals(testBoostId, OnboardingService.chooseHostedZoneParameter(stackName, domainName, mockCfn, mockR53));
     }
 }


### PR DESCRIPTION
…update.

If you configure a domain name but have no pre-existing HostedZone owned by SaaS Boost to serve that domain name in Route53, SaaS Boost will create one for you. This commit fixes a bug in the OnboardingService when handling AppConfig updates that would delete a HostedZone previously created by this SaaS Boost environment.

Fixes #300 


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
