### PR TITLE
Update scripts must not fail if Lambda function does not already exist.

### DIFF
--- a/functions/authorizer/update.sh
+++ b/functions/authorizer/update.sh
@@ -48,8 +48,7 @@ fi
 
 aws s3 cp target/$LAMBDA_CODE s3://$SAAS_BOOST_BUCKET/$LAMBDA_STAGE_FOLDER/
 
-FUNCTIONS=("sb-${ENVIRONMENT}-authorizer" 
-        )
+eval FUNCTIONS=\$\("aws --region $MY_AWS_REGION lambda list-functions --query 'Functions[?starts_with(FunctionName, \`sb-${ENVIRONMENT}-authorizer\`)] | [].FunctionName' --output text"\)
 
 for FUNCTION in ${FUNCTIONS[@]}; do
 	#echo $FUNCTION

--- a/functions/core-stack-listener/update.sh
+++ b/functions/core-stack-listener/update.sh
@@ -48,8 +48,7 @@ fi
 # And copy it up to S3
 aws s3 cp target/$LAMBDA_CODE s3://$SAAS_BOOST_BUCKET/$LAMBDA_STAGE_FOLDER/
 
-FUNCTIONS=("sb-${ENVIRONMENT}-core-stack-listener" 
-        )
+eval FUNCTIONS=\$\("aws --region $MY_AWS_REGION lambda list-functions --query 'Functions[?starts_with(FunctionName, \`sb-${ENVIRONMENT}-core-stack-listener\`)] | [].FunctionName' --output text"\)
 
 for FUNCTION in ${FUNCTIONS[@]}; do
 	#echo $FUNCTION

--- a/functions/ecs-service-update/update.sh
+++ b/functions/ecs-service-update/update.sh
@@ -47,8 +47,7 @@ fi
 
 aws s3 cp target/$LAMBDA_CODE s3://$SAAS_BOOST_BUCKET/$LAMBDA_STAGE_FOLDER/
 
-FUNCTIONS=("sb-${ENVIRONMENT}-update-ecs" 
-        )
+eval FUNCTIONS=\$\("aws --region $MY_AWS_REGION lambda list-functions --query 'Functions[?starts_with(FunctionName, \`sb-${ENVIRONMENT}-update-ecs\`)] | [].FunctionName' --output text"\)
 
 for FUNCTION in ${FUNCTIONS[@]}; do
 	#echo $FUNCTION

--- a/functions/ecs-shutdown-services/update.sh
+++ b/functions/ecs-shutdown-services/update.sh
@@ -48,8 +48,7 @@ fi
 # And copy it up to S3
 aws s3 cp target/$LAMBDA_CODE s3://$SAAS_BOOST_BUCKET/$LAMBDA_STAGE_FOLDER/
 
-FUNCTIONS=("sb-${ENVIRONMENT}-ecs-shutdown-services" 
-        )
+eval FUNCTIONS=\$\("aws --region $MY_AWS_REGION lambda list-functions --query 'Functions[?starts_with(FunctionName, \`sb-${ENVIRONMENT}-ecs-shutdown-services\`)] | [].FunctionName' --output text"\)
 
 for FUNCTION in ${FUNCTIONS[@]}; do
 	#echo $FUNCTION

--- a/functions/ecs-startup-services/update.sh
+++ b/functions/ecs-startup-services/update.sh
@@ -48,8 +48,7 @@ fi
 # And copy it up to S3
 aws s3 cp target/$LAMBDA_CODE s3://$SAAS_BOOST_BUCKET/$LAMBDA_STAGE_FOLDER/
 
-FUNCTIONS=("sb-${ENVIRONMENT}-ecs-startup-services" 
-        )
+eval FUNCTIONS=\$\("aws --region $MY_AWS_REGION lambda list-functions --query 'Functions[?starts_with(FunctionName, \`sb-${ENVIRONMENT}-ecs-startup-services\`)] | [].FunctionName' --output text"\)
 
 for FUNCTION in ${FUNCTIONS[@]}; do
 	#echo $FUNCTION

--- a/functions/onboarding-app-stack-listener/update.sh
+++ b/functions/onboarding-app-stack-listener/update.sh
@@ -48,8 +48,7 @@ fi
 
 aws s3 cp target/$LAMBDA_CODE s3://$SAAS_BOOST_BUCKET/$LAMBDA_STAGE_FOLDER/
 
