### PR TITLE
Fix invalid_scope, ensure UserPoolDomain is unique and active.

### DIFF
--- a/resources/custom-resources/customize-cognito-ui/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/CustomizeCognitoUi.java
+++ b/resources/custom-resources/customize-cognito-ui/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/CustomizeCognitoUi.java
@@ -24,6 +24,7 @@ import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.CognitoIdentityProviderException;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.DomainStatusType;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Exception;
@@ -67,6 +68,7 @@ public class CustomizeCognitoUi implements RequestHandler<Map<String, Object>, O
         final Map<String, Object> resourceProperties = (Map<String, Object>) event.get("ResourceProperties");
         final String sourceBucket = (String) resourceProperties.get("SourceBucket");
         final String userPoolId = (String) resourceProperties.get("UserPoolId");
+        final String userPoolDomain = (String) resourceProperties.get("UserPoolDomain");
 
         ExecutorService service = Executors.newSingleThreadExecutor();
         Map<String, Object> responseData = new HashMap<>();
@@ -80,12 +82,13 @@ public class CustomizeCognitoUi implements RequestHandler<Map<String, Object>, O
                                 .bucket(sourceBucket)
                                 .key(ADMIN_WEB_SOURCE_KEY)
                                 .build());
-                        // Extract just the logo image from the ZIP archive
-                        SdkBytes logo = SdkBytes.fromByteArray(unzip(responseInputStream, ADMIN_WEB_LOGO));
                         // Customize the background colors to match the SaaS Boost branding
                         StringBuilder css = new StringBuilder();
                         css.append(".banner-customizable {background-color: " + ADMIN_WEB_BG_COLOR + ";}\n");
                         css.append(".submitButton-customizable {background-color: " + ADMIN_WEB_BG_COLOR + ";}");
+                        // Extract just the logo image from the ZIP archive
+                        SdkBytes logo = SdkBytes.fromByteArray(unzip(responseInputStream, ADMIN_WEB_LOGO));
+                        waitForActiveDomain(userPoolDomain);
                         // Set our UI customizations in Cognito
                         cognito.setUICustomization(request -> request
                                 .userPoolId(userPoolId)
@@ -132,6 +135,25 @@ public class CustomizeCognitoUi implements RequestHandler<Map<String, Object>, O
             service.shutdown();
         }
         return null;
+    }
+
+    protected void waitForActiveDomain(String userPoolDomain) throws Exception {
+        // Cognito cannot set UI customization until UserPoolDomain is ACTIVE
+        // ACTIVE, CREATING, DELETING, FAILED, UPDATING, UNKNOWN_TO_SDK_VERSION
+        DomainStatusType domainStatus = DomainStatusType.CREATING;
+        List<DomainStatusType> terminalStatuses = List.of(
+                DomainStatusType.ACTIVE,
+                DomainStatusType.FAILED,
+                DomainStatusType.UNKNOWN_TO_SDK_VERSION);
+        do {
+            domainStatus = cognito.describeUserPoolDomain(request -> request.domain(userPoolDomain))
+                    .domainDescription().status();
+        } while (!terminalStatuses.contains(domainStatus));
+        if (domainStatus != DomainStatusType.ACTIVE) {
+            String errorMessage = String.format(
+                    "UserPoolDomain %s reached %s instead of ACTIVE", userPoolDomain, domainStatus);
+            throw new Exception(errorMessage);
+        }
     }
 
     protected static byte[] unzip(InputStream archive, String logoPath) {

--- a/resources/saas-boost-idp.yaml
+++ b/resources/saas-boost-idp.yaml
@@ -140,6 +140,8 @@ Resources:
         - code
       AllowedOAuthScopes:
         - openid
+        - email
+        - profile
       CallbackURLs:
         - !Ref AdminWebUrl
         - http://localhost:3000
@@ -150,7 +152,9 @@ Resources:
     Type: AWS::Cognito::UserPoolDomain
     Condition: UseCognito
     Properties:
-      Domain: !Sub sb-${Environment}-saas-boost
+      Domain: !Sub
+        - sb-${Environment}-saas-boost-${RandomString}
+        - RandomString: !Select [2, !Split ['/', !Ref AWS::StackId]]
       UserPoolId: !Ref UserPool
   UserPoolAdminUser:
     Type: AWS::Cognito::UserPoolUser
@@ -170,13 +174,13 @@ Resources:
     Type: AWS::Logs::LogGroup
     Condition: UseCognito
     Properties:
-      LogGroupName: !Sub /aws/lambda/sb-${Environment}-customize-congito-ui
+      LogGroupName: !Sub /aws/lambda/sb-${Environment}-customize-cognito-ui
       RetentionInDays: 30
   CustomizeCognitoUiExecRole:
     Type: AWS::IAM::Role
     Condition: UseCognito
     Properties:
-      RoleName: !Sub sb-${Environment}-customize-congito-ui-role-${AWS::Region}
+      RoleName: !Sub sb-${Environment}-customize-cognito-ui-role-${AWS::Region}
       Path: '/'
       AssumeRolePolicyDocument:
         Version: 2012-10-17
@@ -188,7 +192,7 @@ Resources:
             Action:
               - sts:AssumeRole
       Policies:
-        - PolicyName: !Sub sb-${Environment}-customize-congito-ui-policy
+        - PolicyName: !Sub sb-${Environment}-customize-cognito-ui-policy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -211,12 +215,16 @@ Resources:
                 Action:
                   - cognito-idp:SetUICustomization
                 Resource: !Sub arn:${AWS::Partition}:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/${UserPool}
+              - Effect: Allow
+                Action:
+                  - cognito-idp:DescribeUserPoolDomain
+                Resource: '*'
   CustomizeCognitoUiLambda:
     Type: AWS::Lambda::Function
     Condition: UseCognito
     DependsOn: CustomizeCognitoUiLogs
     Properties:
-      FunctionName: !Sub sb-${Environment}-customize-congito-ui
+      FunctionName: !Sub sb-${Environment}-customize-cognito-ui
       Role: !GetAtt CustomizeCognitoUiExecRole.Arn
       Runtime: java11
       Timeout: 600
@@ -246,6 +254,7 @@ Resources:
     Properties:
       ServiceToken: !GetAtt CustomizeCognitoUiLambda.Arn
       UserPoolId: !Ref UserPool
+      UserPoolDomain: !Ref UserPoolDomain
       SourceBucket: !Ref SaaSBoostBucket
   keycloak:
     Type: AWS::CloudFormation::Stack


### PR DESCRIPTION
This commit contains three bugfixes.
1. Tell Cognito to expect all three default OAuth scopes: openid, profile, and email.
2. Ensure that UserPoolDomain is globally unique by pulling randomness from the CFN-generated random string in the stack name. This prevents collisions across accounts when different people create environments with the same name.
3. Ensure that the CustomizeCognitoUi custom resource only acts once the UserPoolDomain has reached the ACTIVE state, since the Cognito API call to customize the hosted UI will fail otherwise.

Fixes #415 


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
