### PR TITLE
Refactor appConfig compute and support setting min/max for EC2 AutoScaling Group.

### DIFF
--- a/client/web/src/dashboard/DashboardComponent.js
+++ b/client/web/src/dashboard/DashboardComponent.js
@@ -234,16 +234,16 @@ export const DashboardComponent = (props) => {
                             <dl>
                               <dt>ECR Repository</dt>
                               <dd>
-                                {isEmpty(service.containerRepo)
+                                {isEmpty(service?.compute?.containerRepo)
                                   ? 'Creating...'
-                                  : service.containerRepo}{' '}
+                                  : service?.compute?.containerRepo}{' '}
                                 {' - '}
                                 <a
                                   href={
                                     ecrAwsConsoleLink +
-                                    (service.containerRepo
+                                    (service?.compute?.containerRepo
                                         ? (isCnRegion ? '/' : `/private/${awsAccount}/`) +
-                                        service.containerRepo
+                                        service?.compute?.containerRepo
                                       : '')
                                   }
                                   target="new"
@@ -258,7 +258,7 @@ export const DashboardComponent = (props) => {
                                 <ECRInstructions
                                   awsAccount={awsAccount}
                                   awsRegion={awsRegion}
-                                  ecrRepo={service.containerRepo}
+                                  ecrRepo={service?.compute?.containerRepo}
                                 >
                                   <span className="text-muted">
                                     View docker image upload instructions{' '}
@@ -268,8 +268,8 @@ export const DashboardComponent = (props) => {
                               </dt>
                               <dd className="mb-3">
                                 {awsAccount}.dkr.ecr.{awsRegion}.{serviceUrlSuffix}
-                                {service.containerRepo
-                                  ? `/${service.containerRepo}`
+                                {service?.compute?.containerRepo
+                                  ? `/${service?.compute?.containerRepo}`
                                   : ''}
                               </dd>
                               <dt>Description</dt>

--- a/client/web/src/settings/ApplicationContainer.js
+++ b/client/web/src/settings/ApplicationContainer.js
@@ -198,15 +198,13 @@ export function ApplicationContainer(props) {
         // update the service config
         const {
           name,
-          windowsVersion,
-          operatingSystem,
-          ecsLaunchType,
           provisionDb,
           provisionObjectStorage,
           database,
           filesystem,
           provisionFS,
           filesystemType,
+          compute,
           ...rest
         } = thisService
         const {
@@ -226,14 +224,26 @@ export function ApplicationContainer(props) {
               ? encryptedPassword
               : restDb.password,
         }
+        const {
+          operatingSystem,
+          ecsLaunchType,
+          windowsVersion,
+          ...restCompute
+        } = compute
+        // if operatingSystem is not linux (assumed to mean Windows) then launch type must be EC2. otherwise use the launchType if non-null, defaulting to Fargate
+        const cleanedEcsLaunchType = (!!operatingSystem && operatingSystem !== LINUX) ? "EC2" : (!!ecsLaunchType ? ecsLaunchType : "FARGATE")
+        const cleanedCompute = {
+          operatingSystem: operatingSystem === LINUX ? LINUX : windowsVersion,
+          ecsLaunchType: cleanedEcsLaunchType,
+          ...restCompute
+        }
         cleanedServicesMap[name] = {
           ...rest,
           name,
-          operatingSystem: operatingSystem === LINUX ? LINUX : windowsVersion,
-          ecsLaunchType: (!!ecsLaunchType) ? ecsLaunchType : (operatingSystem === LINUX ? "FARGATE" : "EC2"),
           database: provisionDb ? cleanedDb : null,
           filesystem: cleanFilesystemForSubmittal(provisionFS, filesystemType, filesystem),
-          s3: provisionObjectStorage ? {} : null
+          s3: provisionObjectStorage ? {} : null,
+          compute: cleanedCompute,
         }
       }
 

--- a/client/web/src/settings/ServiceSettingsSubform.js
+++ b/client/web/src/settings/ServiceSettingsSubform.js
@@ -15,79 +15,16 @@
  */
 
 import React from 'react'
-import { Row, Col, Card, CardBody, CardHeader, FormGroup, Label } from 'reactstrap'
-import { Field } from 'formik'
-import { SaasBoostSelect, SaasBoostCheckbox, SaasBoostInput, SaasBoostTextarea } from '../components/FormComponents'
+import { Row, Col, Card, CardBody, CardHeader } from 'reactstrap'
+import { SaasBoostCheckbox, SaasBoostInput, SaasBoostTextarea } from '../components/FormComponents'
 import { PropTypes } from 'prop-types'
-import { cibWindows, cibLinux } from '@coreui/icons'
-import CIcon from '@coreui/icons-react'
 import DatabaseSubform from './DatabaseSubform'
 import ObjectStoreSubform from './components/ObjectStoreSubform'
 import FileSystemSubform from './components/filesystem/FileSystemSubform'
+import ComputeSubform from './components/compute/ComputeSubform'
 
 const ServiceSettingsSubform = (props) => {
   const { serviceValues, osOptions, dbOptions, serviceName, onFileSelected, isLocked, serviceIndex } = props
-  const getWinServerOptions = (serviceIndex) => {
-    if (!osOptions) {
-      return null
-    }
-    const winKeys = Object.keys(osOptions).filter((key) => key.startsWith('WIN'))
-    const options = winKeys.map((key) => {
-      var desc = osOptions[key]
-      return (
-        <option value={key} key={key}>
-          {desc}
-        </option>
-      )
-    })
-    return serviceValues?.operatingSystem === 'WINDOWS' && osOptions ? (
-      <FormGroup>
-        <SaasBoostSelect
-          type="select"
-          name={"services[" + serviceIndex + "].windowsVersion"}
-          id={"windowsVersion-" + serviceIndex}
-          label="Windows Server Version"
-        >
-          <option value="">Select One...</option>
-          {options}
-        </SaasBoostSelect>
-      </FormGroup>
-    ) : null
-  }
-
-  const getLaunchTypeOptions = (serviceIndex) => {
-    return serviceValues?.operatingSystem === 'LINUX' && (
-     <FormGroup>
-       <div className="mb-2">Container Launch Type</div>
-       <FormGroup check inline>
-         <Field
-           className="form-check-input"
-           type="radio"
-           id={"launchtype-ec2-" + serviceIndex}
-           name={"services[" + serviceIndex + "].ecsLaunchType"}
-           value="EC2"
-           disabled={isLocked}
-         />
-         <Label className="form-check-label" check htmlFor={"launchtype-ec2-" + serviceIndex}>
-           EC2
-         </Label>
-       </FormGroup>
-       <FormGroup check inline>
-         <Field
-           className="form-check-input"
-           type="radio"
-           id={"launchtype-fargate-" + serviceIndex}
-           name={"services[" + serviceIndex + "].ecsLaunchType"}
-           value="FARGATE"
-           disabled={isLocked}
-         />
-         <Label className="form-check-label" check htmlFor={"launchtype-fargate-" + serviceIndex}>
-           Fargate
-         </Label>
-       </FormGroup>
-     </FormGroup>
-    )
-  }
 
   return (
     <>
@@ -108,7 +45,17 @@ const ServiceSettingsSubform = (props) => {
                         autoFocus
                       />
                     </Col>
-                    <Col className="d-flex align-items-center">
+                  </Row>
+                  <Row>
+                    <Col>
+                      <SaasBoostInput
+                        key={"services[" + serviceIndex + "].path"}
+                        label="Service Addressable Path"
+                        name={"services[" + serviceIndex + "].path"}
+                        type="text"
+                      />
+                    </Col>
+                    <Col className="d-flex align-items-center justify-content-center">
                       <SaasBoostCheckbox
                         key={"services[" + serviceIndex + "].public"}
                         name={"services[" + serviceIndex + "].public"}
@@ -116,106 +63,36 @@ const ServiceSettingsSubform = (props) => {
                       />
                     </Col>
                   </Row>
-                  <Row>
-                    <SaasBoostInput
-                      key={"services[" + serviceIndex + "].path"}
-                      label="Service Addressable Path"
-                      name={"services[" + serviceIndex + "].path"}
-                      type="text"
-                    />
-                  </Row>
+                </Col>
+                <Col xs={6}>
                   <Row>
                     <SaasBoostTextarea
                       key={"services[" + serviceIndex + "].description"}
                       label="Description"
                       name={"services[" + serviceIndex + "].description"}
                       type="text"
+                      rows={4}
                     />
                   </Row>
-                  <FormGroup>
-                    <div className="mb-2">Container OS</div>
-                    <FormGroup check inline>
-                      <Field
-                        className="form-check-input"
-                        type="radio"
-                        id={"os-linux-" + serviceIndex}
-                        name={"services[" + serviceIndex + "].operatingSystem"}
-                        value="LINUX"
-                        disabled={isLocked}
-                      />
-                      <Label className="form-check-label" check htmlFor={"os-linux-" + serviceIndex}>
-                        <CIcon icon={cibLinux} /> Linux
-                      </Label>
-                    </FormGroup>
-                    <FormGroup check inline>
-                      <Field
-                        className="form-check-input"
-                        type="radio"
-                        id={"os-windows-" + serviceIndex}
-                        name={"services[" + serviceIndex + "].operatingSystem"}
-                        value="WINDOWS"
-                        disabled={isLocked}
-                      />
-                      <Label className="form-check-label" check htmlFor={"os-windows-" + serviceIndex}>
-                      <CIcon icon={cibWindows} /> Windows
-                      </Label>
-                    </FormGroup>
-                  </FormGroup>
-                  {getLaunchTypeOptions(serviceIndex)}
-                  {getWinServerOptions(serviceIndex)}
-                  <Row>
-                    <Col className="d-flex align-items-center">
-                      <SaasBoostCheckbox
-                        key={"services[" + serviceIndex + "].ecsExecEnabled"}
-                        name={"services[" + serviceIndex + "].ecsExecEnabled"}
-                        label="Enable ECS Exec?"
-                        disabled={isLocked}
-                      />
-                    </Col>
-                  </Row>
-                </Col>
-                <Col xs={6}>
-                  <SaasBoostInput
-                    key={"services[" + serviceIndex + "].containerRepo"}
-                    label="Container Repo"
-                    name={"services[" + serviceIndex + "].containerRepo"}
-                    type="text"
-                    disabled={true}
-                  />
-                  <SaasBoostInput
-                    key={"services[" + serviceIndex + "].containerTag"}
-                    label="Container Tag"
-                    name={"services[" + serviceIndex + "].containerTag"}
-                    type="text"
-                  />
-                  <SaasBoostInput
-                    key={"services[" + serviceIndex + "].containerPort"}
-                    label="Container Port"
-                    name={"services[" + serviceIndex + "].containerPort"}
-                    type="number"
-                    disabled={isLocked}
-                  />
-                  <SaasBoostInput
-                    key={"services[" + serviceIndex + "].healthCheckUrl"}
-                    label="Health Check URL"
-                    name={"services[" + serviceIndex + "].healthCheckUrl"}
-                    type="text"
-                    description="Must be relative to root (eg. '/health.html')"
-                    disabled={isLocked}
-                  />
                 </Col>
               </Row>
               <Row>
                 <Col>
-                <FileSystemSubform
+                  <ComputeSubform
+                    values={serviceValues?.compute}
+                    osOptions={osOptions}
+                    isLocked={isLocked}
+                    formikServicePrefix={'services[' + serviceIndex + ']'}
+                  />
+                  <FileSystemSubform
                     isLocked={isLocked}
                     formikServicePrefix={'services[' + serviceIndex + ']'}
                     filesystem={serviceValues?.filesystem}
                     provisionFs={
                       serviceValues?.provisionFS
                     }
-                    containerOs={serviceValues?.operatingSystem}
-                    containerLaunchType={serviceValues?.ecsLaunchType}
+                    containerOs={serviceValues?.compute?.operatingSystem}
+                    containerLaunchType={serviceValues?.compute?.ecsLaunchType}
                     filesystemType={serviceValues?.filesystemType}
                     setFieldValue={props.setFieldValue}
                   ></FileSystemSubform>

--- a/client/web/src/settings/TierServiceSettingsSubform.js
+++ b/client/web/src/settings/TierServiceSettingsSubform.js
@@ -15,11 +15,11 @@
  */
 
 import React, { useState } from 'react'
-import { SaasBoostSelect, SaasBoostInput } from '../components/FormComponents'
 import { Dropdown, Card, Row, Col } from 'react-bootstrap'
 import { PropTypes } from 'prop-types'
 import FileSystemTierSubform from './components/filesystem/FileSystemTierSubform'
 import DatabaseTierSubform from './DatabaseTierSubform'
+import ComputeTierSubform from './components/compute/ComputeTierSubform'
 
 const TierServiceSettingsSubform = (props) => {
   const {
@@ -33,28 +33,11 @@ const TierServiceSettingsSubform = (props) => {
   } = props
 
   const [selectedTier, setSelectedTier] = useState(defaultTier)
-
-  const formikTierPrefix = formikServicePrefix + '.tiers[' + selectedTier + ']'
-
-  if (!!serviceValues?.tiers) {
-    // set compute size if default exists and this tier doesn't
-    if (!!!serviceValues?.tiers[selectedTier]?.computeSize && !!serviceValues?.tiers[defaultTier]?.computeSize) {
-      // set instance to default if it doesn't exist already
-      setFieldValue(formikTierPrefix + '.computeSize', serviceValues?.tiers[defaultTier]?.computeSize)
-    }
-
-    // set min if default exists and this tier doesn't
-    if (!!!serviceValues?.tiers[selectedTier]?.min && !!serviceValues?.tiers[defaultTier]?.min) {
-      // set instance to default if it doesn't exist already
-      setFieldValue(formikTierPrefix + '.min', serviceValues?.tiers[defaultTier]?.min)
-    }
-
-    // set max if default exists and this tier doesn't
-    if (!!!serviceValues?.tiers[selectedTier]?.max && !!serviceValues?.tiers[defaultTier]?.max) {
-      // set instance to default if it doesn't exist already
-      setFieldValue(formikTierPrefix + '.max', serviceValues?.tiers[defaultTier]?.max)
-    }
-  }
+  const ec2AutoScaling = !!(serviceValues?.compute?.operatingSystem)
+      ? serviceValues?.compute?.operatingSystem === 'LINUX'
+          ? serviceValues?.compute?.ecsLaunchType === 'EC2'
+          : true
+      : false
 
   return (
     <>
@@ -88,51 +71,22 @@ const TierServiceSettingsSubform = (props) => {
             </Card.Header>
             <Card.Body>
               <Row>
-                <Col xs={6}>
-                  <SaasBoostSelect
-                    type="select"
-                    name={formikTierPrefix + '.computeSize'}
-                    id={formikTierPrefix + '.computeSize'}
-                    label="Compute Size"
-                  >
-                    <option value="">Select One...</option>
-                    <option value="S">Small</option>
-                    <option value="M">Medium</option>
-                    <option value="L">Large</option>
-                    <option value="XL">X-Large</option>
-                  </SaasBoostSelect>
-                  <Row>
-                    <Col>
-                      <SaasBoostInput
-                        key={formikTierPrefix + '.min'}
-                        label="Minimum Instance Count"
-                        name={formikTierPrefix + '.min'}
-                        type="number"
-                        min="0"
-                      />
-                    </Col>
-                    <Col>
-                      <SaasBoostInput
-                        key={formikTierPrefix + '.max'}
-                        label="Maximum Instance Count"
-                        name={formikTierPrefix + '.max'}
-                        type="number"
-                        min="0"
-                      />
-                    </Col>
-                  </Row>
-                </Col>
-              </Row>
-              <Row>
                 <Col>
+                  <ComputeTierSubform 
+                    values={serviceValues?.compute?.tiers[selectedTier]}
+                    defaultValues={serviceValues?.compute?.tiers[defaultTier]}
+                    formikComputeTierPrefix={formikServicePrefix + '.compute.tiers[' + selectedTier + ']'}
+                    setFieldValue={setFieldValue}
+                    ec2AutoScaling={ec2AutoScaling}
+                  />
                   <FileSystemTierSubform
                     isLocked={isLocked}
                     formikFilesystemTierPrefix={formikServicePrefix + '.filesystem.tiers[' + selectedTier + ']'}
                     defaultFilesystem={serviceValues?.filesystem?.tiers[defaultTier]}
                     filesystem={serviceValues?.filesystem?.tiers[selectedTier]}
                     provisionFs={serviceValues?.provisionFS}
-                    containerOs={serviceValues?.operatingSystem}
-                    containerLaunchType={serviceValues?.ecsLaunchType}
+                    containerOs={serviceValues?.compute?.operatingSystem}
+                    containerLaunchType={serviceValues?.compute?.ecsLaunchType}
                     filesystemType={serviceValues?.filesystemType}
                     setFieldValue={props.setFieldValue}
                   ></FileSystemTierSubform>

--- a/client/web/src/settings/components/compute/ComputeSubform.js
+++ b/client/web/src/settings/components/compute/ComputeSubform.js
@@ -1,0 +1,200 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React, { Fragment } from 'react'
+import { Row, Col, Card, CardBody, CardHeader, FormGroup, Label } from 'reactstrap'
+import {
+  SaasBoostCheckbox,
+  SaasBoostInput,
+  SaasBoostSelect,
+} from '../../../components/FormComponents'
+import CIcon from '@coreui/icons-react'
+import { cibWindows, cibLinux } from '@coreui/icons'
+import { Field } from 'formik'
+
+const ComputeSubform = (props) => {
+
+  const { values, osOptions, isLocked, formikServicePrefix } = props
+
+  const getOsSpecificOptions = () => {
+    if (values?.operatingSystem === 'WINDOWS') {
+      return getWinServerOptions()
+    } else if (values?.operatingSystem === 'LINUX') {
+      return getLaunchTypeOptions()
+    }
+    return null
+  }
+
+  const getWinServerOptions = () => {
+    if (!osOptions) {
+      return null
+    }
+    const winKeys = Object.keys(osOptions).filter((key) => key.startsWith('WIN'))
+    const options = winKeys.map((key) => {
+      var desc = osOptions[key]
+      return (
+        <option value={key} key={key} id={key}>
+          {desc}
+        </option>
+      )
+    })
+    return values?.operatingSystem === 'WINDOWS' && osOptions ? (
+      <FormGroup>
+        <SaasBoostSelect
+          type="select"
+          name={formikServicePrefix + ".compute.windowsVersion"}
+          id={formikServicePrefix + ".compute.windowsVersion"}
+          label="Windows Server Version"
+        >
+          <option value="">Select One...</option>
+          {options}
+        </SaasBoostSelect>
+      </FormGroup>
+    ) : null
+  }
+
+  const getLaunchTypeOptions = () => {
+    return values?.operatingSystem === 'LINUX' && (
+     <FormGroup>
+       <div className="mb-2">Container Launch Type</div>
+       <FormGroup check inline>
+         <Field
+           className="form-check-input"
+           type="radio"
+           id={formikServicePrefix + ".compute.ecsLaunchType.ec2"}
+           name={formikServicePrefix + ".compute.ecsLaunchType"}
+           value="EC2"
+           disabled={isLocked}
+         />
+         <Label className="form-check-label" check htmlFor={formikServicePrefix + ".compute.ecsLaunchType.ec2"}>
+           EC2
+         </Label>
+       </FormGroup>
+       <FormGroup check inline>
+         <Field
+           className="form-check-input"
+           type="radio"
+           id={formikServicePrefix + ".compute.ecsLaunchType.fargate"}
+           name={formikServicePrefix + ".compute.ecsLaunchType"}
+           value="FARGATE"
+           disabled={isLocked}
+         />
+         <Label className="form-check-label" check htmlFor={formikServicePrefix + ".compute.ecsLaunchType.fargate"}>
+           Fargate
+         </Label>
+       </FormGroup>
+     </FormGroup>
+    )
+  }
+
+  return (
+    <Fragment>
+      <Row className="mt-3">
+        <Col xs={12}>
+          <Card>
+            <CardHeader>Compute</CardHeader>
+            <CardBody>
+              <Row>
+                <Col xs={6}>
+                  <Row>
+                    <Col xs={6}>
+                      <FormGroup>
+                        <div className="mb-2">Container OS</div>
+                        <FormGroup check inline>
+                          <Field
+                            className="form-check-input"
+                            type="radio"
+                            id={formikServicePrefix + ".compute.operatingSystem.linux"}
+                            name={formikServicePrefix + ".compute.operatingSystem"}
+                            value="LINUX"
+                            disabled={isLocked}
+                          />
+                          <Label className="form-check-label" check htmlFor={formikServicePrefix + ".compute.operatingSystem.linux"}>
+                            <CIcon icon={cibLinux} /> Linux
+                          </Label>
+                        </FormGroup>
+                        <FormGroup check inline>
+                          <Field
+                            className="form-check-input"
+                            type="radio"
+                            id={formikServicePrefix + ".compute.operatingSystem.windows"}
+                            name={formikServicePrefix + ".compute.operatingSystem"}
+                            value="WINDOWS"
+                            disabled={isLocked}
+                          />
+                          <Label className="form-check-label" check htmlFor={formikServicePrefix + ".compute.operatingSystem.windows"}>
+                            <CIcon icon={cibWindows} /> Windows
+                          </Label>
+                        </FormGroup>
+                      </FormGroup>
+                    </Col>
+                    <Col xs={6}>
+                      {getOsSpecificOptions()}
+                    </Col>
+                  </Row>
+                  <Row>
+                    <Col className="d-flex align-items-center">
+                      <SaasBoostCheckbox
+                        key={formikServicePrefix + ".compute.ecsExecEnabled"}
+                        name={formikServicePrefix + ".compute.ecsExecEnabled"}
+                        label="Enable ECS Exec"
+                        tooltip="Use ECS Exec to run commands in a tenant ECS container."
+                        disabled={isLocked}
+                      />
+                    </Col>
+                  </Row>
+                  <Row>
+                    <SaasBoostInput
+                      key={formikServicePrefix + ".compute.healthCheckUrl"}
+                      label="Health Check URL"
+                      name={formikServicePrefix + ".compute.healthCheckUrl"}
+                      type="text"
+                      description="Must be relative to root (eg. '/health.html')"
+                      disabled={isLocked}
+                    />
+                  </Row>
+                </Col>
+                <Col xs={6}>
+                  <SaasBoostInput
+                    key={formikServicePrefix + ".compute.containerRepo"}
+                    label="Container Repo"
+                    name={formikServicePrefix + ".compute.containerRepo"}
+                    type="text"
+                    disabled={true}
+                  />
+                  <SaasBoostInput
+                    key={formikServicePrefix + ".compute.containerTag"}
+                    label="Container Tag"
+                    name={formikServicePrefix + ".compute.containerTag"}
+                    type="text"
+                  />
+                  <SaasBoostInput
+                    key={formikServicePrefix + ".compute.containerPort"}
+                    label="Container Port"
+                    name={formikServicePrefix + ".compute.containerPort"}
+                    type="number"
+                    disabled={isLocked}
+                  />
+                </Col>
+              </Row>
+            </CardBody>
+          </Card>
+        </Col>
+      </Row>
+    </Fragment>
+  )
+}
+
+export default ComputeSubform

--- a/client/web/src/settings/components/compute/ComputeTierSubform.js
+++ b/client/web/src/settings/components/compute/ComputeTierSubform.js
@@ -1,0 +1,121 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React, { Fragment } from 'react'
+import { Row, Col, Card, CardBody, CardHeader } from 'reactstrap'
+import { SaasBoostSelect, SaasBoostInput } from '../../../components/FormComponents'
+
+export default class ComputeTierSubform extends React.Component {
+
+  render() {
+    let { values, defaultValues, formikComputeTierPrefix, setFieldValue, ec2AutoScaling } = this.props
+
+    // TODO maybe default tier implementation should take effect on the backend?
+    // TODO we should only require values for the default tier
+    if (!!values && !!defaultValues) {
+      // set compute size if default exists and this tier doesn't
+      if (!!!values.computeSize && defaultValues.computeSize) {
+        // set instance to default if it doesn't exist already
+        setFieldValue(formikComputeTierPrefix + '.computeSize', defaultValues.computeSize)
+      }
+  
+      // set min if default exists and this tier doesn't
+      if (!!!values.min && !!defaultValues.min) {
+        // set instance to default if it doesn't exist already
+        setFieldValue(formikComputeTierPrefix + '.min', defaultValues.min)
+      }
+  
+      // set max if default exists and this tier doesn't
+      if (!!!values.max && !!defaultValues.max) {
+        // set instance to default if it doesn't exist already
+        setFieldValue(formikComputeTierPrefix + '.max', defaultValues?.max)
+      }
+    }
+
+    return (
+      <Fragment>
+        <Row className="mt-3">
+          <Col xs={12}>
+            <Card>
+              <CardHeader>Compute</CardHeader>
+              <CardBody>
+                <Row>
+                  <Col xs={6}>
+                    <SaasBoostSelect
+                      type="select"
+                      name={formikComputeTierPrefix + '.computeSize'}
+                      id={formikComputeTierPrefix + '.computeSize'}
+                      label="Compute Size"
+                    >
+                      <option value="">Select One...</option>
+                      <option value="S">Small</option>
+                      <option value="M">Medium</option>
+                      <option value="L">Large</option>
+                      <option value="XL">X-Large</option>
+                    </SaasBoostSelect>
+                    <Row>
+                      <Col>
+                        <SaasBoostInput
+                          key={formikComputeTierPrefix + '.min'}
+                          label="Minimum Instance Count"
+                          name={formikComputeTierPrefix + '.min'}
+                          type="number"
+                          min="0"
+                        />
+                      </Col>
+                      <Col>
+                        <SaasBoostInput
+                          key={formikComputeTierPrefix + '.max'}
+                          label="Maximum Instance Count"
+                          name={formikComputeTierPrefix + '.max'}
+                          type="number"
+                          min="0"
+                        />
+                      </Col>
+                    </Row>
+                  </Col>
+                  {!!ec2AutoScaling && (
+                  <Col xs={6}>
+                    <Row>
+                      <Col>
+                        <SaasBoostInput
+                          key={formikComputeTierPrefix + '.ec2min'}
+                          label="Minimum EC2 AutoScaling Instance Count"
+                          name={formikComputeTierPrefix + '.ec2min'}
+                          type="number"
+                          min="0"
+                        />
+                      </Col>
+                      <Col>
+                        <SaasBoostInput
+                          key={formikComputeTierPrefix + '.ec2max'}
+                          label="Maximum EC2 AutoScaling Instance Count"
+                          name={formikComputeTierPrefix + '.ec2max'}
+                          type="number"
+                          min="0"
+                        />
+                      </Col>
+                    </Row>
+                  </Col>
+                  )}
+                </Row>
+              </CardBody>
+            </Card>
+          </Col>
+        </Row>
+      </Fragment>
+    )
+  }
+}

--- a/functions/core-stack-listener/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/CoreStackListener.java
+++ b/functions/core-stack-listener/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/CoreStackListener.java
@@ -117,7 +117,13 @@ public class CoreStackListener implements RequestHandler<SNSEvent, Object> {
                                     serviceName,
                                     serviceNameContext,
                                     ecrRepo);
-                            services.put(serviceName, Map.of("containerRepo", ecrRepo));
+                            // TODO if in the future we support alternate compute options, ECS may not be
+                            // TODO the right one to specify here however, this coreStackListener has no
+                            // TODO extra information about the container type without the macro providing
+                            // TODO more information when adding the ECR repo to the stack
+                            services.put(serviceName, Map.of("compute", Map.of(
+                                    "type", "ECS", 
+                                    "containerRepo", ecrRepo)));
                         }
                         if ("AWS::S3::Bucket".equals(resource.resourceType())
                                 && "TenantStorage".equals(resource.logicalResourceId())) {

--- a/functions/workload-deploy/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/WorkloadDeploy.java
+++ b/functions/workload-deploy/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/WorkloadDeploy.java
@@ -115,8 +115,9 @@ public class WorkloadDeploy implements RequestHandler<Map<String, Object>, Objec
         Map<String, Object> services = (Map<String, Object>) appConfig.get("services");
         for (Map.Entry<String, Object> serviceConfig : services.entrySet()) {
             Map<String, Object> service = (Map<String, Object>) serviceConfig.getValue();
-            String containerRepo = (String) service.get("containerRepo");
-            String containerTag = (String) service.get("containerTag");
+            Map<String, Object> compute = (Map<String, Object>) service.get("compute");
+            String containerRepo = (String) compute.get("containerRepo");
+            String containerTag = (String) compute.get("containerTag");
             if (repo.equals(containerRepo)) {
                 if (!tag.equals(containerTag)) {
                     LOGGER.error("Image tag in event {} does not match appConfig {}", tag, containerTag);

--- a/resources/tenant-onboarding-app.yaml
+++ b/resources/tenant-onboarding-app.yaml
@@ -115,6 +115,14 @@ Parameters:
     Description: Maximum count of concurrent tasks for this tenant (max size we can auto scale up to)
     Type: Number
     Default: 1
+  MinAutoScalingGroupSize:
+    Description: Minimum count of EC2 instances running in AutoScaling group
+    Type: Number
+    Default: 0
+  MaxAutoScalingGroupSize:
+    Description: Maximum count of EC2 instances running in AutoScaling group
+    Type: Number
+    Default: 1
   ContainerPort:
     Description: The TCP port the container is listening on via EXPOSE in the Dockerfile
     Type: Number
@@ -690,18 +698,12 @@ Resources:
         LaunchTemplateId: !If [Ec2Windows, !Ref WindowsLaunchTemplate, !Ref LinuxLaunchTemplate]
         Version: !If [Ec2Windows, !GetAtt WindowsLaunchTemplate.LatestVersionNumber, !GetAtt LinuxLaunchTemplate.LatestVersionNumber]
       NewInstancesProtectedFromScaleIn: true
-      MinSize: '0'
-      MaxSize: '20'
-      DesiredCapacity: '0'
-      #Cooldown:
+      MinSize: !Ref MinAutoScalingGroupSize
+      MaxSize: !Ref MaxAutoScalingGroupSize
       HealthCheckGracePeriod: 30
-      #HealthCheckType:
-      #MetricsCollection:
-      #NotificationConfigurations:
     UpdatePolicy:
       AutoScalingRollingUpdate:
         MinInstancesInService: 1
-        #MinSuccessfulInstancesPercent: 0
         MaxBatchSize: 1
         PauseTime: PT5M
         WaitOnResourceSignals: false

--- a/samples/java/build.ps1
+++ b/samples/java/build.ps1
@@ -24,8 +24,8 @@ $AWS_REGION = (aws configure list | Select-String -Pattern "region" | Out-String
 $SERVICE_JSON = (aws ssm get-parameter --name "/saas-boost/$SAAS_BOOST_ENV/app/$APP_NAME/SERVICE_JSON" | ConvertFrom-Json).Parameter.Value
 #Write-Output $SERVICE_JSON
 
-$ECR_REPO = ($SERVICE_JSON | ConvertFrom-Json).containerRepo
-$TAG = ($SERVICE_JSON | ConvertFrom-Json).containerTag
+$ECR_REPO = ($SERVICE_JSON | ConvertFrom-Json).compute.containerRepo
+$TAG = ($SERVICE_JSON | ConvertFrom-Json).compute.containerTag
 
 If ("$AWS_REGION" -eq "cn-northwest-1" -or "$AWS_REGION" -eq "cn-north-1") {
     $DOCKER_REPO = "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com.cn/$ECR_REPO"

--- a/services/onboarding-service/pom.xml
+++ b/services/onboarding-service/pom.xml
@@ -33,7 +33,7 @@ limitations under the License.
     </licenses>
 
     <properties>
-        <checkstyle.maxAllowedViolations>160</checkstyle.maxAllowedViolations>
+        <checkstyle.maxAllowedViolations>145</checkstyle.maxAllowedViolations>
     </properties>
 
     <build>

--- a/services/settings-service/pom.xml
+++ b/services/settings-service/pom.xml
@@ -33,7 +33,7 @@ limitations under the License.
     </licenses>
 
     <properties>
-        <checkstyle.maxAllowedViolations>30</checkstyle.maxAllowedViolations>
+        <checkstyle.maxAllowedViolations>25</checkstyle.maxAllowedViolations>
     </properties>
 
     <build>

--- a/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/ServiceConfig.java
+++ b/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/ServiceConfig.java
@@ -18,13 +18,11 @@ package com.amazon.aws.partners.saasfactory.saasboost.appconfig;
 
 import com.amazon.aws.partners.saasfactory.saasboost.Utils;
 import com.amazon.aws.partners.saasfactory.saasboost.appconfig.filesystem.AbstractFilesystem;
+import com.amazon.aws.partners.saasfactory.saasboost.appconfig.compute.AbstractCompute;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
 
 @JsonDeserialize(builder = ServiceConfig.Builder.class)
@@ -35,34 +33,20 @@ public class ServiceConfig {
     private final String name;
     private final String description;
     private final String path;
-    private final Map<String, ServiceTierConfig> tiers;
-    private final Integer containerPort;
-    private final String containerRepo;
-    private final String containerTag;
-    private final String healthCheckUrl;
-    private final OperatingSystem operatingSystem;
     private final Database database;
-    private final EcsLaunchType ecsLaunchType;
-    private final Boolean ecsExecEnabled;
     private final S3Storage s3;
     private final AbstractFilesystem filesystem;
+    private final AbstractCompute compute;
 
     private ServiceConfig(Builder builder) {
         this.publiclyAddressable = builder.publiclyAddressable;
         this.name = builder.name;
         this.description = builder.description;
         this.path = builder.path;
-        this.containerPort = builder.containerPort;
-        this.containerRepo = builder.containerRepo;
-        this.containerTag = builder.containerTag;
-        this.healthCheckUrl = builder.healthCheckUrl;
-        this.operatingSystem = builder.operatingSystem;
-        this.tiers = builder.tiers;
         this.database = builder.database;
-        this.ecsLaunchType = builder.ecsLaunchType;
-        this.ecsExecEnabled = builder.ecsExecEnabled;
         this.s3 = builder.s3;
         this.filesystem = builder.filesystem;
+        this.compute = builder.compute;
     }
 
     public static Builder builder() {
@@ -75,17 +59,10 @@ public class ServiceConfig {
                 .name(other.getName())
                 .description(other.getDescription())
                 .path(other.getPath())
-                .tiers(other.getTiers())
-                .containerPort(other.getContainerPort())
-                .containerRepo(other.getContainerRepo())
-                .containerTag(other.getContainerTag())
-                .healthCheckUrl(other.getHealthCheckUrl())
-                .operatingSystem(other.getOperatingSystem())
                 .database(other.getDatabase())
-                .ecsLaunchType(other.getEcsLaunchType())
-                .ecsExecEnabled(other.getEcsExecEnabled())
                 .s3(other.s3)
-                .filesystem(other.getFilesystem());
+                .filesystem(other.getFilesystem())
+                .compute(other.getCompute());
     }
 
     public Boolean isPublic() {
@@ -104,30 +81,6 @@ public class ServiceConfig {
         return path;
     }
 
-    public Integer getContainerPort() {
-        return containerPort;
-    }
-
-    public String getContainerRepo() {
-        return containerRepo;
-    }
-
-    public String getContainerTag() {
-        return containerTag;
-    }
-
-    public String getHealthCheckUrl() {
-        return healthCheckUrl;
-    }
-
-    public OperatingSystem getOperatingSystem() {
-        return operatingSystem;
-    }
-
-    public Map<String, ServiceTierConfig> getTiers() {
-        return tiers != null ? Map.copyOf(tiers) : null;
-    }
-
     public Database getDatabase() {
         return database;
     }
@@ -136,20 +89,16 @@ public class ServiceConfig {
         return database != null;
     }
 
-    public EcsLaunchType getEcsLaunchType() {
-        return ecsLaunchType;
-    }
-
-    public Boolean getEcsExecEnabled() {
-        return ecsExecEnabled;
-    }
-
     public S3Storage getS3() {
         return s3;
     }
 
     public AbstractFilesystem getFilesystem() {
         return filesystem;
+    }
+    
+    public AbstractCompute getCompute() {
+        return compute;
     }
 
     @Override
@@ -168,42 +117,19 @@ public class ServiceConfig {
 
         final ServiceConfig other = (ServiceConfig) obj;
 
-        boolean tiersEqual = tiers != null && other.tiers != null;
-        if (tiersEqual) {
-            tiersEqual = tiers.size() == other.tiers.size();
-            if (tiersEqual) {
-                for (Map.Entry<String, ServiceTierConfig> tier : tiers.entrySet()) {
-                    tiersEqual = tier.getValue().equals(other.tiers.get(tier.getKey()));
-                    if (!tiersEqual) {
-                        break;
-                    }
-                }
-            }
-        }
-
         return Utils.nullableEquals(name, other.name)
             && Utils.nullableEquals(description, other.description)
             && Utils.nullableEquals(path, other.path)
             && Utils.nullableEquals(publiclyAddressable, other.publiclyAddressable)
-            && Utils.nullableEquals(containerPort, other.containerPort)
-            && Utils.nullableEquals(containerRepo, other.containerRepo)
-            && Utils.nullableEquals(containerTag, other.containerTag)
-            && Utils.nullableEquals(healthCheckUrl, other.healthCheckUrl)
-            && Utils.nullableEquals(operatingSystem, other.operatingSystem)
-            && Utils.nullableEquals(tiers, other.tiers) && tiersEqual
             && Utils.nullableEquals(database, other.database)
-            && Utils.nullableEquals(ecsLaunchType, other.ecsLaunchType)
-            && Utils.nullableEquals(ecsExecEnabled, other.getEcsExecEnabled())
             && Utils.nullableEquals(s3, other.s3)
-            && Utils.nullableEquals(filesystem, other.filesystem);
+            && Utils.nullableEquals(filesystem, other.filesystem)
+            && Utils.nullableEquals(compute, other.compute);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, description, path, publiclyAddressable, containerPort, containerRepo, containerTag,
-                healthCheckUrl, operatingSystem, database, ecsLaunchType, ecsExecEnabled, s3, filesystem)
-                + Arrays.hashCode(tiers != null ? tiers.keySet().toArray(new String[0]) : null)
-                + Arrays.hashCode(tiers != null ? tiers.values().toArray(new Object[0]) : null);
+        return Objects.hash(name, description, path, publiclyAddressable, database, s3, filesystem, compute);
     }
 
     @JsonPOJOBuilder(withPrefix = "") // setters aren't named with[Property]
@@ -214,17 +140,10 @@ public class ServiceConfig {
         private String name;
         private String description;
         private String path;
-        private Integer containerPort;
-        private String containerRepo;
-        private String containerTag;
-        private String healthCheckUrl;
-        private OperatingSystem operatingSystem;
-        private Map<String, ServiceTierConfig> tiers = new HashMap<>();
         private Database database;
-        private EcsLaunchType ecsLaunchType;
-        private Boolean ecsExecEnabled = false;
         private S3Storage s3;
         private AbstractFilesystem filesystem;
+        private AbstractCompute compute;
 
         private Builder() {
         }
@@ -249,83 +168,8 @@ public class ServiceConfig {
             return this;
         }
 
-        public Builder containerPort(Integer containerPort) {
-            this.containerPort = containerPort;
-            return this;
-        }
-
-        public Builder containerPort(String containerPort) {
-            this.containerPort = Utils.isNotEmpty(containerPort) ? Integer.valueOf(containerPort) : null;
-            return this;
-        }
-
-        public Builder containerRepo(String containerRepo) {
-            this.containerRepo = containerRepo;
-            return this;
-        }
-
-        public Builder containerTag(String containerTag) {
-            this.containerTag = containerTag;
-            return this;
-        }
-
-        public Builder healthCheckUrl(String healthCheckUrl) {
-            this.healthCheckUrl = healthCheckUrl;
-            return this;
-        }
-
-        public Builder operatingSystem(String operatingSystem) {
-            if (operatingSystem != null) {
-                try {
-                    this.operatingSystem = OperatingSystem.valueOf(operatingSystem);
-                } catch (IllegalArgumentException e) {
-                    OperatingSystem os = OperatingSystem.ofDescription(operatingSystem);
-                    if (os == null) {
-                        throw new RuntimeException(
-                                new IllegalArgumentException("Can't find OperatingSystem for value " + operatingSystem)
-                        );
-                    }
-                    this.operatingSystem = os;
-                }
-            }
-            return this;
-        }
-
-        public Builder operatingSystem(OperatingSystem operatingSystem) {
-            this.operatingSystem = operatingSystem;
-            return this;
-        }
-
-        public Builder tiers(Map<String, ServiceTierConfig> tiers) {
-            this.tiers = tiers != null ? tiers : new HashMap<>();
-            return this;
-        }
-
         public Builder database(Database database) {
             this.database = database;
-            return this;
-        }
-
-        public Builder ecsLaunchType(String ecsLaunchType) {
-            if (ecsLaunchType != null) {
-                try {
-                    this.ecsLaunchType = EcsLaunchType.valueOf(ecsLaunchType);
-                } catch (IllegalArgumentException e) {
-                    throw new RuntimeException(
-                        new IllegalArgumentException("Can't find EcsLaunchType for value " + ecsLaunchType)
-                    );
-                }
-            }
-            return this;
-        }
-
-        public Builder ecsLaunchType(EcsLaunchType ecsLaunchType) {
-            this.ecsLaunchType = ecsLaunchType;
-            return this;
-        }
-
-        public Builder ecsExecEnabled(Boolean ecsExecEnabled) {
-            this.ecsExecEnabled = ecsExecEnabled;
             return this;
         }
 
@@ -336,6 +180,11 @@ public class ServiceConfig {
 
         public Builder filesystem(AbstractFilesystem filesystem) {
             this.filesystem = filesystem;
+            return this;
+        }
+
+        public Builder compute(AbstractCompute compute) {
+            this.compute = compute;
             return this;
         }
 

--- a/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/compute/AbstractCompute.java
+++ b/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/compute/AbstractCompute.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.amazon.aws.partners.saasfactory.saasboost.appconfig.compute;
+
+import com.amazon.aws.partners.saasfactory.saasboost.Utils;
+import com.amazon.aws.partners.saasfactory.saasboost.appconfig.OperatingSystem;
+import com.amazon.aws.partners.saasfactory.saasboost.appconfig.compute.ecs.EcsCompute;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import java.util.Map;
+import java.util.Objects;
+
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.PROPERTY,
+        property = "type"
+)
+@JsonSubTypes({
+        @Type(value = EcsCompute.class, name = AbstractCompute.ECS)
+})
+public abstract class AbstractCompute {
+    protected static final String ECS = "ECS";
+
+    private final Integer containerPort;
+    private final String containerRepo;
+    private final String containerTag;
+    private final String healthCheckUrl;
+    private final OperatingSystem operatingSystem;
+    
+    protected AbstractCompute(Builder b) {
+        this.containerPort = b.containerPort;
+        this.containerRepo = b.containerRepo;
+        this.containerTag = b.containerTag;
+        this.healthCheckUrl = b.healthCheckUrl;
+        this.operatingSystem = b.operatingSystem;
+    }
+
+    public Integer getContainerPort() {
+        return containerPort;
+    }
+
+    public String getContainerRepo() {
+        return containerRepo;
+    }
+
+    public String getContainerTag() {
+        return containerTag;
+    }
+
+    public String getHealthCheckUrl() {
+        return healthCheckUrl;
+    }
+
+    public OperatingSystem getOperatingSystem() {
+        return operatingSystem;
+    }
+
+    public abstract Map<String, ? extends AbstractComputeTier> getTiers();
+
+    protected Builder fillBuilder(Builder b) {
+        return b.containerPort(containerPort)
+                .containerRepo(containerRepo)
+                .containerTag(containerTag)
+                .healthCheckUrl(healthCheckUrl)
+                .operatingSystem(operatingSystem);
+    }
+
+    public abstract Builder builder();
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        // Same reference?
+        if (this == obj) {
+            return true;
+        }
+        // Same type?
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+
+        AbstractCompute other = (AbstractCompute) obj;
+        return (super.equals(other)
+                && Utils.nullableEquals(containerPort, other.containerPort)
+                && Utils.nullableEquals(containerRepo, other.containerRepo)
+                && Utils.nullableEquals(containerTag, other.containerTag)
+                && Utils.nullableEquals(healthCheckUrl, other.healthCheckUrl)
+                && Utils.nullableEquals(operatingSystem, other.operatingSystem));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), containerPort, containerRepo, containerTag,
+                healthCheckUrl, operatingSystem);
+    }
+
+    @JsonPOJOBuilder(withPrefix = "") // setters aren't named with[Property]
+    public abstract static class Builder {
+        private Integer containerPort;
+        private String containerRepo;
+        private String containerTag;
+        private String healthCheckUrl;
+        private OperatingSystem operatingSystem;
+
+        public Builder containerPort(Integer containerPort) {
+            this.containerPort = containerPort;
+            return this;
+        }
+
+        public Builder containerPort(String containerPort) {
+            this.containerPort = Utils.isNotEmpty(containerPort) ? Integer.valueOf(containerPort) : null;
+            return this;
+        }
+
+        public Builder containerRepo(String containerRepo) {
+            this.containerRepo = containerRepo;
+            return this;
+        }
+
+        public Builder containerTag(String containerTag) {
+            this.containerTag = containerTag;
+            return this;
+        }
+
+        public Builder healthCheckUrl(String healthCheckUrl) {
+            this.healthCheckUrl = healthCheckUrl;
+            return this;
+        }
+
+        public Builder operatingSystem(String operatingSystem) {
+            if (operatingSystem != null) {
+                try {
+                    this.operatingSystem = OperatingSystem.valueOf(operatingSystem);
+                } catch (IllegalArgumentException e) {
+                    OperatingSystem os = OperatingSystem.ofDescription(operatingSystem);
+                    if (os == null) {
+                        throw new RuntimeException(
+                                new IllegalArgumentException("Can't find OperatingSystem for value " + operatingSystem)
+                        );
+                    }
+                    this.operatingSystem = os;
+                }
+            }
+            return this;
+        }
+
+        public Builder operatingSystem(OperatingSystem operatingSystem) {
+            this.operatingSystem = operatingSystem;
+            return this;
+        }
+
+        public abstract AbstractCompute build();
+    }
+}   

--- a/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/compute/AbstractComputeTier.java
+++ b/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/compute/AbstractComputeTier.java
@@ -1,57 +1,29 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-package com.amazon.aws.partners.saasfactory.saasboost.appconfig;
+package com.amazon.aws.partners.saasfactory.saasboost.appconfig.compute;
 
 import com.amazon.aws.partners.saasfactory.saasboost.Utils;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import java.util.Objects;
 
-@JsonDeserialize(builder = ServiceTierConfig.Builder.class)
-public class ServiceTierConfig {
+public abstract class AbstractComputeTier {
     private final Integer min;
     private final Integer max;
     private final ComputeSize computeSize;
     private final Integer cpu;
     private final Integer memory;
     private final String instanceType;
+    private final Integer ec2min;
+    private final Integer ec2max;
 
-    private ServiceTierConfig(Builder builder) {
+    protected AbstractComputeTier(Builder builder) {
         this.min = builder.min;
         this.max = builder.max;
         this.computeSize = builder.computeSize;
         this.cpu = builder.cpu;
         this.memory = builder.memory;
         this.instanceType = builder.instanceType;
-    }
-
-    public static ServiceTierConfig.Builder builder() {
-        return new ServiceTierConfig.Builder();
-    }
-
-    public static ServiceTierConfig.Builder builder(ServiceTierConfig other) {
-        return new Builder()
-            .min(other.getMin())
-            .max(other.getMax())
-            .computeSize(other.getComputeSize())
-            .cpu(other.getCpu())
-            .memory(other.getMemory())
-            .instanceType(other.getInstanceType());
+        this.ec2min = builder.ec2min;
+        this.ec2max = builder.ec2max;
     }
 
     public Integer getMin() {
@@ -87,9 +59,12 @@ public class ServiceTierConfig {
         return instanceType;
     }
 
-    @Override
-    public String toString() {
-        return Utils.toJson(this);
+    public Integer getEc2min() {
+        return ec2min;
+    }
+
+    public Integer getEc2max() {
+        return ec2max;
     }
 
     @Override
@@ -105,33 +80,33 @@ public class ServiceTierConfig {
         if (getClass() != obj.getClass()) {
             return false;
         }
-        final ServiceTierConfig other = (ServiceTierConfig) obj;
-        return (
-                ((min == null && other.min == null) || (min != null && min.equals(other.min)))
-                && ((max == null && other.max == null) || (max != null && max.equals(other.max)))
-                && ((computeSize == null && other.computeSize == null) || (computeSize == other.computeSize))
-                && ((cpu == null && other.cpu == null) || (cpu != null && cpu.equals(other.cpu)))
-                && ((memory == null && other.memory == null) || (memory != null && memory.equals(other.memory)))
-                && ((instanceType == null && other.instanceType == null)
-                    || (instanceType != null && instanceType.equals(other.instanceType))));
+        final AbstractComputeTier other = (AbstractComputeTier) obj;
+        return Utils.nullableEquals(min, other.min)
+            && Utils.nullableEquals(max, other.max)
+            && Utils.nullableEquals(computeSize, other.computeSize)
+            && Utils.nullableEquals(cpu, other.cpu)
+            && Utils.nullableEquals(memory, other.memory)
+            && Utils.nullableEquals(instanceType, other.instanceType)
+            && Utils.nullableEquals(ec2min, other.ec2min)
+            && Utils.nullableEquals(ec2max, other.ec2max);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(min, max, computeSize, cpu, memory, instanceType);
+        return Objects.hash(min, max, computeSize, cpu, memory, instanceType, ec2min, ec2max);
     }
 
     @JsonPOJOBuilder(withPrefix = "") // setters aren't named with[Property]
-    public static final class Builder {
+    public abstract static class Builder {
+        // TODO do validation on cpu/memory/computeSize
         private Integer min;
         private Integer max;
         private ComputeSize computeSize;
         private Integer cpu;
         private Integer memory;
         private String instanceType;
-
-        private Builder() {
-        }
+        private Integer ec2min;
+        private Integer ec2max;
 
         public Builder min(String min) {
             this.min = min != null && !min.isEmpty() ? Integer.valueOf(min) : null;
@@ -194,9 +169,16 @@ public class ServiceTierConfig {
             return this;
         }
 
-        public ServiceTierConfig build() {
-            // TODO do validation on cpu/memory/computeSize
-            return new ServiceTierConfig(this);
+        public Builder ec2min(Integer ec2min) {
+            this.ec2min = ec2min;
+            return this;
         }
+
+        public Builder ec2max(Integer ec2max) {
+            this.ec2max = ec2max;
+            return this;
+        }
+
+        public abstract AbstractComputeTier build();
     }
 }

--- a/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/compute/ComputeSize.java
+++ b/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/compute/ComputeSize.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.amazon.aws.partners.saasfactory.saasboost.appconfig;
+package com.amazon.aws.partners.saasfactory.saasboost.appconfig.compute;
 
 public enum ComputeSize {
 

--- a/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/compute/ecs/EcsCompute.java
+++ b/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/compute/ecs/EcsCompute.java
@@ -1,0 +1,115 @@
+package com.amazon.aws.partners.saasfactory.saasboost.appconfig.compute.ecs;
+
+import com.amazon.aws.partners.saasfactory.saasboost.Utils;
+import com.amazon.aws.partners.saasfactory.saasboost.appconfig.EcsLaunchType;
+import com.amazon.aws.partners.saasfactory.saasboost.appconfig.compute.AbstractCompute;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+@JsonDeserialize(builder = EcsCompute.Builder.class)
+public class EcsCompute extends AbstractCompute {
+
+    private final Map<String, EcsComputeTier> tiers;
+    private final EcsLaunchType ecsLaunchType;
+    private final Boolean ecsExecEnabled;
+
+    protected EcsCompute(Builder b) {
+        super(b);
+        this.tiers = b.tiers;
+        this.ecsLaunchType = b.ecsLaunchType;
+        this.ecsExecEnabled = b.ecsExecEnabled;
+    }
+
+    public Map<String, EcsComputeTier> getTiers() {
+        return tiers;
+    }
+
+    public EcsLaunchType getEcsLaunchType() {
+        return ecsLaunchType;
+    }
+
+    public Boolean getEcsExecEnabled() {
+        return ecsExecEnabled;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        // Same reference?
+        if (this == obj) {
+            return true;
+        }
+        // Same type?
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+
+        EcsCompute other = (EcsCompute) obj;
+        return (super.equals(other)
+                && Utils.nullableEquals(ecsLaunchType, other.ecsLaunchType))
+                && Utils.nullableEquals(ecsExecEnabled, other.getEcsExecEnabled());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), ecsLaunchType, ecsExecEnabled)
+                + Arrays.hashCode(tiers != null ? tiers.keySet().toArray(new String[0]) : null)
+                + Arrays.hashCode(tiers != null ? tiers.values().toArray(new Object[0]) : null);
+    }
+
+    public Builder builder() {
+        return ((Builder) super.fillBuilder(new Builder())).ecsLaunchType(ecsLaunchType);
+    }
+
+    @JsonPOJOBuilder(withPrefix = "") // setters aren't named with[Property]
+    public static final class Builder extends AbstractCompute.Builder {
+
+        private Map<String, EcsComputeTier> tiers = new HashMap<>();
+        private EcsLaunchType ecsLaunchType;
+        private Boolean ecsExecEnabled = false;
+
+        private Builder() {
+            
+        }
+
+        public Builder tiers(Map<String, EcsComputeTier> tiers) {
+            this.tiers = tiers;
+            return this;
+        }
+
+        public Builder ecsLaunchType(String ecsLaunchType) {
+            if (ecsLaunchType != null) {
+                try {
+                    this.ecsLaunchType = EcsLaunchType.valueOf(ecsLaunchType);
+                } catch (IllegalArgumentException e) {
+                    throw new RuntimeException(
+                        new IllegalArgumentException("Can't find EcsLaunchType for value " + ecsLaunchType)
+                    );
+                }
+            }
+            return this;
+        }
+
+        public Builder ecsLaunchType(EcsLaunchType ecsLaunchType) {
+            this.ecsLaunchType = ecsLaunchType;
+            return this;
+        }
+
+        public Builder ecsExecEnabled(Boolean ecsExecEnabled) {
+            this.ecsExecEnabled = ecsExecEnabled;
+            return this;
+        }
+
+        @Override
+        public EcsCompute build() {
+            return new EcsCompute(this);
+        }
+    }    
+}

--- a/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/compute/ecs/EcsComputeTier.java
+++ b/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/compute/ecs/EcsComputeTier.java
@@ -1,0 +1,50 @@
+package com.amazon.aws.partners.saasfactory.saasboost.appconfig.compute.ecs;
+
+import com.amazon.aws.partners.saasfactory.saasboost.appconfig.compute.AbstractComputeTier;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import java.util.Objects;
+
+@JsonDeserialize(builder = EcsComputeTier.Builder.class)
+public class EcsComputeTier extends AbstractComputeTier {
+
+    private EcsComputeTier(Builder b) {
+        super(b);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        // Same reference?
+        if (this == obj) {
+            return true;
+        }
+        // Same type?
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final EcsComputeTier other = (EcsComputeTier) obj;
+        return super.equals(other);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode());
+    }
+
+    @JsonPOJOBuilder(withPrefix = "") // setters aren't named with[Property]
+    public static final class Builder extends AbstractComputeTier.Builder {
+
+        private Builder() {
+            
+        }
+
+        @Override
+        public EcsComputeTier build() {
+            return new EcsComputeTier(this);
+        }
+    }
+}

--- a/services/settings-service/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/AppConfigTest.java
+++ b/services/settings-service/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/AppConfigTest.java
@@ -110,9 +110,8 @@ public class AppConfigTest {
     @Test
     public void testDeserialize() {
         try (InputStream is = getClass().getClassLoader().getResourceAsStream("appConfig.json")) {
-            AppConfig appConfig = Utils.fromJson(is, AppConfig.class);
-            // Utils.fromJson will return null if it encounters any errors in AppConfig
-            assertNotNull("appConfig.json should successfully deserialize", appConfig);
+            AppConfig appConfig = Utils.MAPPER.readValue(is, AppConfig.class);
+            //System.out.println(appConfig.toString());
         } catch (IOException ioe) {
             throw new RuntimeException(ioe);
         }

--- a/services/settings-service/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/compute/AbstractComputeTest.java
+++ b/services/settings-service/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/compute/AbstractComputeTest.java
@@ -1,0 +1,56 @@
+package com.amazon.aws.partners.saasfactory.saasboost.compute;
+
+import com.amazon.aws.partners.saasfactory.saasboost.Utils;
+import com.amazon.aws.partners.saasfactory.saasboost.appconfig.compute.AbstractCompute;
+import com.amazon.aws.partners.saasfactory.saasboost.appconfig.compute.AbstractComputeTier;
+import com.amazon.aws.partners.saasfactory.saasboost.appconfig.compute.ecs.EcsCompute;
+import com.amazon.aws.partners.saasfactory.saasboost.appconfig.compute.ecs.EcsComputeTier;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+public class AbstractComputeTest {
+    @Test
+    public void deserialize_ecsCompute_basic() {
+        String ecsJson = "{\"type\":\"ECS\", \"ecsExecEnabled\": true, \"tiers\":{"
+                + "\"Free\":{\"instanceType\":\"t3.medium\", \"cpu\":512, \"memory\":1024, \"min\":1, \"max\":2, \"ec2min\":0, \"ec2max\":5}," 
+                + "\"Gold\":{\"instanceType\":\"t3.large\", \"cpu\":1024, \"memory\":2048, \"min\":2, \"max\":4, \"ec2min\":5, \"ec2max\":9}}}";
+        AbstractCompute compute = Utils.fromJson(ecsJson, AbstractCompute.class);
+        assertEquals(EcsCompute.class, compute.getClass());
+        assertEquals(Boolean.TRUE, ((EcsCompute) compute).getEcsExecEnabled());
+        assertNotNull(compute.getTiers());
+        for (Map.Entry<String, ? extends AbstractComputeTier> tierEntry : compute.getTiers().entrySet()) {
+            String tierName = tierEntry.getKey();
+            assertEquals(EcsComputeTier.class, tierEntry.getValue().getClass());
+            EcsComputeTier tier = (EcsComputeTier) tierEntry.getValue();
+            switch (tierName) {
+                case "Free": {
+                    assertEquals("t3.medium", tier.getInstanceType());
+                    assertEquals(Integer.valueOf(512), tier.getCpu());
+                    assertEquals(Integer.valueOf(1024), tier.getMemory());
+                    assertEquals(Integer.valueOf(1), tier.getMin());
+                    assertEquals(Integer.valueOf(2), tier.getMax());
+                    assertEquals(Integer.valueOf(0), tier.getEc2min());
+                    assertEquals(Integer.valueOf(5), tier.getEc2max());
+                    break;
+                }
+                case "Gold": {
+                    assertEquals("t3.large", tier.getInstanceType());
+                    assertEquals(Integer.valueOf(1024), tier.getCpu());
+                    assertEquals(Integer.valueOf(2048), tier.getMemory());
+                    assertEquals(Integer.valueOf(2), tier.getMin());
+                    assertEquals(Integer.valueOf(4), tier.getMax());
+                    assertEquals(Integer.valueOf(5), tier.getEc2min());
+                    assertEquals(Integer.valueOf(9), tier.getEc2max());
+                    break;
+                }
+                default: fail("Deserialize ecs compute JSON found an unexpected tier. "
+                        + "Wanted [Free|Gold] but found " + tierName);
+            }
+        }
+    }
+}

--- a/services/settings-service/src/test/resources/appConfig.json
+++ b/services/settings-service/src/test/resources/appConfig.json
@@ -9,11 +9,6 @@
       "description": "Main Service",
       "public": true,
       "path": "/*",
-      "healthCheckUrl": "/health",
-      "operatingSystem": "LINUX",
-      "containerPort": 7000,
-      "containerRepo": "",
-      "containerTag": "latest",
       "database": {
         "engine": "MYSQL",
         "version": "1.2.3",
@@ -32,13 +27,22 @@
           }
         }
       },
-      "tiers": {
-        "default": {
-          "instanceType": "t3.medium",
-          "cpu": 512,
-          "memory": 1024,
-          "min": 1,
-          "max": 2
+      "compute": {
+        "type": "ECS",
+        "ecsExecEnabled": true,
+        "healthCheckUrl": "/health",
+        "operatingSystem": "LINUX",
+        "containerPort": 7000,
+        "containerRepo": "",
+        "containerTag": "latest",
+        "tiers": {
+          "default": {
+            "computeSize": "S",
+            "min": 1,
+            "max": 2,
+            "ec2min": 1,
+            "ec2max": 2
+          }
         }
       },
       "filesystem": {
@@ -62,11 +66,6 @@
       "description": "Feature service public path routing",
       "public": true,
       "path": "/feature*",
-      "healthCheckUrl": "/health",
-      "operatingSystem": "LINUX",
-      "containerPort": 7000,
-      "containerRepo": "",
-      "containerTag": "latest",
       "database": {
         "engine": "MYSQL",
         "version": "1.2.3",
@@ -85,13 +84,19 @@
           }
         }
       },
-      "tiers": {
-        "default": {
-          "instanceType": "t3.medium",
-          "cpu": 512,
-          "memory": 1024,
-          "min": 1,
-          "max": 2
+      "compute": {
+        "type": "ECS",
+        "healthCheckUrl": "/health",
+        "operatingSystem": "LINUX",
+        "containerPort": 7000,
+        "containerRepo": "",
+        "containerTag": "latest",
+        "tiers": {
+          "default": {
+            "computeSize": "S",
+            "min": 1,
+            "max": 2
+          }
         }
       },
       "filesystem": {
@@ -124,11 +129,6 @@
       "description": "Internal private service",
       "public": false,
       "path": "",
-      "healthCheckUrl": "/health",
-      "operatingSystem": "LINUX",
-      "containerPort": 7000,
-      "containerRepo": "",
-      "containerTag": "latest",
       "database": {
         "engine": "MYSQL",
         "version": "1.2.3",
@@ -147,13 +147,19 @@
           }
         }
       },
-      "tiers": {
-        "default": {
-          "instanceType": "t3.medium",
-          "cpu": 512,
-          "memory": 1024,
-          "min": 1,
-          "max": 2
+      "compute": {
+        "type": "ECS",
+        "healthCheckUrl": "/health",
+        "operatingSystem": "LINUX",
+        "containerPort": 7000,
+        "containerRepo": "",
+        "containerTag": "latest",
+        "tiers": {
+          "default": {
+            "computeSize": "S",
+            "min": 1,
+            "max": 2
+          }
         }
       },
       "filesystem": {


### PR DESCRIPTION
This commit contains multiple changes:
1. refactors the ServiceConfig object to contain a top-level "compute" structure, defined with type, that contains all definitions related to a specific type of compute. Right now this includes container information, since future types of compute (e.g. Lambda) may not necessarily be defined by containers. Note that this does not contain path or public/private, since those describe the application running on the compute, not the compute itself. This commit also includes changes to the UI, Onboarding Service, auxiliary functionality (i.e. workload-deploy and core-stack-listener functions), and the sample application build scripts to handle this change with respect specifically to the container repository information.
2. Supports configuring the minimum and maximum EC2 AutoScaling Group size when the EC2 launch type is configured. This will either be when the operating system is Linux and that launch type is selected, or if the operating system is Windows. This commit also includes changes in the Settings and Onboarding services, as well as tenant-onboarding stacks and the UI to support easy configuration of this new setting.
3. This commit also includes a small bugfix in the UI: when creating a new service on the AppConfig page some changed logic to support FileSystem Tier configurations was leading to a failure.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
