### PR TITLE
Fix tenant onboarding status stucked after stack created

### DIFF
--- a/client/web/src/dashboard/DashboardComponent.js
+++ b/client/web/src/dashboard/DashboardComponent.js
@@ -105,11 +105,15 @@ export const DashboardComponent = (props) => {
 
   const awsAccount = globalConfig.awsAccount
   const awsRegion = globalConfig.region
+  const isCnRegion = awsRegion.startsWith("cn-")
 
-  const fileAwsConsoleLink = `https://${awsRegion}.console.aws.amazon.com/efs/home?region=${awsRegion}#file-systems`
-  const rdsAwsConsoleLink = `https://${awsRegion}.console.aws.amazon.com/rds/home?region=${awsRegion}#databases:`
-  const ecrAwsConsoleLink = `https://${awsRegion}.console.aws.amazon.com/ecr/repositories`
-  const s3BucketLink = `https://s3.console.aws.amazon.com/s3/buckets/${s3Bucket?.value}`
+  const consoleUrlSuffix = isCnRegion? "amazonaws.cn": "aws.amazon.com"
+  const serviceUrlSuffix = isCnRegion? "amazonaws.cn": "amazon.com"
+
+  const fileAwsConsoleLink = `https://${awsRegion}.console.${consoleUrlSuffix}/efs/home?region=${awsRegion}#file-systems`
+  const rdsAwsConsoleLink = `https://${awsRegion}.console.${consoleUrlSuffix}/rds/home?region=${awsRegion}#databases:`
+  const ecrAwsConsoleLink = `https://${awsRegion}.console.${consoleUrlSuffix}/ecr/repositories`
+  const s3BucketLink = `https://s3.console.${consoleUrlSuffix}/s3/buckets/${s3Bucket?.value}`
 
   useEffect(() => {
     const fetchTenants = dispatch(fetchTenantsThunk())
@@ -238,7 +242,7 @@ export const DashboardComponent = (props) => {
                                   href={
                                     ecrAwsConsoleLink +
                                     (service.containerRepo
-                                      ? `/private/${awsAccount}/` +
+                                        ? (isCnRegion ? '/' : `/private/${awsAccount}/`) +
                                         service.containerRepo
                                       : '')
                                   }
@@ -263,7 +267,7 @@ export const DashboardComponent = (props) => {
                                 </ECRInstructions>
                               </dt>
                               <dd className="mb-3">
-                                {awsAccount}.dkr.ecr.{awsRegion}.amazonaws.com
+                                {awsAccount}.dkr.ecr.{awsRegion}.{serviceUrlSuffix}
                                 {service.containerRepo
                                   ? `/${service.containerRepo}`
                                   : ''}

--- a/client/web/src/dashboard/DashboardComponent.js
+++ b/client/web/src/dashboard/DashboardComponent.js
@@ -108,7 +108,7 @@ export const DashboardComponent = (props) => {
   const isCnRegion = awsRegion.startsWith("cn-")
 
   const consoleUrlSuffix = isCnRegion? "amazonaws.cn": "aws.amazon.com"
-  const serviceUrlSuffix = isCnRegion? "amazonaws.cn": "amazon.com"
+  const serviceUrlSuffix = isCnRegion? "amazonaws.cn": "amazonaws.com"
 
   const fileAwsConsoleLink = `https://${awsRegion}.console.${consoleUrlSuffix}/efs/home?region=${awsRegion}#file-systems`
   const rdsAwsConsoleLink = `https://${awsRegion}.console.${consoleUrlSuffix}/rds/home?region=${awsRegion}#databases:`

--- a/client/web/src/settings/ApplicationComponent.js
+++ b/client/web/src/settings/ApplicationComponent.js
@@ -62,7 +62,10 @@ export function ApplicationComponent(props) {
   const LINUX = 'LINUX'
   const WINDOWS = 'WINDOWS'
   const awsRegion = globalConfig.region
-  const acmConsoleLink = `https://${awsRegion}.console.aws.amazon.com/acm/home?region=${awsRegion}#/certificates/list`
+  const consoleUrlSuffix = awsRegion.startsWith("cn-")? "amazonaws.cn": "aws.amazon.com"
+
+  const acmConsoleLink = `https://${awsRegion}.console.${consoleUrlSuffix}/acm/home?region=${awsRegion}#/certificates/list`
+  const showProvisionBilling = awsRegion.startsWith("cn-")? false : true
 
   const updateConfig = (values) => {
     updateConfiguration(values)
@@ -444,10 +447,11 @@ export function ApplicationComponent(props) {
                     }
                     setFieldValue={(k, v) => formik.setFieldValue(k, v)}
                   ></ServicesComponent>
-                  <BillingSubform
-                    provisionBilling={formik.values.provisionBilling}
-                    values={formik.values?.billing}
+                  {showProvisionBilling && <BillingSubform
+                      provisionBilling={formik.values.provisionBilling}
+                      values={formik.values?.billing}
                   ></BillingSubform>
+                  }
                   <Row>
                     <Col xs={12}>
                       <Card>

--- a/layers/cloudformation-utils/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/AwsResource.java
+++ b/layers/cloudformation-utils/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/AwsResource.java
@@ -90,6 +90,9 @@ public enum AwsResource {
             } else {
                 url = String.format(this.urlFormat, region, resourceId);
             }
+            if (Utils.isChinaRegion(region)) {
+                url = url.replace("aws.amazon.com", "amazonaws.cn");
+            }
         } catch (IllegalFormatException e) {
             LOGGER.error("Error formatting URL for {}", this.name(), e);
             LOGGER.error(Utils.getFullStackTrace(e));

--- a/services/onboarding-service/pom.xml
+++ b/services/onboarding-service/pom.xml
@@ -33,7 +33,7 @@ limitations under the License.
     </licenses>
 
     <properties>
-        <checkstyle.maxAllowedViolations>155</checkstyle.maxAllowedViolations>
+        <checkstyle.maxAllowedViolations>160</checkstyle.maxAllowedViolations>
     </properties>
 
     <build>

--- a/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingService.java
+++ b/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingService.java
@@ -1187,7 +1187,11 @@ public class OnboardingService {
             Map<String, Object> detail = (Map<String, Object>) event.get("detail");
             String pipeline = (String) detail.get("pipeline");
             try {
-                String pipelineArn = resources.get(0);
+                String pipelineArnFromResource = resources.get(0);
+                LOGGER.info("pipelineArnFromResource = {} when handle onboarding pipeline status changed", pipelineArnFromResource);
+                final String[] lambdaArn = context.getInvokedFunctionArn().split(":");
+                final String partition = lambdaArn[1];
+                String pipelineArn = pipelineArnFromResource.replace("arn:aws:", "arn:" + partition + ":");
                 LOGGER.info("Fetching tenant id from CodePipeline tags");
                 ListTagsForResourceResponse tagsResponse = codePipeline.listTagsForResource(request -> request
                         .resourceArn(pipelineArn)


### PR DESCRIPTION
----
1. After stacked created when onboarding,  the OnboardingService received an event with error Codepipeline's arn in GCR.
```
{
    "version": "0",
    "id": "be3a95aa-80a9-3830-8553-c7aef201cef7",
    "detail-type": "CodePipeline Pipeline Execution State Change",
    "source": "aws.codepipeline",
    "account": "111",
    "time": "2022-11-18T09:49:22Z",
    "region": "cn-north-1",
    "resources": [
        "arn:aws:codepipeline:cn-north-1:111:sb-test-tenant-e49fb688-main"
    ],
    ...
}
```
which causes the corresponding tenant has not created, and the onboarding status stays in "Provisioned".

2. Fix some url in GCR.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
