### PR TITLE
Manually signout in Cognito environments with a /logout redirect.

### DIFF
--- a/client/web/src/App.js
+++ b/client/web/src/App.js
@@ -31,6 +31,7 @@ App.propTypes = {
 
 function App(props) {
   const oidcAuth = props.oidcAuth
+  const signout = props.signout
   if (props.authState === 'signedIn') {
     return (
       <Provider store={store}>
@@ -38,7 +39,7 @@ function App(props) {
           <ScrollToTop>
             <FetchSettings>
               <Switch>
-              <Route path="/" name="Home" render={(props) => <DefaultLayout {...props} oidcAuth={oidcAuth} />} />
+              <Route path="/" name="Home" render={(props) => <DefaultLayout oidcAuth={oidcAuth} signout={signout} {...props} />} />
               </Switch>
             </FetchSettings>
           </ScrollToTop>

--- a/client/web/src/components/Auth/OidcSignIn.js
+++ b/client/web/src/components/Auth/OidcSignIn.js
@@ -19,17 +19,14 @@ import {
   Button,
   Card,
   CardBody,
-  CardGroup,
   Col,
   Container,
   Row,
   Alert,
 } from 'reactstrap'
-import { useAuth } from 'react-oidc-context'
 import { Redirect } from 'react-router-dom'
 import config from '../../config/appConfig'
-export default function OidcSignIn({ signOutReason }) {
-  const auth = useAuth()
+export default function OidcSignIn({ signOutReason, auth }) {
 
   const signInClickHandler = () => {
     const signInParams = {

--- a/client/web/src/config/appConfig.js
+++ b/client/web/src/config/appConfig.js
@@ -20,7 +20,9 @@ const config = {
   apiUri: process.env.REACT_APP_API_URI,
   awsAccount: process.env.REACT_APP_AWS_ACCOUNT,
   issuer: process.env.REACT_APP_ISSUER,
-  scope: process.env.REACT_APP_SCOPE
+  scope: process.env.REACT_APP_SCOPE,
+  idp: process.env.REACT_APP_IDP,
+  idpDomain: process.env.REACT_APP_IDP_DOMAIN,
 }
 
 export default config

--- a/client/web/src/layout/DefaultLayout.js
+++ b/client/web/src/layout/DefaultLayout.js
@@ -23,7 +23,6 @@ import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 // sidebar nav config
 import navigation from '../_nav'
-import { removeUserInfo } from '../api/common'
 
 const mapStateToProps = (state) => {
   return { settings: state.settings, setup: state.settings.setup }
@@ -33,22 +32,12 @@ class DefaultLayout extends Component {
   constructor(props) {
     super(props)
     this.oidcAuth = props.oidcAuth
+    this.signout = props.signout
     this.state = {
       user: this.oidcAuth.user,
     }
 
-    this.handleSignOut = this.handleSignOut.bind(this)
     this.handleProfileClick = this.handleProfileClick.bind(this)
-  }
-
-  handleSignOut = async () => {
-    try {
-      await this.oidcAuth.signoutRedirect()
-      await this.oidcAuth.removeUser()
-      removeUserInfo()
-    } catch (e) {
-      // do nothing
-    }
   }
 
   handleProfileClick = () => {
@@ -68,9 +57,10 @@ class DefaultLayout extends Component {
   loading = () => (
     <div className="animated fadeIn pt-1 text-center">Loading...</div>
   )
+
   render() {
     const { user } = this.state
-    const { setup } = this.props   
+    const { setup, signout } = this.props
     if (!setup) {
       navigation.forEach((nav) => {
         if (nav.name === 'Application') {
@@ -92,7 +82,7 @@ class DefaultLayout extends Component {
         <div className="wrapper d-flex flex-column min-vw-100 min-vh-100 bg-light">
           <Suspense fallback={this.loading()}>
             <AppHeader
-              onLogout={this.handleSignOut}
+              onLogout={signout}
               handleProfileClick={this.handleProfileClick}
               user={user}
               router={router}

--- a/resources/saas-boost-idp.yaml
+++ b/resources/saas-boost-idp.yaml
@@ -311,6 +311,14 @@ Outputs:
       - UseCognito
       - !Sub https://cognito-idp.${AWS::Region}.amazonaws.com/${UserPool}
       - !GetAtt keycloak.Outputs.KeycloakIssuer
+  # OidcDomainUrl is explicitly different for Cognito and is needed for manual 
+  # logout calls since Cognito does not support OIDC end_session_endpoint
+  OidcDomainUrl:
+    Description: Domain System User IdP sits behind
+    Value: !If
+      - UseCognito
+      - !Sub 'https://${UserPoolDomain}.auth.${AWS::Region}.amazoncognito.com'
+      - ''
   AdminWebAppClient:
     Description: Admin Web App Public App Client for authorization code grants with PKCE
     Value: !If [UseCognito, !Ref AdminWebAppClient, !GetAtt keycloak.Outputs.AdminWebAppClientId]

--- a/resources/saas-boost-web.yaml
+++ b/resources/saas-boost-web.yaml
@@ -39,6 +39,12 @@ Parameters:
   OidcIssuerUrl:
     Description: URL to access authority for configured IDP
     Type: String
+  OidcDomainUrl:
+    Description: URL to build login/logout URLs for configured IDP
+    Type: String
+  SystemIdentityProvider:
+    Description: Configured System IDP
+    Type: String
 Resources:
   AdminWebCodeBuildRole:
     Type: AWS::IAM::Role
@@ -124,6 +130,10 @@ Resources:
             Value: openid profile email
           - Name: REACT_APP_ISSUER
             Value: !Ref OidcIssuerUrl
+          - Name: REACT_APP_IDP_DOMAIN
+            Value: !Ref OidcDomainUrl
+          - Name: REACT_APP_IDP
+            Value: !Ref SystemIdentityProvider
       Source:
         Type: NO_SOURCE
         BuildSpec: |
@@ -132,11 +142,11 @@ Resources:
             pre_build:
               commands:
                 - n 14
+                - if [ "$REACT_APP_AWS_REGION" = "cn-northwest-1" ] || [ "$REACT_APP_AWS_REGION" = "cn-north-1" ]; then npm config set registry https://registry.npm.taobao.org; fi
                 - aws s3 cp s3://$SOURCE_BUCKET/client/web/src.zip src.zip
                 - unzip src.zip
             build:
               commands:
-                - if [ "$REACT_APP_AWS_REGION" = "cn-northwest-1" ] || [ "$REACT_APP_AWS_REGION" = "cn-north-1" ]; then npm config set registry https://registry.npm.taobao.org; fi
                 - cd ./client/web
                 - yarn
                 - yarn build

--- a/resources/saas-boost.yaml
+++ b/resources/saas-boost.yaml
@@ -874,6 +874,8 @@ Resources:
         ApiGatewayUrl: !Sub https://${core.Outputs.SaaSBoostPublicApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/${PublicApiStage} #!GetAtt publicapi.Outputs.PublicApiGatewayEndpoint
         AdminWebClientId: !GetAtt idp.Outputs.AdminWebAppClient
         OidcIssuerUrl: !GetAtt idp.Outputs.OidcIssuerUrl
+        OidcDomainUrl: !GetAtt idp.Outputs.OidcDomainUrl
+        SystemIdentityProvider: !Ref SystemIdentityProvider
   core:
     Type: AWS::CloudFormation::Stack
     DependsOn:


### PR DESCRIPTION
Since Cognito doesn't support the `end_session_endpoint` OIDC parameter relied upon by the oidc-client-ts library we use in the admin application, we need special logic for Cognito environments when implementing logout to make a manual call to the /logout endpoint.

Fixes #441 


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