-FUNCTIONS=("sb-${ENVIRONMENT}-onboarding-app-listener" 
-        )
+eval FUNCTIONS=\$\("aws --region $MY_AWS_REGION lambda list-functions --query 'Functions[?starts_with(FunctionName, \`sb-${ENVIRONMENT}-onboarding-app-listener\`)] | [].FunctionName' --output text"\)
 
 for FUNCTION in ${FUNCTIONS[@]}; do
 	#echo $FUNCTION

--- a/functions/onboarding-stack-listener/update.sh
+++ b/functions/onboarding-stack-listener/update.sh
@@ -48,8 +48,7 @@ fi
 
 aws s3 cp target/$LAMBDA_CODE s3://$SAAS_BOOST_BUCKET/$LAMBDA_STAGE_FOLDER/
 
-FUNCTIONS=("sb-${ENVIRONMENT}-onboarding-listener" 
-        )
+eval FUNCTIONS=\$\("aws --region $MY_AWS_REGION lambda list-functions --query 'Functions[?starts_with(FunctionName, \`sb-${ENVIRONMENT}-onboarding-listener\`)] | [].FunctionName' --output text"\)
 
 for FUNCTION in ${FUNCTIONS[@]}; do
 	#echo $FUNCTION

--- a/functions/system-rest-api-client/update.sh
+++ b/functions/system-rest-api-client/update.sh
@@ -45,8 +45,7 @@ fi
 
 aws s3 cp target/$LAMBDA_CODE s3://$SAAS_BOOST_BUCKET/$LAMBDA_STAGE_FOLDER/
 
-FUNCTIONS=("sb-${ENVIRONMENT}-private-api-client"
-        )
+eval FUNCTIONS=\$\("aws --region $MY_AWS_REGION lambda list-functions --query 'Functions[?starts_with(FunctionName, \`sb-${ENVIRONMENT}-private-api-client\`)] | [].FunctionName' --output text"\)
 
 for FUNCTION in ${FUNCTIONS[@]}; do
 	#echo $FUNCTION

--- a/functions/workload-deploy/update.sh
+++ b/functions/workload-deploy/update.sh
@@ -50,6 +50,7 @@ aws s3 cp target/$LAMBDA_CODE s3://$SAAS_BOOST_BUCKET/$LAMBDA_STAGE_FOLDER/
 
 FUNCTIONS=("sb-${ENVIRONMENT}-workload-deploy" 
         )
+eval FUNCTIONS=\$\("aws --region $MY_AWS_REGION lambda list-functions --query 'Functions[?starts_with(FunctionName, \`sb-${ENVIRONMENT}-workload-deploy\`)] | [].FunctionName' --output text"\)
 
 for FUNCTION in ${FUNCTIONS[@]}; do
 	#echo $FUNCTION

--- a/resources/custom-resources/app-services-macro/update.sh
+++ b/resources/custom-resources/app-services-macro/update.sh
@@ -48,5 +48,10 @@ fi
 # And copy it up to S3
 aws s3 cp target/$LAMBDA_CODE s3://$SAAS_BOOST_BUCKET/$LAMBDA_STAGE_FOLDER/
 
-printf "Updating function code for saas-boost-app-services-macro\n"
-aws lambda --region "$MY_AWS_REGION" update-function-code --function-name "saas-boost-app-services-macro" --s3-bucket "$SAAS_BOOST_BUCKET" --s3-key $LAMBDA_STAGE_FOLDER/$LAMBDA_CODE
+FUNCTIONS=("saas-boost-app-services-macro" 
+        )
+
+for FUNCTION in ${FUNCTIONS[@]}; do
+	#echo $FUNCTION
+	aws lambda --region $MY_AWS_REGION update-function-code --function-name $FUNCTION --s3-bucket $SAAS_BOOST_BUCKET --s3-key $LAMBDA_STAGE_FOLDER/$LAMBDA_CODE
+done

--- a/resources/custom-resources/app-services-macro/update.sh
+++ b/resources/custom-resources/app-services-macro/update.sh
@@ -48,8 +48,7 @@ fi
 # And copy it up to S3
 aws s3 cp target/$LAMBDA_CODE s3://$SAAS_BOOST_BUCKET/$LAMBDA_STAGE_FOLDER/
 
-FUNCTIONS=("saas-boost-app-services-macro" 
-        )
+eval FUNCTIONS=\$\("aws --region $MY_AWS_REGION lambda list-functions --query 'Functions[?starts_with(FunctionName, \`saas-boost-app-services-macro\`)] | [].FunctionName' --output text"\)
 
 for FUNCTION in ${FUNCTIONS[@]}; do
 	#echo $FUNCTION

