### PR TITLE
Remove keycloak-metrics-spi.jar when build keycloak

### DIFF
--- a/resources/keycloak/Dockerfile
+++ b/resources/keycloak/Dockerfile
@@ -3,9 +3,6 @@ FROM quay.io/keycloak/keycloak:19.0.3 as builder
 ENV KC_FEATURES=token-exchange
 ENV KC_DB=mysql
 
-# Install custom providers
-RUN curl -sL https://github.com/aerogear/keycloak-metrics-spi/releases/download/2.5.3/keycloak-metrics-spi-2.5.3.jar -o /opt/keycloak/providers/keycloak-metrics-spi-2.5.3.jar
-
 # Build the customized Keycloak setup with MySQL, token exchange, and the metrics service provider interface
 RUN /opt/keycloak/bin/kc.sh build
 


### PR DESCRIPTION
----
Remove the unused jar when build keycloak, as we can't download it from github in China region.

As the connection from China region to Github is slow and unstable, so download the whole jar always cause a timeout error, but the access to Maven is ok.
But I can not find this jar in Maven.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
