### PR TITLE
update iam endpoint setting for gcr

### DIFF
--- a/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/clients/AwsClientBuilderFactory.java
+++ b/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/clients/AwsClientBuilderFactory.java
@@ -134,9 +134,9 @@ public class AwsClientBuilderFactory {
         if (cachedIamBuilder == null) {
             Region region = Region.of(System.getenv("AWS_REGION"));
             if (Utils.isChinaRegion(region)) {
-                // China's IAM endpoints are regional
+                // China's IAM endpoints point to Beijing region
                 // See https://docs.amazonaws.cn/en_us/aws/latest/userguide/iam.html
-                cachedIamBuilder = decorateBuilderWithDefaults(IamClient.builder());
+                cachedIamBuilder = decorateBuilderWithDefaults(IamClient.builder()).region(Region.AWS_CN_GLOBAL);
             } else {
                 // IAM in the commercial regions use the AWS_GLOBAL
                 // ref: https://docs.aws.amazon.com/general/latest/gr/iam-service.html


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

When provisioning boost in GCR Ningxia region, it errors out as it can't connect to IAM regional endpoints.
We can set region to `AWS_CN_GLOBAL`, both Ningxia and Beijing region IAM points to `iam.cn-north-1.amazonaws.com.cn `.

https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/migration-client-region.html
https://docs.amazonaws.cn/en_us/aws/latest/userguide/endpoints-Ningxia.html
https://docs.amazonaws.cn/en_us/aws/latest/userguide/endpoints-Beijing.html