--- a/resources/custom-resources/cidr-dynamodb/update.sh
+++ b/resources/custom-resources/cidr-dynamodb/update.sh
@@ -49,8 +49,7 @@ fi
 aws s3 cp target/$LAMBDA_CODE s3://$SAAS_BOOST_BUCKET/$LAMBDA_STAGE_FOLDER/
 
 printf "Updating function code for sb-${ENVIRONMENT}-populate-ddb\n"
-FUNCTIONS=("sb-${ENVIRONMENT}-populate-ddb" 
-        )
+eval FUNCTIONS=\$\("aws --region $MY_AWS_REGION lambda list-functions --query 'Functions[?starts_with(FunctionName, \`sb-${ENVIRONMENT}-populate-ddb\`)] | [].FunctionName' --output text"\)
 
 for FUNCTION in ${FUNCTIONS[@]}; do
 	#echo $FUNCTION

--- a/resources/custom-resources/clear-ecr-repo/update.sh
+++ b/resources/custom-resources/clear-ecr-repo/update.sh
@@ -48,6 +48,10 @@ fi
 # And copy it up to S3
 aws s3 cp target/$LAMBDA_CODE s3://$SAAS_BOOST_BUCKET/$LAMBDA_STAGE_FOLDER/
 
-FUNCTION="sb-${ENVIRONMENT}-clear-ecr-repo"
-printf "Updating function code for ${FUNCTION}\n"
-aws lambda --region "$MY_AWS_REGION" update-function-code --function-name "${FUNCTION}" --s3-bucket "$SAAS_BOOST_BUCKET" --s3-key $LAMBDA_STAGE_FOLDER/$LAMBDA_CODE
+FUNCTIONS=("sb-${ENVIRONMENT}-clear-ecr-repo" 
+        )
+
+for FUNCTION in ${FUNCTIONS[@]}; do
+	#echo $FUNCTION
+	aws lambda --region $MY_AWS_REGION update-function-code --function-name $FUNCTION --s3-bucket $SAAS_BOOST_BUCKET --s3-key $LAMBDA_STAGE_FOLDER/$LAMBDA_CODE
+done

--- a/resources/custom-resources/clear-ecr-repo/update.sh
+++ b/resources/custom-resources/clear-ecr-repo/update.sh
@@ -48,8 +48,7 @@ fi
 # And copy it up to S3
 aws s3 cp target/$LAMBDA_CODE s3://$SAAS_BOOST_BUCKET/$LAMBDA_STAGE_FOLDER/
 
-FUNCTIONS=("sb-${ENVIRONMENT}-clear-ecr-repo" 
-        )
+eval FUNCTIONS=\$\("aws --region $MY_AWS_REGION lambda list-functions --query 'Functions[?starts_with(FunctionName, \`sb-${ENVIRONMENT}-clear-ecr-repo\`)] | [].FunctionName' --output text"\)
 
 for FUNCTION in ${FUNCTIONS[@]}; do
 	#echo $FUNCTION

--- a/resources/custom-resources/clear-s3-bucket/update.sh
+++ b/resources/custom-resources/clear-s3-bucket/update.sh
@@ -50,8 +50,7 @@ aws s3 cp target/$LAMBDA_CODE s3://$SAAS_BOOST_BUCKET/$LAMBDA_STAGE_FOLDER/
 
 printf "Updating function code for sb-${ENVIRONMENT}-clear-bucket\n"
 
-FUNCTIONS=("sb-${ENVIRONMENT}-clear-bucket" 
-        )
+eval FUNCTIONS=\$\("aws --region $MY_AWS_REGION lambda list-functions --query 'Functions[?starts_with(FunctionName, \`sb-${ENVIRONMENT}-clear-bucket\`)] | [].FunctionName' --output text"\)
 
 for FUNCTION in ${FUNCTIONS[@]}; do
 	#echo $FUNCTION

--- a/resources/custom-resources/clear-s3-bucket/update.sh
+++ b/resources/custom-resources/clear-s3-bucket/update.sh
@@ -49,4 +49,11 @@ fi
 aws s3 cp target/$LAMBDA_CODE s3://$SAAS_BOOST_BUCKET/$LAMBDA_STAGE_FOLDER/
 
 printf "Updating function code for sb-${ENVIRONMENT}-clear-bucket\n"
