### PR TITLE
Fix for Issue #452

### DIFF
--- a/resources/tenant-onboarding-app.yaml
+++ b/resources/tenant-onboarding-app.yaml
@@ -242,9 +242,6 @@ Parameters:
   WIN2019CORE:
     Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
     Default: /aws/service/ami-windows-latest/Windows_Server-2019-English-Core-ECS_Optimized/image_id
-  WIN20H2CORE:
-    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
-    Default: /aws/service/ami-windows-latest/Windows_Server-20H2-English-Core-ECS_Optimized/image_id
   WIN2016FULL:
     Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
     Default: /aws/service/ami-windows-latest/Windows_Server-2016-English-Full-ECS_Optimized/image_id


### PR DESCRIPTION
Windows 10, version 20H2 has reached end of servicing.  Refer - https://learn.microsoft.com/en-us/windows/release-health/status-windows-10-20h2

And there's no reference to /aws/service/ami-windows-latest/Windows_Server-20H2-English-Core-ECS_Optimized/image_id now. Removing this image since its no longer usable.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
