### PR TITLE
Pass S3 extension bucket name through AppConfig rather than as an SSM…

### DIFF
--- a/functions/core-stack-listener/pom.xml
+++ b/functions/core-stack-listener/pom.xml
@@ -33,7 +33,7 @@ limitations under the License.
     </licenses>
 
     <properties>
-        <checkstyle.maxAllowedViolations>1</checkstyle.maxAllowedViolations>
+        <checkstyle.maxAllowedViolations>0</checkstyle.maxAllowedViolations>
     </properties>
 
     <build>

--- a/resources/custom-resources/app-services-macro/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/ApplicationServicesMacro.java
+++ b/resources/custom-resources/app-services-macro/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/ApplicationServicesMacro.java
@@ -127,17 +127,6 @@ public class ApplicationServicesMacro implements RequestHandler<Map<String, Obje
                     (String) templateParameters.get("LoggingBucket"));
             ((Map<String, Object>) template.get("Resources")).put("TenantStorage", s3Resource);
 
-            // SSM Parameter to easily pass around bucket name
-            Map<String, Object> bucketParameter = Map.of(
-                    "Type", "AWS::SSM::Parameter",
-                    "Properties", Map.of(
-                            "Name", "/saas-boost/" + environmentName + "/TENANT_STORAGE_BUCKET",
-                            "Type", "String",
-                            "Value", Map.of("Ref", "TenantStorage")
-                )
-            );
-            ((Map<String, Object>) template.get("Resources")).put("TenantStorageParam", bucketParameter);
-
             // Custom Resource to clear the bucket before we delete it
             Map<String, Object> clearBucketResource = Map.of(
                     "Type", "Custom::CustomResource",

--- a/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingService.java
+++ b/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingService.java
@@ -848,6 +848,12 @@ public class OnboardingService {
                         String containerRepo = (String) service.get("containerRepo");
                         String imageTag = (String) service.getOrDefault("containerTag", "latest");
 
+                        Map<String, Object> s3 = (Map<String, Object>) service.getOrDefault("s3", null);
+                        String tenantStorageBucketName = "";
+                        if (s3 != null) {
+                            tenantStorageBucketName = (String) s3.get("bucketName");
+                        }
+
                         // If there are any private services, we will create an environment variables called
                         // SERVICE_<SERVICE_NAME>_HOST and SERVICE_<SERVICE_NAME>_PORT to pass to the task definitions
                         String serviceEnvName = Utils.toUpperSnakeCase(serviceName);
@@ -1031,7 +1037,7 @@ public class OnboardingService {
                         templateParameters.add(Parameter.builder().parameterKey("RDSBootstrap").parameterValue(dbBootstrap).build());
                         templateParameters.add(Parameter.builder()
                                 .parameterKey("TenantStorageBucket")
-                                .parameterValue(getSetting(context, "TENANT_STORAGE_BUCKET"))
+                                .parameterValue(tenantStorageBucketName)
                                 .build());
                         // TODO rework these last 2?
                         templateParameters.add(Parameter.builder().parameterKey("MetricsStream")

--- a/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingService.java
+++ b/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingService.java
@@ -852,6 +852,11 @@ public class OnboardingService {
                         String tenantStorageBucketName = "";
                         if (s3 != null) {
                             tenantStorageBucketName = (String) s3.get("bucketName");
+                            if (tenantStorageBucketName == null) {
+                                LOGGER.error("S3 exists in AppConfig, but bucketName is not configured.");
+                                failOnboarding(onboarding.getId(), "Invalid S3 configuration for AppConfig.");
+                                return;
+                            }
                         }
 
                         // If there are any private services, we will create an environment variables called

--- a/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/S3Storage.java
+++ b/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/S3Storage.java
@@ -16,14 +16,21 @@
 
  package com.amazon.aws.partners.saasfactory.saasboost.appconfig;
 
+import com.amazon.aws.partners.saasfactory.saasboost.Utils;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 @JsonDeserialize(builder = S3Storage.Builder.class)
 public final class S3Storage {
 
+    private final String bucketName;
+
     public S3Storage(Builder b) {
-        
+        this.bucketName = b.bucketName;
+    }
+
+    public String getBucketName() {
+        return this.bucketName;
     }
 
     @Override
@@ -40,7 +47,9 @@ public final class S3Storage {
             return false;
         }
 
-        return true;
+        S3Storage other = (S3Storage) obj;
+
+        return Utils.nullableEquals(this.getBucketName(), other.getBucketName());
     }
 
     @Override
@@ -58,6 +67,13 @@ public final class S3Storage {
 
     @JsonPOJOBuilder(withPrefix = "") // setters aren't named with[Property]
     public static final class Builder {
+
+        private String bucketName;
+
+        public Builder bucketName(String bucketName) {
+            this.bucketName = bucketName;
+            return this;
+        }
 
         public S3Storage build() {
             return new S3Storage(this);


### PR DESCRIPTION
… Parameter.

To more closely match with existing conventions around core stack creations (since the S3 bucket is implemented as an environment-wide tenant storage bucket with resource-based access controls rather than an individual bucket for each service), this commit changes the original implementation of passing the tenantStorage bucket as an SSM parameter to being part of the AppConfig, since the S3 bucket name is really a concept of the application configuration, rather than any environment specific concept.

Fixes #466 

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
