### PR TITLE
Fix line graphs in metrics dashboards

### DIFF
--- a/client/web/src/metrics/ducks/index.js
+++ b/client/web/src/metrics/ducks/index.js
@@ -61,7 +61,7 @@ const metricQueryAdapter = createEntityAdapter({
 
 const conditionDates = (response) => {
   const formatDate = (date) => {
-    const d = new Date(`${date} UTC`)
+    const d = new Date(`${date}`)
     return `${d.getMonth() + 1}-${d.getDate()} ${d.getHours().toString().padStart(2, '0')}:${d
       .getMinutes()
       .toString()


### PR DESCRIPTION
The period data returned by our metrics service includes Z as a timezone, which indicates UTC. Adding the extra UTC made the data unparseable, leading to NaN:NaN being represented as our periods.

Before fix. Note `NaN-NaN NaN:NaN` as the time period on the left.
> ![Before fix](https://user-images.githubusercontent.com/4009272/217688910-8dc95ee3-a9e4-4826-bf1c-825dc28e791d.png)

After fix. Note we actually have data.
> ![After fix](https://user-images.githubusercontent.com/4009272/217688845-a5f2ee28-d39d-4034-aa1f-dfb7d20d2e2e.png)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
