### PR TITLE
Change ApiGatewayUrl for web in China region

### DIFF
--- a/resources/saas-boost.yaml
+++ b/resources/saas-boost.yaml
@@ -871,7 +871,7 @@ Resources:
           - HasAdminWebAppCustomDomain
           - !Sub 'https://${AdminWebAppDomain}'
           - !Sub 'https://${AdminWebCloudFrontDistribution.DomainName}'
-        ApiGatewayUrl: !Sub https://${core.Outputs.SaaSBoostPublicApi}.execute-api.${AWS::Region}.amazonaws.com/${PublicApiStage} #!GetAtt publicapi.Outputs.PublicApiGatewayEndpoint
+        ApiGatewayUrl: !Sub https://${core.Outputs.SaaSBoostPublicApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/${PublicApiStage} #!GetAtt publicapi.Outputs.PublicApiGatewayEndpoint
         AdminWebClientId: !GetAtt idp.Outputs.AdminWebAppClient
         OidcIssuerUrl: !GetAtt idp.Outputs.OidcIssuerUrl
   core:


### PR DESCRIPTION
----
Use '{AWS::URLSuffix}' to replace 'amazonaws.com' in China region, for ApiGatewayUrl.
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