-aws lambda --region "$MY_AWS_REGION" update-function-code --function-name "sb-${ENVIRONMENT}-clear-bucket" --s3-bucket "$SAAS_BOOST_BUCKET" --s3-key $LAMBDA_STAGE_FOLDER/$LAMBDA_CODE
+
+FUNCTIONS=("sb-${ENVIRONMENT}-clear-bucket" 
+        )
+
+for FUNCTION in ${FUNCTIONS[@]}; do
+	#echo $FUNCTION
+	aws lambda --region $MY_AWS_REGION update-function-code --function-name $FUNCTION --s3-bucket $SAAS_BOOST_BUCKET --s3-key $LAMBDA_STAGE_FOLDER/$LAMBDA_CODE
+done

--- a/resources/custom-resources/cognito-app-client-details/update.sh
+++ b/resources/custom-resources/cognito-app-client-details/update.sh
@@ -26,7 +26,7 @@ LAMBDA_STAGE_FOLDER=$2
 if [ -z $LAMBDA_STAGE_FOLDER ]; then
 	LAMBDA_STAGE_FOLDER="lambdas"
 fi
-LAMBDA_CODE=CidrDynamoDB-lambda.zip
+LAMBDA_CODE=CognitoAppClientDetails-lambda.zip
 
 #set this for V2 AWS CLI to disable paging
 export AWS_PAGER=""
@@ -48,8 +48,9 @@ fi
 # And copy it up to S3
 aws s3 cp target/$LAMBDA_CODE s3://$SAAS_BOOST_BUCKET/$LAMBDA_STAGE_FOLDER/
 
