### PR TITLE
Remove deprecated Windows 20H2 option.

### DIFF
--- a/resources/tenant-onboarding-app.yaml
+++ b/resources/tenant-onboarding-app.yaml
@@ -82,7 +82,7 @@ Parameters:
     Description: Operating System to use for the Docker host
     Type: String
     # Can't have dashes or underscores in Mappings keys :(
-    AllowedValues: [WIN2019FULL, WIN2019CORE, WIN2022FULL, WIN2022CORE, WIN20H2CORE, WIN2016FULL, LINUX]
+    AllowedValues: [WIN2019FULL, WIN2019CORE, WIN2022FULL, WIN2022CORE, WIN2016FULL, LINUX]
   ClusterInstanceType:
     Description: EC2 instance type to use for non Fargate Docker hosts
     Type: String
@@ -278,7 +278,6 @@ Conditions:
   IsWin2019Core: !Equals [WIN2019CORE, !Ref ContainerOS]
   IsWin2022Full: !Equals [WIN2022FULL, !Ref ContainerOS]
   IsWin2022Core: !Equals [WIN2022CORE, !Ref ContainerOS]
-  IsWin20H2Core: !Equals [WIN20H2CORE, !Ref ContainerOS]
 Resources:
   CapacityProvider:
     Type: AWS::ECS::CapacityProvider
@@ -793,10 +792,7 @@ Resources:
                 - !If
                   - IsWin2022Core
                   - !Ref WIN2022CORE
-                  - !If
-                    - IsWin20H2Core
-                    - !Ref WIN20H2CORE
-                    - !Ref WIN2016FULL
+                  - !Ref WIN2016FULL
         InstanceType: !Ref ClusterInstanceType
         IamInstanceProfile:
           Arn: !GetAtt ECSInstanceProfile.Arn

--- a/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/OperatingSystem.java
+++ b/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/OperatingSystem.java
@@ -23,8 +23,7 @@ public enum OperatingSystem {
     WIN_2019_FULL("Windows Server 2019 Full"),
     WIN_2019_CORE("Windows Server 2019 Core"),
     WIN_2022_FULL("Windows Server 2022 Full"),
-    WIN_2022_CORE("Windows Server 2022 Core"),
-    WIN_20H2_CORE("Windows Server 20H2 Core");
+    WIN_2022_CORE("Windows Server 2022 Core");
 
     private final String description;
 


### PR DESCRIPTION
This PR completes the incomplete removal of Windows 20H2 from https://github.com/awslabs/aws-saas-boost/commit/b0c9d3319065dba5051e1221b2c2de6bf4e54b08

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
