### PR TITLE
Fix overwritten database bootstrap file in AppConfig UI.

### DIFF
--- a/client/web/src/settings/ApplicationContainer.js
+++ b/client/web/src/settings/ApplicationContainer.js
@@ -163,6 +163,7 @@ export function ApplicationContainer(props) {
       }
       // clean tiers if present
       if (!!filesystem?.tiers) {
+        let cleanedTiers = {}
         for (let tierName in filesystem.tiers) {
           let {
             weeklyMaintenanceDay,
@@ -174,8 +175,9 @@ export function ApplicationContainer(props) {
           }
           // get rid of keys that aren't needed for this tier for this filesystem type
           removeUnwantedKeys(cleanedFsTier, Object.keys(FILESYSTEM_TYPES[filesystemType].tierDefaults))
-          cleanedFs.tiers[tierName] = cleanedFsTier
+          cleanedTiers[tierName] = cleanedFsTier
         }
+        cleanedFs.tiers = cleanedTiers
       }
       // get rid of keys that aren't needed for this filesystem type
       removeUnwantedKeys(cleanedFs, [...Object.keys(FILESYSTEM_TYPES[filesystemType].defaults), 'type', 'tiers'])

--- a/client/web/src/settings/ducks/index.js
+++ b/client/web/src/settings/ducks/index.js
@@ -301,17 +301,21 @@ export const selectConfigMessage = (state) => state.settings.config.message
 export const selectConfig = (state) => state.settings.config.data
 
 export const selectServiceToS3BucketMap = (state) => {
-  const appConfig = state.settings.config.data
-  if (!!appConfig?.services) {
-    const keys = Object.keys(appConfig?.services)
-    return keys.reduce((prev, curr) => {
-      const map = {
-        ...prev,
-        [curr]:
-          appConfig?.services[curr].database?.bootstrapFilename,
-      }
-      return map
-    }, {})
+  // we only want the selectServiceToS3BucketMap to present any urls if the appConfig is not
+  // being updated, since we might be expecting a presigned url to in the updated appConfig
+  if (state.settings.config.loading !== 'pending') {
+    const appConfig = state.settings.config.data
+    if (!!appConfig?.services) {
+      const keys = Object.keys(appConfig?.services)
+      return keys.reduce((prev, curr) => {
+        const map = {
+          ...prev,
+          [curr]:
+            appConfig?.services[curr].database?.bootstrapFilename,
+        }
+        return map
+      }, {})
+    }
   }
   return {}
 }

--- a/client/web/src/tenant/api/index.js
+++ b/client/web/src/tenant/api/index.js
@@ -31,7 +31,6 @@ const CancelToken = axios.CancelToken
 const source = CancelToken.source()
 
 apiServer.interceptors.request.use(async (r) => {
-  console.log(r)
   //Obtain and pass along Authorization token
   const authorizationToken = await fetchAccessToken()
   r.headers.Authorization = "Bearer " + authorizationToken


### PR DESCRIPTION
The database bootstrap files are uploaded to S3 using presigned URLs for the service resources bucket generated by the Settings service. The UI will first update AppConfig then upload any files to their presigned locations when the new AppConfig is returned from Settings service containing the presigned URLs. The Settings service will then receive an event when a new object is put in that resources bucket and will save the bootstrap filename into the AppConfig.

This commit makes it so that the AppConfig UI page mirrors the bootstrapFilename back to the Settings service if no new bootstrap file was selected in the file upload component. This means that the same bootstrap filename will be saved in Settings service backend, no new presigned url will be generated, and the configuration will retain the indication that the same bootstrap file should be used for subsequent database onboardings.

Fixes #245.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
