### PR TITLE
Fix client-side uploading of tenant zipfile configuration.

### DIFF
--- a/client/web/src/onboarding/OnboardingCreateContainer.js
+++ b/client/web/src/onboarding/OnboardingCreateContainer.js
@@ -63,7 +63,7 @@ export default function OnboardingCreateContainer() {
     let onboardingResponse
     try {
       onboardingResponse = await dispatch(createOnboarding(valsToSend))
-      const presignedS3url = onboardingResponse.payload.zipFileUrl
+      const presignedS3url = onboardingResponse.payload.zipFile
       if (presignedS3url && !!file && file.name) {
         await dispatch(
           saveToPresignedBucket({ dbFile: file, url: presignedS3url })

--- a/resources/saas-boost.yaml
+++ b/resources/saas-boost.yaml
@@ -296,7 +296,7 @@ Resources:
             - HasAdminWebAppCustomDomain
             - - AllowedOrigins: [http://localhost:3000, !Sub 'https://${AdminWebAppDomain}']
                 AllowedMethods: [PUT]
-            - - AllowedOrigins: [http://localhost:3000, !GetAtt AdminWebCloudFrontDistribution.DomainName]
+            - - AllowedOrigins: [http://localhost:3000, !Sub 'https://${AdminWebCloudFrontDistribution.DomainName}']
                 AllowedMethods: [PUT]
       Tags:
         - Key: SaaS Boost


### PR DESCRIPTION
This commit contains two fixes for client-side uploading of tenant zipfile configuration to the SaaS Boost resources bucket:
1. The Onboarding blob returned from createOnboarding returns the presigned URL as "zipFile", not "zipFileUrl"
2. The SaaS Boost resources bucket needs to configure CORS access under https:// for the CloudFront admin distribution URL.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
