### PR TITLE
Fix apigateway permissions in Onboarding for CloudFormation

### DIFF
--- a/resources/saas-boost-svc-onboarding.yaml
+++ b/resources/saas-boost-svc-onboarding.yaml
@@ -314,7 +314,7 @@ Resources:
             Action:
               - apigateway:GET
             Resource:
-              - !Sub arn:${AWS::Partition}:apigateway:*::/restapis/*/resources
+              - !Sub arn:${AWS::Partition}:apigateway:*::/restapis/*
           - Effect: Allow
             Action:
               - lambda:AddPermission


### PR DESCRIPTION
Currently trying to create an AppConfig with an environment from the main branch results in an error when the core stack is updated with the following error: `Unable to retrieve RootResourceId attribute for AWS::ApiGateway::RestApi, with error message "User:
arn:aws:sts::${account}:assumed-role/sb-${env}-onboarding-svc-role-us-west-2/sb-${env}-onboarding-events is not authorized to perform: apigateway:GET on resource: arn:aws:apigateway:us-west-2::/restapis/${restApiId} because no identity-based policy allows the apigateway:GET action`. This commit adds the missing policy, allowing CloudFormation to update correctly.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
