### PR TITLE
Support enabling ECS Exec for individual services at creation time.

### DIFF
--- a/client/web/src/settings/ApplicationComponent.js
+++ b/client/web/src/settings/ApplicationComponent.js
@@ -161,6 +161,7 @@ export function ApplicationComponent(props) {
       name: thisService?.name || serviceName,
       path: thisService?.path || '/*',
       public: thisService ? thisService.public : true,
+      ecsExecEnabled: thisService ? thisService.ecsExecEnabled : false,
       healthCheckUrl: thisService?.healthCheckUrl || '/',
       containerPort: thisService?.containerPort || 0,
       containerTag: thisService?.containerTag || 'latest',
@@ -279,6 +280,7 @@ export function ApplicationComponent(props) {
           .required('Health Check URL is a required field')
           .matches(/^\//, 'Health Check must start with forward slash (/)'),
         operatingSystem: Yup.string().required('Container OS is a required field.'),
+        ecsExecEnabled: Yup.boolean().required(),
         windowsVersion: Yup.string().when('operatingSystem', {
           is: (containerOs) => containerOs && containerOs === WINDOWS,
           then: Yup.string().required('Windows version is a required field'),

--- a/client/web/src/settings/ServiceSettingsSubform.js
+++ b/client/web/src/settings/ServiceSettingsSubform.js
@@ -162,6 +162,16 @@ const ServiceSettingsSubform = (props) => {
                   </FormGroup>
                   {getLaunchTypeOptions(serviceIndex)}
                   {getWinServerOptions(serviceIndex)}
+                  <Row>
+                    <Col className="d-flex align-items-center">
+                      <SaasBoostCheckbox
+                        key={"services[" + serviceIndex + "].ecsExecEnabled"}
+                        name={"services[" + serviceIndex + "].ecsExecEnabled"}
+                        label="Enable ECS Exec?"
+                        disabled={isLocked}
+                      />
+                    </Col>
+                  </Row>
                 </Col>
                 <Col xs={6}>
                   <SaasBoostInput

--- a/resources/tenant-onboarding-app.yaml
+++ b/resources/tenant-onboarding-app.yaml
@@ -41,6 +41,11 @@ Parameters:
   ECSCluster:
     Description: This tenant's container cluster
     Type: String
+  EnableECSExec:
+    Description: Enable ECS Exec for this ECS Service?
+    Type: String
+    AllowedValues: ['true', 'false']
+    Default: 'false'
   PubliclyAddressable:
     Description: Is this service publicly accessible from the Internet?
     Type: String
@@ -283,6 +288,7 @@ Conditions:
   IsWin2022Full: !Equals [WIN2022FULL, !Ref ContainerOS]
   IsWin2022Core: !Equals [WIN2022CORE, !Ref ContainerOS]
   UseS3: !Not [!Equals [!Ref TenantStorageBucket, '']]
+  EcsExec: !Equals [!Ref EnableECSExec, 'true']
 Resources:
   CapacityProvider:
     Type: AWS::ECS::CapacityProvider
@@ -467,6 +473,15 @@ Resources:
                   - s3:ListMultipartUploadParts
                 Resource:
                   - !Sub arn:${AWS::Partition}:s3:::${TenantStorageBucket}/${ServiceResourceName}/${TenantId}/*
+              - Effect: !If [EcsExec, 'Allow', 'Deny']
+                Action:
+                  - ssmmessages:CreateControlChannel
+                  - ssmmessages:CreateDataChannel
+                  - ssmmessages:OpenControlChannel
+                  - ssmmessages:OpenDataChannel
+                Resource:
+                  # ssmmessages does not support providing ARNs as resource access restrictors
+                  - '*'
   ECSTaskDefinition:
     Type: AWS::ECS::TaskDefinition
     Properties:
@@ -1144,7 +1159,7 @@ Resources:
     DependsOn:
       - ClusterCapacityAssociationWaitCondition
     Properties:
-      EnableExecuteCommand: !If [WindowsOS, false, true]
+      EnableExecuteCommand: !Ref EnableECSExec
       ServiceName: !Ref ServiceResourceName
       Cluster: !Ref ECSCluster
       TaskDefinition: !Ref ECSTaskDefinition

--- a/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingService.java
+++ b/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingService.java
@@ -837,6 +837,7 @@ public class OnboardingService {
                         String pathPart = (isPublic) ? (String) service.get("path") : "";
                         Integer publicPathRulePriority = (isPublic) ? pathPriority.get(serviceName) : 0;
                         String healthCheck = (String) service.get("healthCheckUrl");
+                        Boolean enableEcsExec = (Boolean) service.get("ecsExecEnabled");
 
                         // CloudFormation won't let you use dashes or underscores in Mapping second level key names
                         // And it won't let you use Fn::Join or Fn::Split in Fn::FindInMap... so we will mangle this
@@ -986,6 +987,7 @@ public class OnboardingService {
                         templateParameters.add(Parameter.builder().parameterKey("ContainerRepository").parameterValue(containerRepo).build());
                         templateParameters.add(Parameter.builder().parameterKey("ContainerRepositoryTag").parameterValue(imageTag).build());
                         templateParameters.add(Parameter.builder().parameterKey("ECSCluster").parameterValue(ecsCluster).build());
+                        templateParameters.add(Parameter.builder().parameterKey("EnableECSExec").parameterValue(enableEcsExec.toString()).build());
                         templateParameters.add(Parameter.builder()
                                 .parameterKey("OnboardingDdbTable")
                                 .parameterValue(ONBOARDING_TABLE).build());

--- a/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/ServiceConfig.java
+++ b/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/ServiceConfig.java
@@ -42,6 +42,7 @@ public class ServiceConfig {
     private final OperatingSystem operatingSystem;
     private final Database database;
     private final EcsLaunchType ecsLaunchType;
+    private final Boolean ecsExecEnabled;
     private final S3Storage s3;
 
     private ServiceConfig(Builder builder) {
@@ -57,6 +58,7 @@ public class ServiceConfig {
         this.tiers = builder.tiers;
         this.database = builder.database;
         this.ecsLaunchType = builder.ecsLaunchType;
+        this.ecsExecEnabled = builder.ecsExecEnabled;
         this.s3 = builder.s3;
     }
 
@@ -78,6 +80,7 @@ public class ServiceConfig {
                 .operatingSystem(other.getOperatingSystem())
                 .database(other.getDatabase())
                 .ecsLaunchType(other.getEcsLaunchType())
+                .ecsExecEnabled(other.getEcsExecEnabled())
                 .s3(other.s3);
     }
 
@@ -133,6 +136,10 @@ public class ServiceConfig {
         return ecsLaunchType;
     }
 
+    public Boolean getEcsExecEnabled() {
+        return ecsExecEnabled;
+    }
+
     public S3Storage getS3() {
         return s3;
     }
@@ -178,13 +185,14 @@ public class ServiceConfig {
             && Utils.nullableEquals(tiers, other.tiers) && tiersEqual
             && Utils.nullableEquals(database, other.database)
             && Utils.nullableEquals(ecsLaunchType, other.ecsLaunchType)
+            && Utils.nullableEquals(ecsExecEnabled, other.getEcsExecEnabled())
             && Utils.nullableEquals(s3, other.s3);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(name, description, path, publiclyAddressable, containerPort, containerRepo, containerTag,
-                healthCheckUrl, operatingSystem, database, ecsLaunchType, s3)
+                healthCheckUrl, operatingSystem, database, ecsLaunchType, ecsExecEnabled, s3)
                 + Arrays.hashCode(tiers != null ? tiers.keySet().toArray(new String[0]) : null)
                 + Arrays.hashCode(tiers != null ? tiers.values().toArray(new Object[0]) : null);
     }
@@ -205,6 +213,7 @@ public class ServiceConfig {
         private Map<String, ServiceTierConfig> tiers = new HashMap<>();
         private Database database;
         private EcsLaunchType ecsLaunchType;
+        private Boolean ecsExecEnabled = false;
         private S3Storage s3;
 
         private Builder() {
@@ -297,6 +306,11 @@ public class ServiceConfig {
                     );
                 }
             }
+            return this;
+        }
+
+        public Builder ecsExecEnabled(Boolean ecsExecEnabled) {
+            this.ecsExecEnabled = ecsExecEnabled;
             return this;
         }
 


### PR DESCRIPTION
This commit adds support for the ECS Exec feature of ECS. Enabling ECS Exec in the Admin UI for a given service will create the ECS Service with the ExecuteCommand option and allowed permissions for ExecuteCommand, which will let admins run commands on tenant service containers for debugging purposes. Those permissions are also explicitly denied for services where ECS Exec is not enabled.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
