### PR TITLE
Fix Joda time deserialization bug

### DIFF
--- a/layers/utils/pom.xml
+++ b/layers/utils/pom.xml
@@ -76,6 +76,11 @@ limitations under the License.
             <version>2.13.3</version>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-joda</artifactId>
+            <version>2.13.3</version>
+        </dependency>
+        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>aws-core</artifactId>
             <version>${aws.java.sdk.version}</version>


### PR DESCRIPTION
Likely fixes #365 

Fix for Joda time deserialization bug effecting our CloudFormation listeners. The recent Jackson library update from dependabot #223 changed the default way Jackson deals with unknown class deserialization. Now explicitly supporting Joda date time formats that are used in some of the AWS Lambda Events classes.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