-printf "Updating function code for sb-${ENVIRONMENT}-populate-ddb\n"
-FUNCTIONS=("sb-${ENVIRONMENT}-populate-ddb" 
+printf "Updating function code for sb-${ENVIRONMENT}-cognito-client-details\n"
+
+FUNCTIONS=("sb-${ENVIRONMENT}-cognito-client-details" 
         )
 
 for FUNCTION in ${FUNCTIONS[@]}; do

--- a/resources/custom-resources/cognito-app-client-details/update.sh
+++ b/resources/custom-resources/cognito-app-client-details/update.sh
@@ -50,8 +50,7 @@ aws s3 cp target/$LAMBDA_CODE s3://$SAAS_BOOST_BUCKET/$LAMBDA_STAGE_FOLDER/
 
 printf "Updating function code for sb-${ENVIRONMENT}-cognito-client-details\n"
 
-FUNCTIONS=("sb-${ENVIRONMENT}-cognito-client-details" 
-        )
+eval FUNCTIONS=\$\("aws --region $MY_AWS_REGION lambda list-functions --query 'Functions[?starts_with(FunctionName, \`sb-${ENVIRONMENT}-cognito-client-details\`)] | [].FunctionName' --output text"\)
 
 for FUNCTION in ${FUNCTIONS[@]}; do
 	#echo $FUNCTION

--- a/resources/custom-resources/rds-options/update.sh
+++ b/resources/custom-resources/rds-options/update.sh
@@ -49,8 +49,7 @@ fi
 aws s3 cp target/$LAMBDA_CODE s3://$SAAS_BOOST_BUCKET/$LAMBDA_STAGE_FOLDER/
 
 printf "Updating function code for sb-${ENVIRONMENT}-rds-options\n"
-FUNCTIONS=("sb-${ENVIRONMENT}-rds-options" 
-        )
+eval FUNCTIONS=\$\("aws --region $MY_AWS_REGION lambda list-functions --query 'Functions[?starts_with(FunctionName, \`sb-${ENVIRONMENT}-rds-options\`)] | [].FunctionName' --output text"\)
 
 for FUNCTION in ${FUNCTIONS[@]}; do
 	#echo $FUNCTION

--- a/resources/custom-resources/rds-options/update.sh
+++ b/resources/custom-resources/rds-options/update.sh
@@ -49,4 +49,10 @@ fi
 aws s3 cp target/$LAMBDA_CODE s3://$SAAS_BOOST_BUCKET/$LAMBDA_STAGE_FOLDER/
 
 printf "Updating function code for sb-${ENVIRONMENT}-rds-options\n"
-aws lambda --region "$MY_AWS_REGION" update-function-code --function-name "sb-${ENVIRONMENT}-rds-options" --s3-bucket "$SAAS_BOOST_BUCKET" --s3-key $LAMBDA_STAGE_FOLDER/$LAMBDA_CODE
+FUNCTIONS=("sb-${ENVIRONMENT}-rds-options" 
+        )
+
+for FUNCTION in ${FUNCTIONS[@]}; do
+	#echo $FUNCTION
+	aws lambda --region $MY_AWS_REGION update-function-code --function-name $FUNCTION --s3-bucket $SAAS_BOOST_BUCKET --s3-key $LAMBDA_STAGE_FOLDER/$LAMBDA_CODE
+done

--- a/resources/custom-resources/set-instance-protection/update.sh
+++ b/resources/custom-resources/set-instance-protection/update.sh
@@ -49,4 +49,10 @@ fi
 aws s3 cp target/$LAMBDA_CODE s3://$SAAS_BOOST_BUCKET/$LAMBDA_STAGE_FOLDER/
 
 printf "Updating function code for sb-${ENVIRONMENT}-set-instance-protection\n"
-aws lambda --region "$MY_AWS_REGION" update-function-code --function-name "sb-${ENVIRONMENT}-set-instance-protection" --s3-bucket "$SAAS_BOOST_BUCKET" --s3-key $LAMBDA_STAGE_FOLDER/$LAMBDA_CODE
+FUNCTIONS=("sb-${ENVIRONMENT}-set-instance-protection" 
+        )
+
+for FUNCTION in ${FUNCTIONS[@]}; do
+	#echo $FUNCTION
+	aws lambda --region $MY_AWS_REGION update-function-code --function-name $FUNCTION --s3-bucket $SAAS_BOOST_BUCKET --s3-key $LAMBDA_STAGE_FOLDER/$LAMBDA_CODE
+done

--- a/resources/custom-resources/set-instance-protection/update.sh
+++ b/resources/custom-resources/set-instance-protection/update.sh
@@ -49,8 +49,7 @@ fi
 aws s3 cp target/$LAMBDA_CODE s3://$SAAS_BOOST_BUCKET/$LAMBDA_STAGE_FOLDER/
 
 printf "Updating function code for sb-${ENVIRONMENT}-set-instance-protection\n"
-FUNCTIONS=("sb-${ENVIRONMENT}-set-instance-protection" 
-        )
+eval FUNCTIONS=\$\("aws --region $MY_AWS_REGION lambda list-functions --query 'Functions[?starts_with(FunctionName, \`sb-${ENVIRONMENT}-set-instance-protection\`)] | [].FunctionName' --output text"\)
 
 for FUNCTION in ${FUNCTIONS[@]}; do
 	#echo $FUNCTION

--- a/resources/custom-resources/start-codebuild/update.sh
+++ b/resources/custom-resources/start-codebuild/update.sh
@@ -49,4 +49,10 @@ fi
 aws s3 cp target/$LAMBDA_CODE s3://$SAAS_BOOST_BUCKET/$LAMBDA_STAGE_FOLDER/
 
 printf "Updating function code for sb-${ENVIRONMENT}-start-build\n"
-aws lambda --region "$MY_AWS_REGION" update-function-code --function-name "sb-${ENVIRONMENT}-start-build" --s3-bucket "$SAAS_BOOST_BUCKET" --s3-key $LAMBDA_STAGE_FOLDER/$LAMBDA_CODE
+FUNCTIONS=("sb-${ENVIRONMENT}-start-build" 
+        )
+
+for FUNCTION in ${FUNCTIONS[@]}; do
+	#echo $FUNCTION
+	aws lambda --region $MY_AWS_REGION update-function-code --function-name $FUNCTION --s3-bucket $SAAS_BOOST_BUCKET --s3-key $LAMBDA_STAGE_FOLDER/$LAMBDA_CODE
+done

--- a/resources/custom-resources/start-codebuild/update.sh
+++ b/resources/custom-resources/start-codebuild/update.sh
@@ -49,8 +49,7 @@ fi
 aws s3 cp target/$LAMBDA_CODE s3://$SAAS_BOOST_BUCKET/$LAMBDA_STAGE_FOLDER/
 
 printf "Updating function code for sb-${ENVIRONMENT}-start-build\n"
-FUNCTIONS=("sb-${ENVIRONMENT}-start-build" 
-        )
+eval FUNCTIONS=\$\("aws --region $MY_AWS_REGION lambda list-functions --query 'Functions[?starts_with(FunctionName, \`sb-${ENVIRONMENT}-start-build\`)] | [].FunctionName' --output text"\)
 
 for FUNCTION in ${FUNCTIONS[@]}; do
 	#echo $FUNCTION


### PR DESCRIPTION
When updating from older versions of SaaS Boost to newer ones, we rely on each Lambda function's update.sh script to build the code and update any relevant Lambda functions in the AWS account. If any of these update.sh scripts fail, an entire SaaS Boost update will fail, since it assumes something has gone wrong with building or uploading that code.

However, in the case we add a new Lambda function, the existing Lambda function may not already exist until the CloudFormation stack is updated, which is something the Installer executes after running each update.sh script. This change makes these update scripts not fail in that case.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
