### PR TITLE
Instruct users to install jq in cloud9 doc

### DIFF
--- a/docs/install-using-cloud9.md
+++ b/docs/install-using-cloud9.md
@@ -31,20 +31,16 @@ sudo alternatives --config java
 
 sudo alternatives --config javac
 ```
-7.	Upgrade to node 14
+
+7. If you plan on running the sample app, you need to install `jq` for use in our sample build scripts
 ```
-nvm install 14
+sudo yum install jq
 ```
 
-8.	Install yarn
-```
-npm install --global yarn
-```
-
-9.	Run AWS SaaS Boost install script
+8.	Run AWS SaaS Boost install script
 ```
 cd ~/environment/aws-saas-boost
 ./install.sh
 ```
 
-10. Follow the install script prompts to install AWS SaaS Boost!
+9. Follow the install script prompts to install AWS SaaS Boost!


### PR DESCRIPTION
If users are following the `getting-started` guide for starting with SaaS Boost the first time, they will not be able to run the sample application's `build.sh` script (or many of our helper scripts) without having `jq` installed for parsing AWS CLI JSON output. This commit adds a suggestion to run `sudo yum install jq`

Fixes #409 
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
