### PR TITLE
change for CloudFront do not support managed policies in GCR

### DIFF
--- a/resources/saas-boost-web.yaml
+++ b/resources/saas-boost-web.yaml
@@ -27,6 +27,12 @@ Parameters:
   WebS3Bucket:
     Description: S3 Bucket to host the Admin Console web app
     Type: String
+
+Conditions:
+  IsCNRegion: !Or
+    - !Equals [ !Sub '${AWS::Region}', 'cn-north-1' ]
+    - !Equals [ !Sub '${AWS::Region}', 'cn-northwest-1' ]
+
 Resources:
   ConsoleOriginAccessIdentity:
     Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
@@ -68,10 +74,25 @@ Resources:
           TargetOriginId: !Sub sb-${Environment}-s3-website
           ViewerProtocolPolicy: redirect-to-https
           Compress: true
+          ForwardedValues:
+            'Fn::If':
+              - IsCNRegion
+              - QueryString: true
+                Cookies:
+                  Forward: none
+              - !Ref AWS::NoValue
           # CachingOptimized managed cache policy
-          CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6
+          CachePolicyId:
+            'Fn::If':
+              - IsCNRegion
+              - !Ref AWS::NoValue
+              - 658327ea-f89d-4fab-a63d-7e88639e58f6
           # CORS-S3Origin managed origin request policy
-          OriginRequestPolicyId: 88a5eaf4-2fd4-4709-b370-b4c650ea3fcf
+          OriginRequestPolicyId:
+            'Fn::If':
+              - IsCNRegion
+              - !Ref AWS::NoValue
+              - 88a5eaf4-2fd4-4709-b370-b4c650ea3fcf
           # CORS-with-preflight-and-SecurityHeadersPolicy managed response headers policy
           ResponseHeadersPolicyId: eaab4381-ed33-4a86-88ca-d9558dc6cd63
         ViewerCertificate:


### PR DESCRIPTION
----
Use deprecated ForwardedValues property in GCR as CloudFront managed cache policy and managed origin request policy are not currently supported in GCR.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
