### PR TITLE
Replace the built-in API Gateway Cognito authorizer with a Lambda Authorizer

### DIFF
--- a/client/web/src/api/common.js
+++ b/client/web/src/api/common.js
@@ -89,7 +89,7 @@ export function getApiServer(endpoint) {
   apiServer.interceptors.request.use(async (r) => {
     //Obtain and pass along Authorization token
     const authorizationToken = await fetchAccessToken()
-    r.headers.Authorization = authorizationToken
+    r.headers.Authorization = "Bearer " + authorizationToken
 
     //Configure the AbortSignal
     r.signal.onabort = () => {

--- a/client/web/src/metrics/api/index.js
+++ b/client/web/src/metrics/api/index.js
@@ -43,7 +43,7 @@ const source = CancelToken.source()
 apiServer.interceptors.request.use(async (r) => {
   //Obtain and pass along Authorization token
   const authorizationToken = await fetchAccessToken()
-  r.headers.Authorization = authorizationToken
+  r.headers.Authorization = "Bearer " + authorizationToken
   r.headers['Content-Type'] = 'application/json'
 
   //Configure the AbortSignal
@@ -58,8 +58,6 @@ apiServer.interceptors.request.use(async (r) => {
 })
 
 datasetServer.interceptors.request.use(async (r) => {
-  //Obtain and pass along Authorization token
-
   r.headers['Content-Type'] = 'application/json'
 
   //Configure the AbortSignal

--- a/client/web/src/settings/api/index.js
+++ b/client/web/src/settings/api/index.js
@@ -33,7 +33,7 @@ const source = CancelToken.source()
 apiServer.interceptors.request.use(async (r) => {
   //Obtain and pass along Authorization token
   const authorizationToken = await fetchAccessToken()
-  r.headers.Authorization = authorizationToken
+  r.headers.Authorization = "Bearer " + authorizationToken
 
   //Configure the AbortSignal
   r.signal.onabort = () => {

--- a/client/web/src/tenant/api/index.js
+++ b/client/web/src/tenant/api/index.js
@@ -34,7 +34,7 @@ apiServer.interceptors.request.use(async (r) => {
   console.log(r)
   //Obtain and pass along Authorization token
   const authorizationToken = await fetchAccessToken()
-  r.headers.Authorization = authorizationToken
+  r.headers.Authorization = "Bearer " + authorizationToken
 
   //Configure the AbortSignal
   if (r.signal) {
@@ -64,7 +64,7 @@ const tenantAPI = {
         mode: 'cors',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: authorizationToken,
+          Authorization: "Bearer " + authorizationToken,
         },
       })
 
@@ -98,7 +98,7 @@ const tenantAPI = {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: authorizationToken,
+          Authorization: "Bearer " + authorizationToken,
         },
       })
       const responseJSON = await handleErrorResponse(response)
@@ -122,7 +122,7 @@ const tenantAPI = {
         }),
         headers: {
           'Content-Type': 'application/json',
-          Authorization: authorizationToken,
+          Authorization: "Bearer " + authorizationToken,
         },
       })
       const responseJSON = await handleErrorResponse(response)

--- a/client/web/src/tier/api/index.js
+++ b/client/web/src/tier/api/index.js
@@ -34,7 +34,7 @@ const source = CancelToken.source()
 apiServer.interceptors.request.use(async (r) => {
   //Obtain and pass along Authorization token
   const authorizationToken = await fetchAccessToken()
-  r.headers.Authorization = authorizationToken
+  r.headers.Authorization = "Bearer " + authorizationToken
 
   //Configure the AbortSignal
   if (r.signal) {
@@ -85,7 +85,7 @@ const tierAPI = {
         }),
         headers: {
           'Content-Type': 'application/json',
-          Authorization: authorizationToken,
+          Authorization: "Bearer " + authorizationToken,
         },
       })
       return await handleErrorResponse(response)
@@ -107,7 +107,7 @@ const tierAPI = {
         }),
         headers: {
           'Content-Type': 'application/json',
-          Authorization: authorizationToken,
+          Authorization: "Bearer " + authorizationToken,
         },
       })
       console.log('tier api update response', response)
@@ -125,7 +125,7 @@ const tierAPI = {
       const response = await fetch(`${apiUri}/tiers/${tierId}`, {
         headers: {
           'Content-Type': 'application/json',
-          Authorization: authorizationToken,
+          Authorization: "Bearer " + authorizationToken,
         },
       })
       return await handleErrorResponse(response)

--- a/client/web/src/users/api/index.js
+++ b/client/web/src/users/api/index.js
@@ -35,7 +35,7 @@ apiServer.interceptors.request.use(async (r) => {
   console.log(r)
   //Obtain and pass along Authorization token
   const authorizationToken = await fetchAccessToken()
-  r.headers.Authorization = authorizationToken
+  r.headers.Authorization = "Bearer " + authorizationToken
 
   //Configure the AbortSignal
   r.signal.onabort = () => {

--- a/functions/authorizer/pom.xml
+++ b/functions/authorizer/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.amazon.aws.partners.saasfactory.saasboost</groupId>
+        <artifactId>saasboost-functions</artifactId>
+        <version>1.0.0</version>
+    </parent>
+    <artifactId>Authorizer</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <licenses>
+        <license>
+            <name>Apache-2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+        </license>
+    </licenses>
+
+    <properties>
+        <checkstyle.maxAllowedViolations>0</checkstyle.maxAllowedViolations>
+    </properties>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <environmentVariables>
+                        <AWS_REGION>us-east-1</AWS_REGION>
+                        <SAAS_BOOST_ENV>test</SAAS_BOOST_ENV>
+                    </environmentVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <version>4.0.0</version>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                    <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+                    <includeOnlyProperties>
+                        <includeOnlyProperty>^git.commit.id.describe</includeOnlyProperty>
+                        <includeOnlyProperty>^git.commit.id.describe-short</includeOnlyProperty>
+                        <includeOnlyProperty>^git.commit.time</includeOnlyProperty>
+                        <includeOnlyProperty>^git.closest.tag.name</includeOnlyProperty>
+                    </includeOnlyProperties>
+                    <commitIdGenerationMode>full</commitIdGenerationMode>
+                    <dotGitDirectory>../../.git</dotGitDirectory>
+                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.amazon.aws.partners.saasfactory.saasboost</groupId>
+            <artifactId>Utils</artifactId>
+            <version>1.0.0</version>
+            <!-- Don't bundle our layer so we get the shared one at runtime -->
+            <scope>provided</scope>
+	</dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.13.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.13.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.auth0</groupId>
+            <artifactId>java-jwt</artifactId>
+            <version>4.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.auth0</groupId>
+            <artifactId>jwks-rsa</artifactId>
+            <version>0.21.1</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/functions/authorizer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/ApiGatewayAuthorizer.java
+++ b/functions/authorizer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/ApiGatewayAuthorizer.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.amazon.aws.partners.saasfactory.saasboost;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.regions.Region;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+
+public class ApiGatewayAuthorizer implements RequestStreamHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ApiGatewayAuthorizer.class);
+    private static final String AWS_REGION = System.getenv("AWS_REGION");
+    private static final String IDENTITY_PROVIDER = System.getenv("IDENTITY_PROVIDER");
+    private final Authorizer authorizer;
+
+    public ApiGatewayAuthorizer() {
+        LOGGER.info("Version Info: {}", Utils.version(this.getClass()));
+        if (Utils.isBlank(AWS_REGION)) {
+            throw new IllegalStateException("Missing required environment variable AWS_REGION");
+        }
+        if (Utils.isBlank(IDENTITY_PROVIDER)) {
+            throw new IllegalStateException("Missing required environment variable IDENTITY_PROVIDER");
+        }
+        // Initialize the authorizer here not in the handler so we can take advantage
+        // of the JWKS cache as long as this execution environment is warm
+        authorizer = AuthorizerFactory.getInstance().getAuthorizer(IDENTITY_PROVIDER);
+        if (authorizer == null) {
+            throw new UnsupportedOperationException("No implementation for IdP " + IDENTITY_PROVIDER);
+        }
+    }
+
+    public void handleRequest(InputStream input, OutputStream output, Context context) {
+        // Using a RequestSteamHandler here because there doesn't seem to be a way to get
+        // a hold of the internal Jackson ObjectMapper from AWS to adjust it to deal with
+        // the uppercase property names in the Policy document
+        TokenAuthorizerRequest event = Utils.fromJson(input, TokenAuthorizerRequest.class);
+        if (null == event) {
+            throw new RuntimeException("Can't deserialize input");
+        }
+        LOGGER.info(Utils.toJson(event));
+
+        AuthorizerResponse response;
+        if (!authorizer.verifyToken(event)) {
+            LOGGER.error("JWT not verified. Returning Not Authorized");
+            response = AuthorizerResponse.builder()
+                    .principalId(event.getAccountId())
+                    .policyDocument(PolicyDocument.builder()
+                            .statement(Statement.builder()
+                                    .effect("Deny")
+                                    .resource(ApiGatewayAuthorizer.apiGatewayResource(event))
+                                    .build()
+                            )
+                            .build()
+                    )
+                    .context(new HashMap<>())
+                    .build();
+        } else {
+            LOGGER.info("JWT verified. Returning Authorized.");
+            response = AuthorizerResponse.builder()
+                    .principalId(event.getAccountId())
+                    .policyDocument(PolicyDocument.builder()
+                            .statement(Statement.builder()
+                                    .effect("Allow")
+                                    .resource(ApiGatewayAuthorizer.apiGatewayResource(event))
+                                    .build()
+                            )
+                            .build()
+                    )
+                    .context(new HashMap<>())
+                    .build();
+        }
+        LOGGER.info(Utils.toJson(response));
+
+        try (Writer writer = new OutputStreamWriter(output, StandardCharsets.UTF_8)) {
+            writer.write(Utils.toJson(response));
+            writer.flush();
+        } catch (Exception e) {
+            LOGGER.error(Utils.getFullStackTrace(e));
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+
+    public static String apiGatewayResource(TokenAuthorizerRequest event) {
+        return apiGatewayResource(event, "*", "*");
+    }
+
+    public static String apiGatewayResource(TokenAuthorizerRequest event, String method, String resource) {
+        String partition = Region.of(AWS_REGION).metadata().partition().id();
+        String arn = String.format("arn:%s:execute-api:%s:%s:%s/%s/%s/%s",
+                partition,
+                event.getRegion(),
+                event.getAccountId(),
+                event.getApiId(),
+                event.getStage(),
+                method,
+                resource
+        );
+        return arn;
+    }
+}

--- a/functions/authorizer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/Authorizer.java
+++ b/functions/authorizer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/Authorizer.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.amazon.aws.partners.saasfactory.saasboost;
+
+public interface Authorizer {
+
+    boolean verifyToken(TokenAuthorizerRequest request);
+}

--- a/functions/authorizer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/AuthorizerFactory.java
+++ b/functions/authorizer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/AuthorizerFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.amazon.aws.partners.saasfactory.saasboost;
+
+public class AuthorizerFactory {
+
+    private AuthorizerFactory() {
+    }
+
+    public static AuthorizerFactory getInstance() {
+        return AuthorizerFactoryInstance.instance;
+    }
+
+    public Authorizer getAuthorizer(String identityProvider) {
+        switch (identityProvider) {
+            case "COGNITO":
+                return new CognitoAuthorizer();
+            default:
+                return null;
+        }
+    }
+
+    private static class AuthorizerFactoryInstance {
+        public static final AuthorizerFactory instance = new AuthorizerFactory();
+    }
+}

--- a/functions/authorizer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/AuthorizerResponse.java
+++ b/functions/authorizer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/AuthorizerResponse.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.amazon.aws.partners.saasfactory.saasboost;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@JsonDeserialize(builder = AuthorizerResponse.Builder.class)
+public class AuthorizerResponse {
+
+    private final String principalId;
+    private final PolicyDocument policyDocument;
+    private final Map<String, String> context;
+
+    private AuthorizerResponse(Builder builder) {
+        this.principalId = builder.principalId;
+        this.policyDocument = builder.policyDocument;
+        this.context = builder.context;
+    }
+
+    public String getPrincipalId() {
+        return principalId;
+    }
+
+    public PolicyDocument getPolicyDocument() {
+        return policyDocument;
+    }
+
+    public Map<String, String> getContext() {
+        return context != null ? Map.copyOf(context) : null;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static final class Builder {
+        private String principalId;
+        private PolicyDocument policyDocument = PolicyDocument.builder().build();
+        private Map<String, String> context = new HashMap<>();
+
+        private Builder() {
+        }
+
+        public Builder principalId(String principalId) {
+            this.principalId = principalId;
+            return this;
+        }
+
+        public Builder policyDocument(PolicyDocument policyDocument) {
+            this.policyDocument = policyDocument != null ? policyDocument : PolicyDocument.builder().build();
+            return this;
+        }
+
+        public Builder context(Map<String, String> context) {
+            this.context = context != null ? context : new HashMap<>();
+            return this;
+        }
+
+        public AuthorizerResponse build() {
+            return new AuthorizerResponse(this);
+        }
+    }
+}

--- a/functions/authorizer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/CognitoAuthorizer.java
+++ b/functions/authorizer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/CognitoAuthorizer.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.amazon.aws.partners.saasfactory.saasboost;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.interfaces.JWTVerifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+
+public class CognitoAuthorizer implements Authorizer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CognitoAuthorizer.class);
+    private static final String AWS_REGION = System.getenv("AWS_REGION");
+    private static final String USER_POOL_ID = System.getenv("USER_POOL_ID");
+
+    public CognitoAuthorizer() {
+        LOGGER.info("Version Info: {}", Utils.version(this.getClass()));
+        if (Utils.isBlank(AWS_REGION)) {
+            throw new IllegalStateException("Missing required environment variable AWS_REGION");
+        }
+        if (Utils.isBlank(USER_POOL_ID)) {
+            throw new IllegalStateException("Missing required environment variable USER_POOL_ID");
+        }
+    }
+
+    @Override
+    public boolean verifyToken(TokenAuthorizerRequest request) {
+        // TODO add aud claim and pass client id in to the Lambda as an env variable
+        JWTVerifier verifier = JWT
+                .require(Algorithm.RSA256(new CognitoKeyProvider()))
+                .acceptLeeway(5L)
+                .withClaim("token_use", (claim, token) -> (
+                        "access".equals(claim.asString()) || "id".equals(claim.asString()))
+                )
+                .build();
+        boolean valid = false;
+        try {
+            verifier.verify(request.tokenPayload());
+            valid = true;
+        } catch (JWTVerificationException e) {
+            LOGGER.error(Utils.getFullStackTrace(e));
+        }
+        return valid;
+    }
+}

--- a/functions/authorizer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/CognitoAuthorizer.java
+++ b/functions/authorizer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/CognitoAuthorizer.java
@@ -47,8 +47,10 @@ public class CognitoAuthorizer implements Authorizer {
         // TODO add aud claim and pass client id in to the Lambda as an env variable
         JWTVerifier verifier = JWT
                 .require(Algorithm.RSA256(new CognitoKeyProvider()))
-                .acceptLeeway(5L)
+                .acceptLeeway(5L) // Allowed seconds of clock skew between token issuer and verifier
                 .withClaim("token_use", (claim, token) -> (
+                        // Per Cognito documentation, make sure we got an Access or Identity token
+                        // (not a refresh token)
                         "access".equals(claim.asString()) || "id".equals(claim.asString()))
                 )
                 .build();

--- a/functions/authorizer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/CognitoKeyProvider.java
+++ b/functions/authorizer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/CognitoKeyProvider.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.amazon.aws.partners.saasfactory.saasboost;
+
+import com.auth0.jwk.JwkException;
+import com.auth0.jwk.JwkProvider;
+import com.auth0.jwk.JwkProviderBuilder;
+import com.auth0.jwt.interfaces.RSAKeyProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+
+public class CognitoKeyProvider implements RSAKeyProvider {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CognitoKeyProvider.class);
+    private static final String AWS_REGION = System.getenv("AWS_REGION");
+    private static final String USER_POOL_ID = System.getenv("USER_POOL_ID");
+    private final JwkProvider keyProvider;
+
+    public CognitoKeyProvider() {
+        if (Utils.isBlank(AWS_REGION)) {
+            throw new IllegalStateException("Missing required environment variable AWS_REGION");
+        }
+        if (Utils.isBlank(USER_POOL_ID)) {
+            throw new IllegalStateException("Missing required environment variable USER_POOL_ID");
+        }
+        keyProvider = new JwkProviderBuilder(jwksUrl()).build();
+    }
+
+    @Override
+    public RSAPublicKey getPublicKeyById(String kid) {
+        try {
+            return (RSAPublicKey) keyProvider.get(kid).getPublicKey();
+        } catch (JwkException e) {
+            LOGGER.error(Utils.getFullStackTrace(e));
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public RSAPrivateKey getPrivateKey() {
+        return null;
+    }
+
+    @Override
+    public String getPrivateKeyId() {
+        return null;
+    }
+
+    protected static URL jwksUrl() {
+        URL url = null;
+        try {
+            url = new URL("https://cognito-idp." + AWS_REGION + ".amazonaws.com/" + USER_POOL_ID
+                    + "/.well-known/jwks.json");
+        } catch (MalformedURLException e) {
+            LOGGER.error(Utils.getFullStackTrace(e));
+        }
+        return url;
+    }
+}

--- a/functions/authorizer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/PolicyDocument.java
+++ b/functions/authorizer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/PolicyDocument.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.amazon.aws.partners.saasfactory.saasboost;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@JsonDeserialize(builder = PolicyDocument.Builder.class)
+public class PolicyDocument {
+
+    @JsonIgnore
+    private static final String VERSION = "2012-10-17";
+    @JsonIgnore
+    private final List<Statement> statements;
+
+    private PolicyDocument(Builder builder) {
+        this.statements = builder.statements;
+    }
+
+    @JsonProperty("Version")
+    public String getVersion() {
+        return VERSION;
+    }
+
+    @JsonProperty("Statement")
+    public List<Statement> getStatement() {
+        return List.copyOf(statements);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static final class Builder {
+        private List<Statement> statements = new ArrayList<>(List.of(Statement.builder().build()));
+
+        private Builder() {
+        }
+
+        public Builder statement(Statement... statement) {
+            if (statement != null && statement.length > 0) {
+                statements.clear();
+                Collections.addAll(this.statements, statement);
+            } else {
+                this.statements = new ArrayList<>();
+            }
+            return this;
+        }
+
+        public PolicyDocument build() {
+            return new PolicyDocument(this);
+        }
+    }
+}

--- a/functions/authorizer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/Statement.java
+++ b/functions/authorizer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/Statement.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.amazon.aws.partners.saasfactory.saasboost;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@JsonDeserialize(builder = Statement.Builder.class)
+public class Statement {
+
+    @JsonIgnore
+    private static final String ACTION = "execute-api:Invoke";
+    @JsonIgnore
+    private final String effect;
+    @JsonIgnore
+    private final List<String> resources;
+
+    private Statement(Builder builder) {
+        this.effect = builder.effect;
+        this.resources = builder.resources;
+    }
+
+    @JsonProperty("Action")
+    public String getAction() {
+        return ACTION;
+    }
+
+    @JsonProperty("Effect")
+    public String getEffect() {
+        return effect;
+    }
+
+    @JsonProperty("Resource")
+    public List<String> getResource() {
+        return List.copyOf(resources);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static final class Builder {
+        private String effect = "Deny";
+        private List<String> resources = new ArrayList<>(List.of("*"));
+
+        private Builder() {
+        }
+
+        public Builder effect(String effect) {
+            this.effect = Utils.isNotBlank(effect) ? effect : "Deny";
+            return this;
+        }
+
+        public Builder resource(String... resource) {
+            if (resource != null && resource.length > 0) {
+                resources.clear();
+                Collections.addAll(this.resources, resource);
+            } else {
+                this.resources = new ArrayList<>(List.of("*"));
+            }
+            return this;
+        }
+
+        public Statement build() {
+            return new Statement(this);
+        }
+    }
+}

--- a/functions/authorizer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/TokenAuthorizerRequest.java
+++ b/functions/authorizer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/TokenAuthorizerRequest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.amazon.aws.partners.saasfactory.saasboost;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import java.util.regex.Pattern;
+
+@JsonDeserialize(builder = TokenAuthorizerRequest.Builder.class)
+public class TokenAuthorizerRequest {
+
+    private static final Pattern BEARER_TOKEN_REGEX = Pattern.compile("^[B|b]earer +");
+    private final String type;
+    private final String methodArn;
+    private final String authorizationToken;
+    @JsonIgnore
+    private final String region;
+    @JsonIgnore
+    private final String accountId;
+    @JsonIgnore
+    private final String apiId;
+    @JsonIgnore
+    private final String stage;
+
+    private TokenAuthorizerRequest(Builder builder) {
+        this.type = builder.type;
+        this.methodArn = builder.methodArn;
+        this.authorizationToken = builder.authorizationToken;
+
+        String[] request = methodArn.split(":");
+        String[] apiGatewayArn = request[5].split("/");
+
+        region = request[3];
+        accountId = request[4];
+        apiId = apiGatewayArn[0];
+        stage = apiGatewayArn[1];
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public String getAccountId() {
+        return accountId;
+    }
+
+    public String getApiId() {
+        return apiId;
+    }
+
+    public String getStage() {
+        return stage;
+    }
+
+    public String tokenPayload() {
+        return BEARER_TOKEN_REGEX.split(authorizationToken)[1];
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static final class Builder {
+
+        private String type = "TOKEN";
+        private String methodArn;
+        private String authorizationToken;
+
+        private Builder() {
+        }
+
+        public Builder type(String type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder methodArn(String methodArn) {
+            this.methodArn = methodArn;
+            return this;
+        }
+
+        public Builder authorizationToken(String authorizationToken) {
+            this.authorizationToken = authorizationToken;
+            return this;
+        }
+
+        public TokenAuthorizerRequest build() {
+            return new TokenAuthorizerRequest(this);
+        }
+    }
+}

--- a/functions/authorizer/src/main/resources/lambda-assembly.xml
+++ b/functions/authorizer/src/main/resources/lambda-assembly.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+    <id>lambda</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <outputDirectory></outputDirectory>
+            <directory>${project.build.outputDirectory}</directory>
+            <includes>
+                <include>com/amazon/aws/partners/saasfactory/**</include>
+                <include>log4j2.xml</include>
+                <include>git.properties</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+    <dependencySets>
+        <dependencySet>
+            <useProjectArtifact>false</useProjectArtifact>
+            <useTransitiveDependencies>true</useTransitiveDependencies>
+            <outputDirectory>lib</outputDirectory>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/functions/authorizer/src/main/resources/log4j2.xml
+++ b/functions/authorizer/src/main/resources/log4j2.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Configuration status="WARN">
+    <Appenders>
+        <Lambda name="Lambda">
+            <PatternLayout>
+                <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %X{AWSRequestId} %-5p %C{1} - %m%n</pattern>
+            </PatternLayout>
+        </Lambda>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Lambda"/>
+        </Root>
+        <Logger name="software.amazon.awssdk" level="WARN"/>
+        <Logger name="software.amazon.awssdk.request" level="INFO"/>
+        <Logger name="com.amazon.aws.partners.saasfactory" level="DEBUG"/>
+    </Loggers>
+</Configuration>

--- a/functions/authorizer/src/main/test/java/com/amazon/aws/partners/saasfactory/saasboost/ApiGatewayAuthorizerTest.java
+++ b/functions/authorizer/src/main/test/java/com/amazon/aws/partners/saasfactory/saasboost/ApiGatewayAuthorizerTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.amazon.aws.partners.saasfactory.saasboost;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ApiGatewayAuthorizerTest {
+
+    @Test
+    public void testApiGatewayResource_Default() {
+        TokenAuthorizerRequest event = TokenAuthorizerRequest.builder()
+                .methodArn("arn:aws:execute-api:us-east-1:123456789012:abcdef123/test/GET/request")
+                .build();
+
+        assertEquals("arn:aws:execute-api:us-east-1:123456789012:abcdef123/test/*/*",
+                ApiGatewayAuthorizer.apiGatewayResource(event));
+    }
+
+}

--- a/functions/authorizer/src/main/test/java/com/amazon/aws/partners/saasfactory/saasboost/TokenAuthorizerRequestTest.java
+++ b/functions/authorizer/src/main/test/java/com/amazon/aws/partners/saasfactory/saasboost/TokenAuthorizerRequestTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.amazon.aws.partners.saasfactory.saasboost;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class TokenAuthorizerRequestTest {
+
+    private TokenAuthorizerRequest request;
+
+    @Before
+    public void setup() {
+        request = TokenAuthorizerRequest.builder()
+                .methodArn("arn:aws:execute-api:us-east-1:123456789012:abcdef123/test/GET/request")
+                .authorizationToken("Bearer eyJraWQiOiI1Y21PWU00b0paNXZsVXh1aDBRalhzZXBBNU02RldcL0sxcGQ2YkE3eXRjWT0iLCJhbGciOiJSUzI1NiJ9"
+                        + ".eyJzdWIiOiIxNWY0OWQ5Mi1mNjBkLTQwODktYWRlOC1jYmY1YmY0ZWI1N2EiLCJpc3MiOiJodHRwczpcL1wvY29nbml0by1pZHAuZXUtd2VzdC0xLmFtYXpvbmF3cy5jb21cL2V1LXdlc3QtMV85RWJlS2lYME8iLCJjb2duaXRvOnVzZXJuYW1lIjoibWliZWFyZCtzdnMzMDNkcnlydW5AYW1hem9uLmNvbSIsImN1c3RvbTp0ZW5hbnRfaWQiOiI3N2IyYmUyMC1mMzBhLTQwYzYtYmZmZi0zNzYxMTI4MzJmOTUiLCJnaXZlbl9uYW1lIjoiTGFiIDIiLCJjdXN0b206Y29tcGFueSI6IkNvZ25pdG8gQ29uZmlybWVkIiwiYXVkIjoiNXI1MHZxY21wcDg1ZmdtcjU0bnYwOTczb3MiLCJjdXN0b206cGxhbiI6IlN0YW5kYXJkIFBsYW4iLCJldmVudF9pZCI6IjViZWUzNWMwLTM3MTMtNDA2My05NWY3LWViZWVlZGJhZmNiNyIsInRva2VuX3VzZSI6ImlkIiwiYXV0aF90aW1lIjoxNTczMTA2ODc1LCJleHAiOjE1NzMxMTA0NzUsImlhdCI6MTU3MzEwNjg3NSwiZmFtaWx5X25hbWUiOiJDb2duaXRvIiwiZW1haWwiOiJtaWJlYXJkK3N2czMwM2RyeXJ1bkBhbWF6b24uY29tIn0"
+                        + ".caMbyrFGqUA2oWxiorymOek8iNhfhY9Yr6iwT2XrrDAJcRrix9NT3TzDI9fJkhsOGdnPNEhceNFRckuQOmLdjuoU0UneAc7vf3RwL1c3XCn6MvZwUFxKo3SX1liALEz7cJYZtApze5-7XHQ4X5Mo44kDwd5AbBsH-r8x_b2p7iUp1w6WjOIn1_kmLc1otnwH5BNUnXPdLWx-gaVyd2mJlc3GmJWZzzEmmWB1xy2w0osZwXcthu_lnseVcRNmKds9L2J8Y0i1mEH1ROOKbDo7RKT8k6CCq_akCJ3e4maJ9aRRrIlw3OKoZDz7YYdkpfIiT6_CXLK0BIvaPHGjndLVHw")
+                .build();
+    }
+
+    @Test
+    public void testParseBearerToken() {
+        assertTrue(request.tokenPayload().startsWith("eyJraWQiOiI1Y2"));
+    }
+
+    @Test
+    public void testPrincipalId() {
+        assertEquals("123456789012", request.getAccountId());
+    }
+
+    @Test
+    public void testRegion() {
+        assertEquals("us-east-1", request.getRegion());
+    }
+
+    @Test
+    public void testApiId() {
+        assertEquals("abcdef123", request.getApiId());
+    }
+
+    @Test
+    public void testStage() {
+        assertEquals("test", request.getStage());
+    }
+
+    @Test
+    public void testType() {
+        assertEquals("TOKEN", request.getType());
+    }
+
+}

--- a/functions/authorizer/update.sh
+++ b/functions/authorizer/update.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+MY_AWS_REGION=$(aws configure list | grep region | awk '{print $2}')
+echo "AWS Region = $MY_AWS_REGION"
+
+if [ "X$1" = "X" ]; then
+    echo "usage: $0 <Environment>"
+    exit 2
+fi
+ENVIRONMENT=$1
+LAMBDA_STAGE_FOLDER=$2
+if [ "X$LAMBDA_STAGE_FOLDER" = "X" ]; then
+	LAMBDA_STAGE_FOLDER="lambdas"
+fi
+
+LAMBDA_CODE=Authorizer-lambda.zip
+
+#set this for V2 AWS CLI to disable paging
+export AWS_PAGER=""
+
+SAAS_BOOST_BUCKET=`aws ssm get-parameter --name "/saas-boost/${ENVIRONMENT}/SAAS_BOOST_BUCKET" --query "Parameter.Value" --output text`
+echo "SaaS Boost Bucket = $SAAS_BOOST_BUCKET"
+if [ "X$SAAS_BOOST_BUCKET" = "X" ]; then
+    echo "/saas-boost/${ENVIRONMENT}/SAAS_BOOST_BUCKET SSM parameter not read from AWS env"
+    exit 1
+fi
+
+
+
+mvn
+if [ $? -ne 0 ]; then
+    echo "Error building project"
+    exit 1
+fi
+
+aws s3 cp target/$LAMBDA_CODE s3://$SAAS_BOOST_BUCKET/$LAMBDA_STAGE_FOLDER/
+
+FUNCTIONS=("sb-${ENVIRONMENT}-authorizer" 
+        )
+
+for FUNCTION in ${FUNCTIONS[@]}; do
+	#echo $FUNCTION
+	aws lambda --region $MY_AWS_REGION update-function-code --function-name $FUNCTION --s3-bucket $SAAS_BOOST_BUCKET --s3-key $LAMBDA_STAGE_FOLDER/$LAMBDA_CODE
+done

--- a/functions/pom.xml
+++ b/functions/pom.xml
@@ -12,7 +12,8 @@
     <version>1.0.0</version>
     <packaging>pom</packaging>
     <url>https://github.com/awslabs/aws-saas-boost</url>
-    <modules>
+	<modules>
+		<module>authorizer</module>
         <module>core-stack-listener</module>
         <module>ecs-service-update</module>
         <module>ecs-shutdown-services</module>

--- a/functions/system-rest-api-client/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/ApiRequestEvent.java
+++ b/functions/system-rest-api-client/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/ApiRequestEvent.java
@@ -35,7 +35,6 @@ public class ApiRequestEvent {
     private ApiRequest detail;
 
     public ApiRequestEvent() {
-
     }
 
     public String getVersion() {

--- a/resources/saas-boost-public-api.yaml
+++ b/resources/saas-boost-public-api.yaml
@@ -18,6 +18,15 @@ Parameters:
   Environment:
     Description: Environment name
     Type: String
+  SaaSBoostBucket:
+    Description: SaaS Boost assets S3 bucket
+    Type: String
+  LambdaSourceFolder:
+    Description: Folder for lambda source code to change on each deployment
+    Type: String
+  SaaSBoostUtilsLayer:
+    Description: Utils Layer ARN
+    Type: String
   PublicApi:
     Description: API Gateway REST API
     Type: String
@@ -125,6 +134,68 @@ Parameters:
     Description: User Service auth token Lambda ARN
     Type: String
 Resources:
+  AuthorizerExecRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub sb-${Environment}-authorizer-role-${AWS::Region}
+      Path: '/'
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: !Sub sb-${Environment}-authorizer-policy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:PutLogEvents
+                Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogStream
+                  - logs:DescribeLogStreams
+                Resource:
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+  AuthorizerLogs:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/lambda/sb-${Environment}-authorizer
+      RetentionInDays: 30
+  AuthorizerLambda:
+    Type: AWS::Lambda::Function
+    DependsOn: AuthorizerLogs
+    Properties:
+      FunctionName: !Sub sb-${Environment}-authorizer
+      Role: !GetAtt AuthorizerExecRole.Arn
+      Runtime: java11
+      Timeout: 30
+      MemorySize: 1024
+      Handler: com.amazon.aws.partners.saasfactory.saasboost.ApiGatewayAuthorizer
+      Code:
+        S3Bucket: !Ref SaaSBoostBucket
+        S3Key: !Sub ${LambdaSourceFolder}/Authorizer-lambda.zip
+      Layers:
+        - !Ref SaaSBoostUtilsLayer
+      Environment:
+        Variables:
+          SAAS_BOOST_ENV: !Ref Environment
+          JAVA_TOOL_OPTIONS: '-XX:+TieredCompilation -XX:TieredStopAtLevel=1'
+          IDENTITY_PROVIDER: COGNITO
+          USER_POOL_ID: !Ref CognitoUserPoolId
+      Tags:
+        - Key: "Application"
+          Value: "SaaSBoost"
+        - Key: "Environment"
+          Value: !Ref Environment
+        - Key: "BoostService"
+          Value: "Authorizer"
   ApiGatewayLoggingRole:
     Type: AWS::IAM::Role
     Properties:
@@ -145,15 +216,45 @@ Resources:
     Type: AWS::ApiGateway::Account
     Properties:
       CloudWatchRoleArn: !GetAtt ApiGatewayLoggingRole.Arn
-  CognitoAuthorizer:
+  ApiGatewayAccessLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/apigateway/${PublicApi}
+      RetentionInDays: 30
+  ApiGatewayLambdaAuthorizerRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub sb-${Environment}-api-authorizer-role-${AWS::Region}
+      Path: '/'
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - apigateway.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: !Sub sb-${Environment}-api-authorizer-policy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - lambda:invokeFunction
+                Resource:
+                  - !GetAtt AuthorizerLambda.Arn
+  ApiGatewayLambdaAuthorizer:
     Type: AWS::ApiGateway::Authorizer
     Properties:
-      Name: CognitoAuthorizer
       RestApiId: !Ref PublicApi
-      Type: COGNITO_USER_POOLS
-      ProviderARNs:
-        - !Sub arn:${AWS::Partition}:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/${CognitoUserPoolId}
+      Type: TOKEN
+      Name: !Sub sb-${Environment}-pub-api-authorizer
+      AuthorizerCredentials: !GetAtt ApiGatewayLambdaAuthorizerRole.Arn
       IdentitySource: method.request.header.Authorization
+      IdentityValidationExpression: ^[Bb]earer [A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*$
+      AuthorizerUri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${AuthorizerLambda.Arn}/invocations
   BillingServiceResource:
     Type: AWS::ApiGateway::Resource
     Properties:
@@ -202,10 +303,8 @@ Resources:
       RestApiId: !Ref PublicApi
       ResourceId: !Ref BillingServicePlansResource
       HttpMethod: GET
-      AuthorizationType: COGNITO_USER_POOLS
-      AuthorizerId: !Ref CognitoAuthorizer
-      AuthorizationScopes:
-        - aws.cognito.signin.user.admin
+      AuthorizationType: CUSTOM
+      AuthorizerId: !Ref ApiGatewayLambdaAuthorizer
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
@@ -271,10 +370,8 @@ Resources:
       RestApiId: !Ref PublicApi
       ResourceId: !Ref MetricsServiceQueryResource
       HttpMethod: POST
-      AuthorizationType: COGNITO_USER_POOLS
-      AuthorizerId: !Ref CognitoAuthorizer
-      AuthorizationScopes:
-        - aws.cognito.signin.user.admin
+      AuthorizationType: CUSTOM
+      AuthorizerId: !Ref ApiGatewayLambdaAuthorizer
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
@@ -328,10 +425,8 @@ Resources:
       RestApiId: !Ref PublicApi
       ResourceId: !Ref MetricsServiceDatasetsResource
       HttpMethod: GET
-      AuthorizationType: COGNITO_USER_POOLS
-      AuthorizerId: !Ref CognitoAuthorizer
-      AuthorizationScopes:
-        - aws.cognito.signin.user.admin
+      AuthorizationType: CUSTOM
+      AuthorizerId: !Ref ApiGatewayLambdaAuthorizer
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
@@ -385,10 +480,8 @@ Resources:
       RestApiId: !Ref PublicApi
       ResourceId: !Ref MetricsServiceAlbQueryResource
       HttpMethod: GET
-      AuthorizationType: COGNITO_USER_POOLS
-      AuthorizerId: !Ref CognitoAuthorizer
-      AuthorizationScopes:
-        - aws.cognito.signin.user.admin
+      AuthorizationType: CUSTOM
+      AuthorizerId: !Ref ApiGatewayLambdaAuthorizer
       RequestParameters:
         method.request.path.metric: true
         method.request.path.timerange: true
@@ -448,10 +541,8 @@ Resources:
       RestApiId: !Ref PublicApi
       ResourceId: !Ref MetricsServiceAlbQueryByTenantIdResource
       HttpMethod: GET
-      AuthorizationType: COGNITO_USER_POOLS
-      AuthorizerId: !Ref CognitoAuthorizer
-      AuthorizationScopes:
-        - aws.cognito.signin.user.admin
+      AuthorizationType: CUSTOM
+      AuthorizerId: !Ref ApiGatewayLambdaAuthorizer
       RequestParameters:
         method.request.path.metric: true
         method.request.path.timerange: true
@@ -525,10 +616,8 @@ Resources:
       RestApiId: !Ref PublicApi
       ResourceId: !Ref OnboardingServiceResource
       HttpMethod: GET
-      AuthorizationType: COGNITO_USER_POOLS
-      AuthorizerId: !Ref CognitoAuthorizer
-      AuthorizationScopes:
-        - aws.cognito.signin.user.admin
+      AuthorizationType: CUSTOM
+      AuthorizerId: !Ref ApiGatewayLambdaAuthorizer
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
@@ -552,10 +641,8 @@ Resources:
       RestApiId: !Ref PublicApi
       ResourceId: !Ref OnboardingServiceResource
       HttpMethod: POST
-      AuthorizationType: COGNITO_USER_POOLS
-      AuthorizerId: !Ref CognitoAuthorizer
-      AuthorizationScopes:
-        - aws.cognito.signin.user.admin
+      AuthorizationType: CUSTOM
+      AuthorizerId: !Ref ApiGatewayLambdaAuthorizer
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
@@ -609,10 +696,8 @@ Resources:
       RestApiId: !Ref PublicApi
       ResourceId: !Ref OnboardingServiceByIdResource
       HttpMethod: GET
-      AuthorizationType: COGNITO_USER_POOLS
-      AuthorizerId: !Ref CognitoAuthorizer
-      AuthorizationScopes:
-        - aws.cognito.signin.user.admin
+      AuthorizationType: CUSTOM
+      AuthorizerId: !Ref ApiGatewayLambdaAuthorizer
       RequestParameters: {method.request.path.id: true}
       Integration:
         Type: AWS_PROXY
@@ -692,10 +777,8 @@ Resources:
       RestApiId: !Ref PublicApi
       ResourceId: !Ref SettingsServiceResource
       HttpMethod: GET
-      AuthorizationType: COGNITO_USER_POOLS
-      AuthorizerId: !Ref CognitoAuthorizer
-      AuthorizationScopes:
-        - aws.cognito.signin.user.admin
+      AuthorizationType: CUSTOM
+      AuthorizerId: !Ref ApiGatewayLambdaAuthorizer
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
@@ -749,10 +832,8 @@ Resources:
       RestApiId: !Ref PublicApi
       ResourceId: !Ref SettingsServiceOptionsResource
       HttpMethod: GET
-      AuthorizationType: COGNITO_USER_POOLS
-      AuthorizerId: !Ref CognitoAuthorizer
-      AuthorizationScopes:
-        - aws.cognito.signin.user.admin
+      AuthorizationType: CUSTOM
+      AuthorizerId: !Ref ApiGatewayLambdaAuthorizer
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
@@ -806,10 +887,8 @@ Resources:
       RestApiId: !Ref PublicApi
       ResourceId: !Ref SettingsServiceConfigResource
       HttpMethod: GET
-      AuthorizationType: COGNITO_USER_POOLS
-      AuthorizerId: !Ref CognitoAuthorizer
-      AuthorizationScopes:
-        - aws.cognito.signin.user.admin
+      AuthorizationType: CUSTOM
+      AuthorizerId: !Ref ApiGatewayLambdaAuthorizer
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
@@ -833,10 +912,8 @@ Resources:
       RestApiId: !Ref PublicApi
       ResourceId: !Ref SettingsServiceConfigResource
       HttpMethod: PUT
-      AuthorizationType: COGNITO_USER_POOLS
-      AuthorizerId: !Ref CognitoAuthorizer
-      AuthorizationScopes:
-        - aws.cognito.signin.user.admin
+      AuthorizationType: CUSTOM
+      AuthorizerId: !Ref ApiGatewayLambdaAuthorizer
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
@@ -890,10 +967,8 @@ Resources:
       RestApiId: !Ref PublicApi
       ResourceId: !Ref SettingsServiceByIdResource
       HttpMethod: GET
-      AuthorizationType: COGNITO_USER_POOLS
-      AuthorizerId: !Ref CognitoAuthorizer
-      AuthorizationScopes:
-        - aws.cognito.signin.user.admin
+      AuthorizationType: CUSTOM
+      AuthorizerId: !Ref ApiGatewayLambdaAuthorizer
       RequestParameters: {method.request.path.id: true}
       Integration:
         Type: AWS_PROXY
@@ -973,10 +1048,8 @@ Resources:
       RestApiId: !Ref PublicApi
       ResourceId: !Ref TenantServiceResource
       HttpMethod: GET
-      AuthorizationType: COGNITO_USER_POOLS
-      AuthorizerId: !Ref CognitoAuthorizer
-      AuthorizationScopes:
-        - aws.cognito.signin.user.admin
+      AuthorizationType: CUSTOM
+      AuthorizerId: !Ref ApiGatewayLambdaAuthorizer
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
@@ -1030,10 +1103,8 @@ Resources:
       RestApiId: !Ref PublicApi
       ResourceId: !Ref TenantServiceByIdResource
       HttpMethod: GET
-      AuthorizationType: COGNITO_USER_POOLS
-      AuthorizerId: !Ref CognitoAuthorizer
-      AuthorizationScopes:
-        - aws.cognito.signin.user.admin
+      AuthorizationType: CUSTOM
+      AuthorizerId: !Ref ApiGatewayLambdaAuthorizer
       RequestParameters: {method.request.path.id: true}
       Integration:
         Type: AWS_PROXY
@@ -1059,10 +1130,8 @@ Resources:
       RestApiId: !Ref PublicApi
       ResourceId: !Ref TenantServiceByIdResource
       HttpMethod: PUT
-      AuthorizationType: COGNITO_USER_POOLS
-      AuthorizerId: !Ref CognitoAuthorizer
-      AuthorizationScopes:
-        - aws.cognito.signin.user.admin
+      AuthorizationType: CUSTOM
+      AuthorizerId: !Ref ApiGatewayLambdaAuthorizer
       RequestParameters: {method.request.path.id: true}
       Integration:
         Type: AWS_PROXY
@@ -1088,10 +1157,8 @@ Resources:
       RestApiId: !Ref PublicApi
       ResourceId: !Ref TenantServiceByIdResource
       HttpMethod: DELETE
-      AuthorizationType: COGNITO_USER_POOLS
-      AuthorizerId: !Ref CognitoAuthorizer
-      AuthorizationScopes:
-        - aws.cognito.signin.user.admin
+      AuthorizationType: CUSTOM
+      AuthorizerId: !Ref ApiGatewayLambdaAuthorizer
       RequestParameters: {method.request.path.id: true}
       Integration:
         Type: AWS_PROXY
@@ -1147,10 +1214,8 @@ Resources:
       RestApiId: !Ref PublicApi
       ResourceId: !Ref TenantServiceEnableResource
       HttpMethod: PATCH
-      AuthorizationType: COGNITO_USER_POOLS
-      AuthorizerId: !Ref CognitoAuthorizer
-      AuthorizationScopes:
-        - aws.cognito.signin.user.admin
+      AuthorizationType: CUSTOM
+      AuthorizerId: !Ref ApiGatewayLambdaAuthorizer
       RequestParameters: {method.request.path.id: true}
       Integration:
         Type: AWS_PROXY
@@ -1206,10 +1271,8 @@ Resources:
       RestApiId: !Ref PublicApi
       ResourceId: !Ref TenantServiceDisableResource
       HttpMethod: PATCH
-      AuthorizationType: COGNITO_USER_POOLS
-      AuthorizerId: !Ref CognitoAuthorizer
-      AuthorizationScopes:
-        - aws.cognito.signin.user.admin
+      AuthorizationType: CUSTOM
+      AuthorizerId: !Ref ApiGatewayLambdaAuthorizer
       RequestParameters: {method.request.path.id: true}
       Integration:
         Type: AWS_PROXY
@@ -1337,10 +1400,8 @@ Resources:
       RestApiId: !Ref PublicApi
       ResourceId: !Ref TierServiceResource
       HttpMethod: GET
-      AuthorizationType: COGNITO_USER_POOLS
-      AuthorizerId: !Ref CognitoAuthorizer
-      AuthorizationScopes:
-        - aws.cognito.signin.user.admin
+      AuthorizationType: CUSTOM
+      AuthorizerId: !Ref ApiGatewayLambdaAuthorizer
       RequestParameters: {method.request.path.id: true}
       Integration:
         Type: AWS_PROXY
@@ -1366,10 +1427,8 @@ Resources:
       RestApiId: !Ref PublicApi
       ResourceId: !Ref TierServiceResource
       HttpMethod: POST
-      AuthorizationType: COGNITO_USER_POOLS
-      AuthorizerId: !Ref CognitoAuthorizer
-      AuthorizationScopes:
-        - aws.cognito.signin.user.admin
+      AuthorizationType: CUSTOM
+      AuthorizerId: !Ref ApiGatewayLambdaAuthorizer
       RequestParameters: {method.request.path.id: true}
       Integration:
         Type: AWS_PROXY
@@ -1395,10 +1454,8 @@ Resources:
       RestApiId: !Ref PublicApi
       ResourceId: !Ref TierServiceByIdResource
       HttpMethod: GET
-      AuthorizationType: COGNITO_USER_POOLS
-      AuthorizerId: !Ref CognitoAuthorizer
-      AuthorizationScopes:
-        - aws.cognito.signin.user.admin
+      AuthorizationType: CUSTOM
+      AuthorizerId: !Ref ApiGatewayLambdaAuthorizer
       RequestParameters: {method.request.path.id: true}
       Integration:
         Type: AWS_PROXY
@@ -1424,10 +1481,8 @@ Resources:
       RestApiId: !Ref PublicApi
       ResourceId: !Ref TierServiceByIdResource
       HttpMethod: PUT
-      AuthorizationType: COGNITO_USER_POOLS
-      AuthorizerId: !Ref CognitoAuthorizer
-      AuthorizationScopes:
-        - aws.cognito.signin.user.admin
+      AuthorizationType: CUSTOM
+      AuthorizerId: !Ref ApiGatewayLambdaAuthorizer
       RequestParameters: {method.request.path.id: true}
       Integration:
         Type: AWS_PROXY
@@ -1453,10 +1508,8 @@ Resources:
       RestApiId: !Ref PublicApi
       ResourceId: !Ref TierServiceByIdResource
       HttpMethod: DELETE
-      AuthorizationType: COGNITO_USER_POOLS
-      AuthorizerId: !Ref CognitoAuthorizer
-      AuthorizationScopes:
-        - aws.cognito.signin.user.admin
+      AuthorizationType: CUSTOM
+      AuthorizerId: !Ref ApiGatewayLambdaAuthorizer
       RequestParameters: {method.request.path.id: true}
       Integration:
         Type: AWS_PROXY
@@ -1512,10 +1565,8 @@ Resources:
       RestApiId: !Ref PublicApi
       ResourceId: !Ref UserServiceResource
       HttpMethod: GET
-      AuthorizationType: COGNITO_USER_POOLS
-      AuthorizerId: !Ref CognitoAuthorizer
-      AuthorizationScopes:
-        - aws.cognito.signin.user.admin
+      AuthorizationType: CUSTOM
+      AuthorizerId: !Ref ApiGatewayLambdaAuthorizer
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
@@ -1539,10 +1590,8 @@ Resources:
       RestApiId: !Ref PublicApi
       ResourceId: !Ref UserServiceResource
       HttpMethod: POST
-      AuthorizationType: COGNITO_USER_POOLS
-      AuthorizerId: !Ref CognitoAuthorizer
-      AuthorizationScopes:
-        - aws.cognito.signin.user.admin
+      AuthorizationType: CUSTOM
+      AuthorizerId: !Ref ApiGatewayLambdaAuthorizer
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
@@ -1596,10 +1645,8 @@ Resources:
       RestApiId: !Ref PublicApi
       ResourceId: !Ref UserServiceByIdResource
       HttpMethod: GET
-      AuthorizationType: COGNITO_USER_POOLS
-      AuthorizerId: !Ref CognitoAuthorizer
-      AuthorizationScopes:
-        - aws.cognito.signin.user.admin
+      AuthorizationType: CUSTOM
+      AuthorizerId: !Ref ApiGatewayLambdaAuthorizer
       RequestParameters: {method.request.path.id: true}
       Integration:
         Type: AWS_PROXY
@@ -1625,10 +1672,8 @@ Resources:
       RestApiId: !Ref PublicApi
       ResourceId: !Ref UserServiceByIdResource
       HttpMethod: PUT
-      AuthorizationType: COGNITO_USER_POOLS
-      AuthorizerId: !Ref CognitoAuthorizer
-      AuthorizationScopes:
-        - aws.cognito.signin.user.admin
+      AuthorizationType: CUSTOM
+      AuthorizerId: !Ref ApiGatewayLambdaAuthorizer
       RequestParameters: {method.request.path.id: true}
       Integration:
         Type: AWS_PROXY
@@ -1654,10 +1699,8 @@ Resources:
       RestApiId: !Ref PublicApi
       ResourceId: !Ref UserServiceByIdResource
       HttpMethod: DELETE
-      AuthorizationType: COGNITO_USER_POOLS
-      AuthorizerId: !Ref CognitoAuthorizer
-      AuthorizationScopes:
-        - aws.cognito.signin.user.admin
+      AuthorizationType: CUSTOM
+      AuthorizerId: !Ref ApiGatewayLambdaAuthorizer
       RequestParameters: {method.request.path.id: true}
       Integration:
         Type: AWS_PROXY
@@ -1713,10 +1756,8 @@ Resources:
       RestApiId: !Ref PublicApi
       ResourceId: !Ref UserServiceEnableResource
       HttpMethod: PATCH
-      AuthorizationType: COGNITO_USER_POOLS
-      AuthorizerId: !Ref CognitoAuthorizer
-      AuthorizationScopes:
-        - aws.cognito.signin.user.admin
+      AuthorizationType: CUSTOM
+      AuthorizerId: !Ref ApiGatewayLambdaAuthorizer
       RequestParameters: {method.request.path.id: true}
       Integration:
         Type: AWS_PROXY
@@ -1772,10 +1813,8 @@ Resources:
       RestApiId: !Ref PublicApi
       ResourceId: !Ref UserServiceDisableResource
       HttpMethod: PATCH
-      AuthorizationType: COGNITO_USER_POOLS
-      AuthorizerId: !Ref CognitoAuthorizer
-      AuthorizationScopes:
-        - aws.cognito.signin.user.admin
+      AuthorizationType: CUSTOM
+      AuthorizerId: !Ref ApiGatewayLambdaAuthorizer
       RequestParameters: {method.request.path.id: true}
       Integration:
         Type: AWS_PROXY
@@ -1933,16 +1972,21 @@ Resources:
       - UserServiceTokenResourceCORS
     Properties:
       RestApiId: !Ref PublicApi
-      #StageDescription:
-      #  DataTraceEnabled: true
-      #  LoggingLevel: ERROR
-      #StageName: !Ref PublicApiStage
   ApiStage:
     Type: AWS::ApiGateway::Stage
+    DependsOn: ApiGatewayLoggingAccount
     Properties:
       RestApiId: !Ref PublicApi
       StageName: !Ref PublicApiStage
       DeploymentId: !Ref ApiDeployment
+      AccessLogSetting:
+        DestinationArn: !GetAtt ApiGatewayAccessLogGroup.Arn
+        Format: "{\"operationName\":\"$context.operationName\",\"userAgent\":\"$context.identity.userAgent\",\"extendedRequestId\":\"$context.extendedRequestId\",\"requestId\":\"$context.requestId\",\"ip\":\"$context.identity.sourceIp\",\"accountId\":\"$context.identity.accountId\",\"user\":\"$context.identity.user\",\"userArn\":\"$context.identity.userArn\",\"principalOrgId\":\"$context.identity.principalOrgId\",\"requestTime\":\"$context.requestTime\",\"httpMethod\":\"$context.httpMethod\",\"resourcePath\":\"$context.resourcePath\",\"requestPath\":\"$context.path\",\"status\":\"$context.status\",\"latency\":\"$context.responseLatency\",\"integrationLatency\":\"$context.integrationLatency\",\"integrationErrorMessage\":\"$context.integrationErrorMessage\",\"authorizerLatency\":\"$context.authorizer.integrationLatency\",\"xrayTraceId\":\"$context.xrayTraceId\",\"responseLength\":\"$context.responseLength\",\"stage\":\"$context.stage\",\"executions\":$context.executions}"
+      MethodSettings:
+        - DataTraceEnabled: true
+          HttpMethod: '*'
+          LoggingLevel: INFO
+          ResourcePath: '/*'
 Outputs:
   PublicApiGatewayEndpoint:
     Description: SaaS Boost Admin PI Gateway Invoke URL

--- a/resources/saas-boost-web.yaml
+++ b/resources/saas-boost-web.yaml
@@ -120,39 +120,6 @@ Resources:
         - ALLOW_REFRESH_TOKEN_AUTH
         - ALLOW_USER_SRP_AUTH
       GenerateSecret: false
-  ConsoleIdentityPool:
-    Type: AWS::Cognito::IdentityPool
-    Properties:
-      IdentityPoolName: !Sub sb-${Environment}-identities
-      AllowClassicFlow: true
-      AllowUnauthenticatedIdentities: false
-      CognitoIdentityProviders:
-        - ClientId: !Ref ConsoleUserPoolClient
-          ProviderName: !Sub cognito-idp.${AWS::Region}.amazonaws.com/${ConsoleUserPool}
-          ServerSideTokenCheck: true
-  ConsoleIdentityPoolAuthRole:
-    Type: AWS::IAM::Role
-    Properties:
-      RoleName: !Sub sb-${Environment}-cognito-auth-role-${AWS::Region}
-      Path: '/'
-      AssumeRolePolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Principal: {"Federated": "cognito-identity.amazonaws.com"}
-            Action:
-              - sts:AssumeRoleWithWebIdentity
-            Condition:
-              StringEquals:
-                cognito-identity.amazonaws.com:aud:
-                  - !Ref ConsoleIdentityPool
-              ForAnyValue:StringLike: {"cognito-identity.amazonaws.com:amr": authenticated}
-  ConsoleIdentityPoolRoleAttachment:
-    Type: AWS::Cognito::IdentityPoolRoleAttachment
-    Properties:
-      IdentityPoolId: !Ref ConsoleIdentityPool
-      Roles:
-        authenticated: !GetAtt ConsoleIdentityPoolAuthRole.Arn
   # Create the initial admin user
   ConsoleAdminUser:
     Type: AWS::Cognito::UserPoolUser
@@ -161,8 +128,6 @@ Resources:
         - EMAIL
       ForceAliasCreation: false
       UserAttributes:
-        - Name: "custom:identity_pool"
-          Value: !Ref ConsoleIdentityPool
         - Name: "email"
           Value: !Ref AdminEmailAddress
         - Name: "email_verified"
@@ -202,11 +167,6 @@ Outputs:
     Value: !Ref ConsoleUserPoolClient
     Export:
       Name: !Sub saas-boost::${Environment}-${AWS::Region}:userPoolClientId
-  SBIdentityPool:
-    Description: SaaS Boost Identity Pool Id
-    Value: !Ref ConsoleIdentityPool
-    Export:
-      Name: !Sub saas-boost::${Environment}-${AWS::Region}:identityPoolId
   CloudFrontDistributionUrl:
     Description: Saas Boost Cloudfront distribution URL
     Value: !Sub https://${ConsoleCloudFrontDistribution.DomainName}

--- a/resources/saas-boost.yaml
+++ b/resources/saas-boost.yaml
@@ -772,6 +772,9 @@ Resources:
       TemplateURL: !Sub https://${SaaSBoostBucket}.s3.${AWS::URLSuffix}/saas-boost-public-api.yaml
       Parameters:
         Environment: !Ref Environment
+        SaaSBoostBucket: !Ref SaaSBoostBucket
+        LambdaSourceFolder: !Ref LambdaSourceFolder
+        SaaSBoostUtilsLayer: !Ref SaaSBoostUtilsLayer
         PublicApi: !GetAtt core.Outputs.SaaSBoostPublicApi
         RootResourceId: !GetAtt core.Outputs.SaaSBoostPublicApiRootResourceId
         PublicApiStage: !Ref PublicApiStage


### PR DESCRIPTION
Custom Lambda authorizer that does the exact same thing the built-in API Gateway Cognito authorizer does in preparation for supporting different identity providers for API authorization.

This PR also removes the unused Cognito Identity Pool as well as the unused Cognito OAuth scopes.
Include the `Bearer` prefix in the HTTP authorization header to match the OAuth spec and differentiate from other types of authorization.

Co-authored-by: amliuyong <yonmzn@amazon.com>

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
