### PR TITLE
Change "Users" to "System Users" in UI.

### DIFF
--- a/client/web/src/_nav.js
+++ b/client/web/src/_nav.js
@@ -24,6 +24,7 @@ import {
   cilUserPlus,
 } from '@coreui/icons'
 import { CNavGroup, CNavItem } from '@coreui/react'
+import { BaseUserRoute } from './users'
 
 const _nav = [
   {
@@ -87,8 +88,8 @@ const _nav = [
   },
   {
     component: CNavItem,
-    name: 'Users',
-    to: '/users',
+    name: 'System Users',
+    to: BaseUserRoute,
     icon: <CIcon icon={cilPeople} customClassName="nav-icon" />,
   },
 ]

--- a/client/web/src/users/UserDeleteConfirmationComponent.js
+++ b/client/web/src/users/UserDeleteConfirmationComponent.js
@@ -60,7 +60,7 @@ export default function UserDeleteConfirmationComponent(props) {
           <Form>
             <ModalHeader>Delete User</ModalHeader>
             <ModalBody>
-              <p>Are you sure you want to delete the user &apos;{username}&apos;?</p>
+              <p>Are you sure you want to delete the system user &apos;{username}&apos;?</p>
               <p>Type &apos;delete&apos; to confirm:</p>
               <FormGroup>
                 <SaasBoostInput type="text" name="confirmText" tabIndex="1" />

--- a/client/web/src/users/UserFormComponent.js
+++ b/client/web/src/users/UserFormComponent.js
@@ -67,7 +67,7 @@ export const UserFormComponent = ({
             <Row>
               <Col md={6}>
                 <Card>
-                  <CardHeader>User Details</CardHeader>
+                  <CardHeader>System User Details</CardHeader>
                   <CardBody>
                     <SaasBoostInput
                       label="Username"

--- a/client/web/src/users/UserListComponent.js
+++ b/client/web/src/users/UserListComponent.js
@@ -84,7 +84,7 @@ export const UserListComponent = ({
               </span>
             </Button>
             <Button color="primary" onClick={handleCreateUser}>
-              Create User
+              Create System User
             </Button>
           </div>
         </Col>
@@ -93,7 +93,7 @@ export const UserListComponent = ({
         <Col xl={12}>
           <Card>
             <CardHeader>
-              <CIcon icon={cilListRich} /> Users
+              <CIcon icon={cilListRich} /> System Users
             </CardHeader>
             <CardBody>{table}</CardBody>
           </Card>

--- a/client/web/src/users/UserListContainer.js
+++ b/client/web/src/users/UserListContainer.js
@@ -19,6 +19,7 @@ import { UserListComponent } from './UserListComponent'
 import { useDispatch, useSelector } from 'react-redux'
 import { fetchUsers, selectAllUsers, dismissError } from './ducks'
 import { useHistory } from 'react-router-dom'
+import { BaseUserRoute } from '.'
 
 export default function UserListContainer() {
   const dispatch = useDispatch()
@@ -29,7 +30,7 @@ export default function UserListContainer() {
   const error = useSelector((state) => state.users.error)
 
   const handleUserClick = (username) => {
-    history.push(`/users/${username}`)
+    history.push(`${BaseUserRoute}/${username}`)
   }
 
   const handleRefresh = () => {
@@ -37,7 +38,7 @@ export default function UserListContainer() {
   }
 
   const handleCreateUser = () => {
-    history.push(`/users/create`)
+    history.push(`${BaseUserRoute}/create`)
   }
 
   const handleError = () => {

--- a/client/web/src/users/UserViewComponent.js
+++ b/client/web/src/users/UserViewComponent.js
@@ -28,7 +28,6 @@ import {
   CardHeader,
   CardBody,
 } from 'reactstrap'
-import { SBMoment } from '../components/SBMoment'
 import Moment from 'react-moment'
 import Display from '../components/Display'
 import UserDeleteConfirmationComponent from './UserDeleteConfirmationComponent'
@@ -135,7 +134,7 @@ export class UserViewComponent extends Component {
               <Card>
                 <CardHeader>
                   <i className="fa fa-info" />
-                  User Details
+                  System User Details
                 </CardHeader>
                 <CardBody>
                   <Row>

--- a/client/web/src/users/UserViewContainer.js
+++ b/client/web/src/users/UserViewContainer.js
@@ -19,6 +19,7 @@ import UserViewComponent from './UserViewComponent'
 import { UserFormComponent } from './UserFormComponent'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router'
+import { BaseUserRoute } from '.'
 
 import {
   fetchUser,
@@ -115,7 +116,7 @@ class UserViewContainer extends Component {
     try {
       const deletedUserResponse = await deletedUser(username)
       if (!deletedUserResponse.error) {
-        history.push('/users')
+        history.push(BaseUserRoute)
       } else {
         toggleDeleteModal()
         setSubmitting(false)

--- a/client/web/src/users/index.js
+++ b/client/web/src/users/index.js
@@ -20,23 +20,25 @@ const UserListContainer = lazy(() => import('./UserListContainer'))
 const UserViewContainer = lazy(() => import('./UserViewContainer'))
 const UserCreateContainer = lazy(() => import('./UserCreateContainer'))
 
+export const BaseUserRoute = '/sysusers'
+
 export const UserRoutes = [
   {
-    path: '/users',
+    path: BaseUserRoute,
     exact: true,
-    name: 'Users',
+    name: 'System Users',
     component: UserListContainer,
   },
   {
-    path: '/users/create',
+    path: BaseUserRoute + '/create',
     exact: true,
-    name: 'Create a new User',
+    name: 'Create a new System User',
     component: UserCreateContainer,
   },
   {
-    path: '/users/:username',
+    path: BaseUserRoute + '/:username',
     exact: true,
-    name: 'User Detail',
+    name: 'System User Detail',
     component: UserViewContainer,
   },
 ]


### PR DESCRIPTION
This change helps reduce confusion about whether
operations on the UI pages affect users of the
SaaS Boost control plane (system users) or the
tenant's end users logging into the SaaS application.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
