### PR TITLE
Enable adding new service to app config with provisioned tenants

### DIFF
--- a/functions/core-stack-listener/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/CoreStackListener.java
+++ b/functions/core-stack-listener/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/CoreStackListener.java
@@ -125,18 +125,13 @@ public class CoreStackListener implements RequestHandler<SNSEvent, Object> {
                                     "type", "ECS", 
                                     "containerRepo", ecrRepo)));
                         }
+                        // The object storage extension creates a single S3 bucket for the entire application
+                        // with a separate "folder" for each service.
                         if ("AWS::S3::Bucket".equals(resource.resourceType())
                                 && "TenantStorage".equals(resource.logicalResourceId())) {
-                            // S3 extension
                             tenantStorageBucketName = resource.physicalResourceId();
                             LOGGER.info("Updating appConfig for TenantStorageBucket {}",
                                     tenantStorageBucketName);
-                        }
-                        if ("AWS::Route53::HostedZone".equals(resource.resourceType())) {
-                            // When CloudFormation stack first completes, the Settings Service won't even exist yet.
-                            String hostedZoneId = resource.physicalResourceId();
-                            LOGGER.info("Publishing appConfig update event for Route53 hosted zone {}", hostedZoneId);
-                            appConfig.put("hostedZone", hostedZoneId);
                         }
                     }
                 }

--- a/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostInstall.java
+++ b/installer/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SaaSBoostInstall.java
@@ -279,7 +279,8 @@ public class SaaSBoostInstall {
                 LOGGER.info("Setting SaaS Boost environment = [{}]", this.envName);
                 break;
             } else {
-                outputMessage("Entered value is incorrect, maximum of 10 alphanumeric characters, please try again.");
+                outputMessage("Entered value is invalid, maximum of 10 alphanumeric characters, and cannot be AWS,"
+                        + " Amazon, or Cognito. Please try again.");
             }
         }
 
@@ -1460,7 +1461,8 @@ public class SaaSBoostInstall {
             System.out.print("Please enter the existing SaaS Boost environment label: ");
             environment = Keyboard.readString();
             if (!validateEnvironmentName(environment)) {
-                outputMessage("Entered value is incorrect, maximum of 10 alphanumeric characters, please try again.");
+                outputMessage("Entered value is invalid, maximum of 10 alphanumeric characters, and cannot be AWS,"
+                        + " Amazon, or Cognito. Please try again.");
                 environment = null;
             }
         }
@@ -1487,6 +1489,11 @@ public class SaaSBoostInstall {
         if (envName != null) {
             // Follows CloudFormation stack name rules but limits to 10 characters
             valid = envName.matches("^[a-zA-Z](?:[a-zA-Z0-9-]){0,9}$");
+            if (valid) {
+                valid = (!envName.equalsIgnoreCase("aws")
+                        && !envName.equalsIgnoreCase("amazon")
+                        && !envName.equalsIgnoreCase("cognito"));
+            }
         }
         return valid;
     }

--- a/layers/cloudformation-utils/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/AwsResource.java
+++ b/layers/cloudformation-utils/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/AwsResource.java
@@ -54,7 +54,14 @@ public enum AwsResource {
             "AWS::EC2::SecurityGroup", true),
     PRIVATE_SERVICE_DISCOVERY_NAMESPACE("https://%s.console.aws.amazon.com/cloudmap/home/namespaces/%s",
             "arn:%s:servicediscovery:%s:%s:namespace/%s",
-            "AWS::ServiceDiscovery::PrivateDnsNamespace", false);
+            "AWS::ServiceDiscovery::PrivateDnsNamespace", false),
+    SECRET("https://%s.console.aws.amazon.com/secretsmanager/secret?region=%s&name=%s",
+            "arn:%s:secretsmanager:%s:%s:secret:%s",
+            "AWS::SecretsManager::Secret", true),
+    MANAGED_AD("https://%s.console.aws.amazon.com/directoryservicev2/home?region=%s#!/directories/%s",
+            "arn:%s:ds:%s:%s:directory/%s",
+            "AWS::DirectoryService::MicrosoftAD", true);
+
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AwsResource.class);
 

--- a/resources/saas-boost-svc-onboarding.yaml
+++ b/resources/saas-boost-svc-onboarding.yaml
@@ -555,6 +555,7 @@ Resources:
             Action:
               - elasticloadbalancing:CreateRule
               - elasticloadbalancing:ModifyRule
+              - elasticloadbalancing:SetRulePriorities
               - elasticloadbalancing:DeleteRule
               - elasticloadbalancing:DeleteListener
             Resource:

--- a/resources/saas-boost-svc-onboarding.yaml
+++ b/resources/saas-boost-svc-onboarding.yaml
@@ -1184,6 +1184,7 @@ Resources:
               "prefix": "Onboarding "
             },
             "Application Configuration Changed",
+            "Application Configuration Update Completed",
             "Tenant Deleted",
             "Tenant Enabled",
             "Tenant Disabled"

--- a/resources/saas-boost-svc-onboarding.yaml
+++ b/resources/saas-boost-svc-onboarding.yaml
@@ -371,6 +371,7 @@ Resources:
           - Effect: Allow
             Action: 
               - ds:CreateMicrosoftAD
+              - ds:DescribeDirectories
               - secretsmanager:GetRandomPassword
             Resource: 
               - '*'

--- a/resources/saas-boost-svc-settings.yaml
+++ b/resources/saas-boost-svc-settings.yaml
@@ -234,8 +234,6 @@ Resources:
         Variables:
           SAAS_BOOST_ENV: !Ref Environment
           JAVA_TOOL_OPTIONS: '-XX:+TieredCompilation -XX:TieredStopAtLevel=1'
-      SnapStart:
-        ApplyOn: PublishedVersions
       Tags:
         - Key: "Application"
           Value: "SaaSBoost"
@@ -392,8 +390,6 @@ Resources:
         Variables:
           SAAS_BOOST_ENV: !Ref Environment
           JAVA_TOOL_OPTIONS: '-XX:+TieredCompilation -XX:TieredStopAtLevel=1'
-      SnapStart:
-        ApplyOn: PublishedVersions
       Tags:
         - Key: "Application"
           Value: "SaaSBoost"
@@ -450,10 +446,14 @@ Resources:
         S3Key: !Sub ${LambdaSourceFolder}/SettingsService-lambda.zip
       Layers:
         - !Ref SaaSBoostUtilsLayer
+        - !Ref ApiGatewayHelperLayer
       Environment:
         Variables:
           SAAS_BOOST_ENV: !Ref Environment
           SAAS_BOOST_EVENT_BUS: !Ref SaaSBoostEventBus
+          API_TRUST_ROLE: !Sub '{{resolve:ssm:/saas-boost/${Environment}/PRIVATE_API_TRUST_ROLE}}'
+          API_GATEWAY_HOST: !Sub ${SaaSBoostPrivateApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}
+          API_GATEWAY_STAGE: !Ref PrivateApiStage
           JAVA_TOOL_OPTIONS: '-XX:+TieredCompilation -XX:TieredStopAtLevel=1'
       Tags:
         - Key: "Application"

--- a/resources/saas-boost-svc-settings.yaml
+++ b/resources/saas-boost-svc-settings.yaml
@@ -234,6 +234,8 @@ Resources:
         Variables:
           SAAS_BOOST_ENV: !Ref Environment
           JAVA_TOOL_OPTIONS: '-XX:+TieredCompilation -XX:TieredStopAtLevel=1'
+      SnapStart:
+        ApplyOn: PublishedVersions
       Tags:
         - Key: "Application"
           Value: "SaaSBoost"
@@ -390,6 +392,8 @@ Resources:
         Variables:
           SAAS_BOOST_ENV: !Ref Environment
           JAVA_TOOL_OPTIONS: '-XX:+TieredCompilation -XX:TieredStopAtLevel=1'
+      SnapStart:
+        ApplyOn: PublishedVersions
       Tags:
         - Key: "Application"
           Value: "SaaSBoost"

--- a/resources/tenant-onboarding-ad.yaml
+++ b/resources/tenant-onboarding-ad.yaml
@@ -37,55 +37,42 @@ Parameters:
     Description: The GUID for the tenant
     Type: String
 Resources:
-  ADPassword:
+  ADCredentials:
     Type: AWS::SecretsManager::Secret
     Properties:
-      Name: !Sub /saas-boost/${Environment}/${TenantId}/ACTIVE_DIRECTORY_PASSWORD
+      Name: !Sub /saas-boost/${Environment}/${TenantId}/ACTIVE_DIRECTORY_ADMIN
       GenerateSecretString:
-        PasswordLength: 64
+        IncludeSpace: false
         ExcludePunctuation: true
+        PasswordLength: 12
+        GenerateStringKey: password
+        SecretStringTemplate: !Sub '{"username": "admin"}'
   ADDirectory:
     Type: AWS::DirectoryService::MicrosoftAD
     Properties:
-      Name: !Sub ${Environment}.${AWS::Region}.saasboost.com
+      Name: 
+        !Join
+          - ''
+          - - 'tenant-'
+            - !Select [0, !Split ['-', !Ref TenantId]]
+            - '.'
+            - !Ref AWS::Region
+            - '.sb-'
+            - !Ref Environment
       Edition: !Ref Edition
-      Password: !Sub '{{resolve:secretsmanager:${ADPassword}::::}}'
+      Password: !Sub '{{resolve:secretsmanager:${ADCredentials}:SecretString:password}}'
       ShortName: 
         !Join
           - ''
-          - - 'Tenant-'
+          - - 'tenant-'
             - !Select [0, !Split ['-', !Ref TenantId]]
       VpcSettings:
         SubnetIds: !Ref Subnets
         VpcId: !Ref VpcId
-  SSMParamMADIps:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub /saas-boost/${Environment}/${TenantId}/ACTIVE_DIRECTORY_DNS_IPS
-      Type: String
-      Value:
-       !Join [",", !GetAtt ADDirectory.DnsIpAddresses]
-  SSMParamDirectoryName:
-    Type: AWS::SSM::Parameter
-    DependsOn: ADDirectory
-    Properties:
-      Name: !Sub /saas-boost/${Environment}/${TenantId}/ACTIVE_DIRECTORY_DNS_NAME
-      Type: String
-      Value: !Sub ${Environment}.${AWS::Region}.saasboost.com
-  SSMParamUserName:
-    Type: AWS::SSM::Parameter
-    DependsOn: ADDirectory
-    Properties:
-      Name: !Sub /saas-boost/${Environment}/${TenantId}/ACTIVE_DIRECTORY_USER
-      Type: String
-      Value: admin
-  SSMParamDirectoryId:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub /saas-boost/${Environment}/${TenantId}/ACTIVE_DIRECTORY_ID
-      Type: String
-      Value: !Ref ADDirectory
 Outputs:
-  ADPasswordSecret:
-    Description: SecretsManager reference to AD Password
-    Value: !Ref ADPassword
+  ActiveDirectoryCredentials:
+    Description: SecretsManager reference to Active Directory username and password
+    Value: !Ref ADCredentials
+  ActiveDirectoryId:
+    Description: AWS Managed Active Directory ID
+    Value: !Ref ADDirectory

--- a/resources/tenant-onboarding-app.yaml
+++ b/resources/tenant-onboarding-app.yaml
@@ -209,6 +209,10 @@ Parameters:
     Description: Active Directory controller hostname to use when joining Windows cluster hosts to domain for FSx
     Type: String
     Default: ''
+  ActiveDirectoryCredentials:
+    Description: Secrets Manager ARN for active directory username and password
+    Type: String
+    Default: ''
   FSxFileSystemType:
     Description: Type of FSx file system to provision
     Type: String
@@ -789,17 +793,9 @@ Resources:
                 Resource: '*'
               - Effect: Allow
                 Action:
-                  - ssm:GetParameter
-                  - ssm:GetParameters
-                Resource:
-                  - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/saas-boost/${Environment}/${TenantId}/ACTIVE_DIRECTORY_USER
-                  - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/saas-boost/${Environment}/${TenantId}/ACTIVE_DIRECTORY_DNS_IPS
-                  - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/saas-boost/${Environment}/${TenantId}/ACTIVE_DIRECTORY_DNS_NAME
-              - Effect: Allow
-                Action:
                   - secretsmanager:GetSecretValue
                 Resource:
-                  - !Sub arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/saas-boost/${Environment}/${TenantId}/ACTIVE_DIRECTORY_PASSWORD*
+                  - !Sub arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/saas-boost/${Environment}/${TenantId}/ACTIVE_DIRECTORY_ADMIN*
               - Effect: Allow
                 Action:
                   - kms:Decrypt
@@ -901,11 +897,12 @@ Resources:
                 [Environment]::SetEnvironmentVariable("ECS_ENABLE_AWSLOGS_EXECUTIONROLE_OVERRIDE", $TRUE, "Machine")
                 Restart-Service AmazonECS
 
-                Write-Output ("Getting SSM Parameters for the Active Directory domain")
-                $directoryName = (Get-SSMParameterValue -Name /saas-boost/${Environment}/${TenantId}/ACTIVE_DIRECTORY_DNS_NAME).Parameters[0].Value
-                $username = (Get-SSMParameterValue -Name /saas-boost/${Environment}/${TenantId}/ACTIVE_DIRECTORY_USER).Parameters[0].Value
-                $password = (Get-SECSecretValue -SecretId /saas-boost/${Environment}/${TenantId}/ACTIVE_DIRECTORY_PASSWORD -Select 'SecretString') | ConvertTo-SecureString -asPlainText -Force
-                $ipdns = (Get-SSMParameterValue -Name /saas-boost/${Environment}/${TenantId}/ACTIVE_DIRECTORY_DNS_IPS).Parameters[0].Value
+                Write-Output ("Getting Active Directory credentials from Secrets Manager")
+                $adCredentials = (Get-SECSecretValue -SecretId /saas-boost/${Environment}/${TenantId}/ACTIVE_DIRECTORY_ADMIN -Select 'SecretString') | ConvertFrom-Json
+                $username = $adCredentials.username
+                $password = $adCredentials.password | ConvertTo-SecureString -asPlainText -Force
+                $directoryName = "${ActiveDirectoryDnsName}"
+                $ipdns = "${ActiveDirectoryDnsIps}"
                 $ips = $ipdns.Split(",")
 
                 Write-Output ("Reading the existing VPC DNS Server IP")
@@ -1267,6 +1264,7 @@ Resources:
         ActiveDirectoryId: !Ref ActiveDirectoryId
         ActiveDirectoryDnsIps: !Ref ActiveDirectoryDnsIps
         ActiveDirectoryDnsName: !Ref ActiveDirectoryDnsName
+        ActiveDirectoryCredentials: !Ref ActiveDirectoryCredentials
         PrivateSubnetA: !Ref SubnetPrivateA
         PrivateSubnetB: !Ref SubnetPrivateB
         PrivateRouteTable: !Ref PrivateRouteTable

--- a/resources/tenant-onboarding-fsx.yaml
+++ b/resources/tenant-onboarding-fsx.yaml
@@ -46,6 +46,10 @@ Parameters:
   ECSSecurityGroup:
     Description: Source security group of ECS instances
     Type: AWS::EC2::SecurityGroup::Id
+  ActiveDirectoryCredentials:
+    Description: Secrets Manager ARN for active directory username and password
+    Type: String
+    Default: ''
   ActiveDirectoryId:
     Description: Id of the AWS Managed Microsoft AD. If you are using self-managed Active Directory, leave this blank.
     Type: String
@@ -472,16 +476,27 @@ Resources:
             Fn::Join: ['', ['tenant-', !Select [0, !Split ['-', !Ref TenantId]]]]
           # TODO how do we support non SaaS Boost provisioned AD instances?
           SelfManagedActiveDirectoryConfiguration:
-            OrganizationalUnitDistinguishedName: !Sub OU=Computers,OU=sb-${Environment},DC=${Environment},DC=${AWS::Region},DC=saasboost,DC=com
+            OrganizationalUnitDistinguishedName:
+              !Join
+                - ''
+                - - 'OU=Computers,OU=tenant-'
+                  - !Select [0, !Split ['-', !Ref TenantId]]
+                  - ',DC='
+                  - !Select [0, !Split ['.', !Ref ActiveDirectoryDnsName]]
+                  - ',DC='
+                  - !Select [1, !Split ['.', !Ref ActiveDirectoryDnsName]]
+                  - ',DC='
+                  - !Select [2, !Split ['.', !Ref ActiveDirectoryDnsName]]
             FileSystemAdministratorsGroup: AWS Delegated FSx Administrators
+            # Domain name is limited to 47 characters by FSx
             DomainName: !Ref ActiveDirectoryDnsName
             # Must pass the comma delimited string in as a parameter, because {{resolve:ssm:}} can't
             # be nested inside a Fn::Split. The split happens before the resolution of the parameter.
             DnsIps: !Split [',', !Ref ActiveDirectoryDnsIps]
             # Don't use Domain\Username here - only Username
-            UserName: !Sub '{{resolve:ssm:/saas-boost/${Environment}/${TenantId}/ACTIVE_DIRECTORY_USER}}'
+            UserName: !Sub '{{resolve:secretsmanager:${ActiveDirectoryCredentials}:SecretStrings:username}}'
             # Can't use ssm-secure here
-            Password: !Sub '{{resolve:secretsmanager:/saas-boost/${Environment}/${TenantId}/ACTIVE_DIRECTORY_PASSWORD::::}}'
+            Password: !Sub '{{resolve:secretsmanager:${ActiveDirectoryCredentials}:SecretString:password}}'
         - !Ref 'AWS::NoValue'
       Tags:
         - Key: Name

--- a/resources/tenant-onboarding.yaml
+++ b/resources/tenant-onboarding.yaml
@@ -400,7 +400,4 @@ Outputs:
   DNSName:
     Description: DNSName for this tenant's application load balancer
     Value: !GetAtt ApplicationLoadBalancer.DNSName
-  ADPasswordSecret:
-    Description: SecretsManager reference to AD Password
-    Value: !If [ProvisionManagedAD, !GetAtt ad.Outputs.ADPasswordSecret, ""]
 ...

--- a/services/onboarding-service/pom.xml
+++ b/services/onboarding-service/pom.xml
@@ -33,7 +33,7 @@ limitations under the License.
     </licenses>
 
     <properties>
-        <checkstyle.maxAllowedViolations>145</checkstyle.maxAllowedViolations>
+        <checkstyle.maxAllowedViolations>25</checkstyle.maxAllowedViolations>
     </properties>
 
     <build>
@@ -166,21 +166,6 @@ limitations under the License.
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sqs</artifactId>
-            <version>${aws.java.sdk.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>software.amazon.awssdk</groupId>
-                    <artifactId>netty-nio-client</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>software.amazon.awssdk</groupId>
-                    <artifactId>apache-client</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>elasticloadbalancingv2</artifactId>
             <version>${aws.java.sdk.version}</version>
             <exclusions>
                 <exclusion>

--- a/services/onboarding-service/pom.xml
+++ b/services/onboarding-service/pom.xml
@@ -208,5 +208,20 @@ limitations under the License.
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>directory</artifactId>
+            <version>${aws.java.sdk.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>apache-client</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 </project>

--- a/services/onboarding-service/pom.xml
+++ b/services/onboarding-service/pom.xml
@@ -33,7 +33,7 @@ limitations under the License.
     </licenses>
 
     <properties>
-        <checkstyle.maxAllowedViolations>25</checkstyle.maxAllowedViolations>
+        <checkstyle.maxAllowedViolations>24</checkstyle.maxAllowedViolations>
     </properties>
 
     <build>
@@ -54,6 +54,21 @@ limitations under the License.
             <plugin>
                 <groupId>io.github.git-commit-id</groupId>
                 <artifactId>git-commit-id-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <configuration>
+                    <effort>Max</effort>
+                    <threshold>medium</threshold>
+                    <plugins>
+                        <plugin>
+                            <groupId>software.amazon.lambda.snapstart</groupId>
+                            <artifactId>aws-lambda-snapstart-java-rules</artifactId>
+                            <version>0.1.0</version>
+                        </plugin>
+                    </plugins>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/AbstractStackParameters.java
+++ b/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/AbstractStackParameters.java
@@ -13,6 +13,14 @@ public class AbstractStackParameters extends Properties {
         super(defaults);
     }
 
+    @Override
+    public synchronized Object setProperty(String key, String value) {
+        if (value == null) {
+            value = getProperty(key);
+        }
+        return super.setProperty(key, value);
+    }
+
     public final List<Parameter> forCreate() {
         List<Parameter> parameters = new ArrayList<>();
         for (String parameter : stringPropertyNames()) {
@@ -46,7 +54,7 @@ public class AbstractStackParameters extends Properties {
         return parameters;
     }
 
-    private final void validate() {
+    protected void validate() {
         // CloudFormation SDK stack operations fail if any parameters are null
         List<String> invalidParameters = new ArrayList<>();
         for (String parameter : stringPropertyNames()) {

--- a/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/AbstractStackParameters.java
+++ b/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/AbstractStackParameters.java
@@ -4,7 +4,7 @@ import software.amazon.awssdk.services.cloudformation.model.Parameter;
 
 import java.util.*;
 
-public class AbstractStackParameters extends Properties {
+public abstract class AbstractStackParameters extends Properties {
 
     private AbstractStackParameters() {
     }
@@ -31,7 +31,7 @@ public class AbstractStackParameters extends Properties {
                             .build()
             );
         }
-        validate();
+        validateForCreate();
         return parameters;
     }
 
@@ -50,11 +50,13 @@ public class AbstractStackParameters extends Properties {
             }
             parameters.add(builder.build());
         }
-        validate();
+        validateForUpdate();
         return parameters;
     }
 
-    protected void validate() {
+    protected abstract void validateForCreate();
+
+    protected void validateForUpdate() {
         // CloudFormation SDK stack operations fail if any parameters are null
         List<String> invalidParameters = new ArrayList<>();
         for (String parameter : stringPropertyNames()) {

--- a/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/AbstractStackParameters.java
+++ b/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/AbstractStackParameters.java
@@ -1,0 +1,61 @@
+package com.amazon.aws.partners.saasfactory.saasboost;
+
+import software.amazon.awssdk.services.cloudformation.model.Parameter;
+
+import java.util.*;
+
+public class AbstractStackParameters extends Properties {
+
+    private AbstractStackParameters() {
+    }
+
+    public AbstractStackParameters(Properties defaults) {
+        super(defaults);
+    }
+
+    public final List<Parameter> forCreate() {
+        List<Parameter> parameters = new ArrayList<>();
+        for (String parameter : stringPropertyNames()) {
+            parameters.add(
+                    Parameter.builder()
+                            .parameterKey(parameter)
+                            .parameterValue(getProperty(parameter))
+                            .build()
+            );
+        }
+        validate();
+        return parameters;
+    }
+
+    public final List<Parameter> forUpdate(Map<String, String> updateParameters) {
+        for (Map.Entry<String, String> updateParam : updateParameters.entrySet()) {
+            setProperty(updateParam.getKey(), updateParam.getValue());
+        }
+        List<Parameter> parameters = new ArrayList<>();
+        for (String parameter : stringPropertyNames()) {
+            Parameter.Builder builder = Parameter.builder();
+            builder.parameterKey(parameter);
+            if (updateParameters.containsKey(parameter)) {
+                builder.parameterValue(getProperty(parameter));
+            } else {
+                builder.usePreviousValue(true);
+            }
+            parameters.add(builder.build());
+        }
+        validate();
+        return parameters;
+    }
+
+    private final void validate() {
+        // CloudFormation SDK stack operations fail if any parameters are null
+        List<String> invalidParameters = new ArrayList<>();
+        for (String parameter : stringPropertyNames()) {
+            if (null == getProperty(parameter)) {
+                invalidParameters.add(parameter);
+            }
+        }
+        if (!invalidParameters.isEmpty()) {
+            throw new RuntimeException("NULL CloudFormation parameters " + String.join(",", invalidParameters));
+        }
+    }
+}

--- a/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/CoreStackParameters.java
+++ b/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/CoreStackParameters.java
@@ -27,8 +27,6 @@ public class CoreStackParameters extends AbstractStackParameters {
         DEFAULTS.put("PublicApiStage", "v1");
         DEFAULTS.put("PrivateApiStage", "v1");
         DEFAULTS.put("Version", "");
-        DEFAULTS.put("DeployActiveDirectory", "false");
-        DEFAULTS.put("ADPasswordParam", "");
         DEFAULTS.put("ApplicationServices", "");
         DEFAULTS.put("AppExtensions", "");
         DEFAULTS.put("CreateMacroResources", "false");

--- a/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/CoreStackParameters.java
+++ b/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/CoreStackParameters.java
@@ -1,10 +1,15 @@
 package com.amazon.aws.partners.saasfactory.saasboost;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 
 public class CoreStackParameters extends AbstractStackParameters {
 
     static Properties DEFAULTS = new Properties();
+    static final List<String> REQUIRED_FOR_CREATE = List.of("SaaSBoostBucket", "Environment", "LambdaSourceFolder",
+            "Tier", "SystemIdentityProvider", "AdminUsername", "AdminEmailAddress", "PublicApiStage", "PrivateApiStage",
+            "Version", "CreateMacroResources");
 
     static {
         DEFAULTS.put("SaaSBoostBucket", "");
@@ -31,5 +36,19 @@ public class CoreStackParameters extends AbstractStackParameters {
 
     public CoreStackParameters() {
         super(DEFAULTS);
+    }
+
+    @Override
+    protected void validateForCreate() {
+        List<String> invalidParameters = new ArrayList<>();
+        for (String requiredParameter : REQUIRED_FOR_CREATE) {
+            if (Utils.isBlank(getProperty(requiredParameter))) {
+                invalidParameters.add(requiredParameter);
+            }
+        }
+        if (!invalidParameters.isEmpty()) {
+            throw new RuntimeException("Missing values for required parameters "
+                    + String.join(",", invalidParameters));
+        }
     }
 }

--- a/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/CoreStackParameters.java
+++ b/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/CoreStackParameters.java
@@ -1,0 +1,35 @@
+package com.amazon.aws.partners.saasfactory.saasboost;
+
+import java.util.Properties;
+
+public class CoreStackParameters extends AbstractStackParameters {
+
+    static Properties DEFAULTS = new Properties();
+
+    static {
+        DEFAULTS.put("SaaSBoostBucket", "");
+        DEFAULTS.put("LambdaSourceFolder", "lambdas");
+        DEFAULTS.put("Environment", "");
+        DEFAULTS.put("SystemIdentityProvider", "COGNITO");
+        DEFAULTS.put("SystemIdentityProviderDomain", "");
+        DEFAULTS.put("SystemIdentityProviderHostedZone", "");
+        DEFAULTS.put("SystemIdentityProviderCertificate", "");
+        DEFAULTS.put("AdminWebAppDomain", "");
+        DEFAULTS.put("AdminWebAppHostedZone", "");
+        DEFAULTS.put("AdminWebAppCertificate", "");
+        DEFAULTS.put("AdminUsername", "admin");
+        DEFAULTS.put("AdminEmailAddress", "");
+        DEFAULTS.put("PublicApiStage", "v1");
+        DEFAULTS.put("PrivateApiStage", "v1");
+        DEFAULTS.put("Version", "");
+        DEFAULTS.put("DeployActiveDirectory", "false");
+        DEFAULTS.put("ADPasswordParam", "");
+        DEFAULTS.put("ApplicationServices", "");
+        DEFAULTS.put("AppExtensions", "");
+        DEFAULTS.put("CreateMacroResources", "false");
+    }
+
+    public CoreStackParameters() {
+        super(DEFAULTS);
+    }
+}

--- a/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/Onboarding.java
+++ b/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/Onboarding.java
@@ -107,6 +107,17 @@ public class Onboarding {
         }
     }
 
+    public OnboardingStack baseStack() {
+        OnboardingStack baseStack = null;
+        for (OnboardingStack stack : getStacks()) {
+            if (stack.isBaseStack()) {
+                baseStack = stack;
+                break;
+            }
+        }
+        return baseStack;
+    }
+
     public boolean isEcsClusterLocked() {
         return ecsClusterLocked;
     }

--- a/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingAppStackParameters.java
+++ b/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingAppStackParameters.java
@@ -6,7 +6,9 @@ import java.util.Properties;
 
 public class OnboardingAppStackParameters extends AbstractStackParameters {
 
-    static Properties DEFAULTS = new Properties();
+    static final Properties DEFAULTS = new Properties();
+    static final List<String> REQUIRED_FOR_CREATE = List.of("Environment", "TenantId", "Tier", "VPC", "SubnetPrivateA",
+            "SubnetPrivateB", "ECSCluster", "ECSSecurityGroup");
 
     static {
         DEFAULTS.put("Environment", "");
@@ -84,20 +86,23 @@ public class OnboardingAppStackParameters extends AbstractStackParameters {
     }
 
     @Override
-    protected void validate() {
-        super.validate();
+    protected void validateForCreate() {
         List<String> invalidParameters = new ArrayList<>();
-        List<String> required = List.of("Environment", "TenantId", "Tier", "VPC", "SubnetPrivateA", "SubnetPrivateB",
-                "ECSCluster", "ECSSecurityGroup");
-        for (String requiredParameter : required) {
-            if (Utils.isBlank(getProperty(requiredParameter))) {
-                invalidParameters.add(requiredParameter);
-            }
-        }
         if (Utils.isBlank(getProperty("ECSLoadBalancerHttpListener"))
                 && Utils.isBlank(getProperty("ECSLoadBalancerHttpsListener"))) {
             invalidParameters.add("ECSLoadBalancerHttpListener");
             invalidParameters.add("ECSLoadBalancerHttpsListener");
+        }
+        for (String requiredParameter : REQUIRED_FOR_CREATE) {
+            if ("ECSLoadBalancerHttpListener".equals(requiredParameter)) {
+                continue;
+            }
+            if ("ECSLoadBalancerHttpsListener".equals(requiredParameter)) {
+                continue;
+            }
+            if (Utils.isBlank(getProperty(requiredParameter))) {
+                invalidParameters.add(requiredParameter);
+            }
         }
         if (!invalidParameters.isEmpty()) {
             throw new RuntimeException("Missing values for required parameters "

--- a/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingAppStackParameters.java
+++ b/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingAppStackParameters.java
@@ -8,7 +8,7 @@ public class OnboardingAppStackParameters extends AbstractStackParameters {
 
     static final Properties DEFAULTS = new Properties();
     static final List<String> REQUIRED_FOR_CREATE = List.of("Environment", "TenantId", "Tier", "VPC", "SubnetPrivateA",
-            "SubnetPrivateB", "ECSCluster", "ECSSecurityGroup");
+            "SubnetPrivateB", "ECSCluster", "ECSSecurityGroup", "ContainerRepository", "ContainerRepositoryTag");
 
     static {
         DEFAULTS.put("Environment", "");

--- a/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingAppStackParameters.java
+++ b/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingAppStackParameters.java
@@ -1,5 +1,7 @@
 package com.amazon.aws.partners.saasfactory.saasboost;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 
 public class OnboardingAppStackParameters extends AbstractStackParameters {
@@ -30,13 +32,13 @@ public class OnboardingAppStackParameters extends AbstractStackParameters {
         DEFAULTS.put("ContainerOS", "");
         DEFAULTS.put("ClusterInstanceType", "");
         DEFAULTS.put("TaskLaunchType", "");
-        DEFAULTS.put("TaskMemory", "");
-        DEFAULTS.put("TaskCPU", "");
-        DEFAULTS.put("MinTaskCount", "");
-        DEFAULTS.put("MaxTaskCount", "");
-        DEFAULTS.put("MinAutoScalingGroupSize", "");
-        DEFAULTS.put("MaxAutoScalingGroupSize", "");
-        DEFAULTS.put("ContainerPort", "");
+        DEFAULTS.put("TaskMemory", "1024");
+        DEFAULTS.put("TaskCPU", "512");
+        DEFAULTS.put("MinTaskCount", "1");
+        DEFAULTS.put("MaxTaskCount", "1");
+        DEFAULTS.put("MinAutoScalingGroupSize", "1");
+        DEFAULTS.put("MaxAutoScalingGroupSize", "1");
+        DEFAULTS.put("ContainerPort", "0");
         DEFAULTS.put("ContainerHealthCheckPath", "");
         DEFAULTS.put("UseRDS", "false");
         DEFAULTS.put("RDSInstanceClass", "");
@@ -58,14 +60,14 @@ public class OnboardingAppStackParameters extends AbstractStackParameters {
         DEFAULTS.put("ActiveDirectoryId", "");
         DEFAULTS.put("ActiveDirectoryDnsIps", "");
         DEFAULTS.put("ActiveDirectoryDnsName", "");
-        DEFAULTS.put("FSxFileSystemType", "");
+        DEFAULTS.put("FSxFileSystemType", "FSX_WINDOWS");
         DEFAULTS.put("FSxWindowsMountDrive", "");
-        DEFAULTS.put("FileSystemStorage", "");
-        DEFAULTS.put("FileSystemThroughput", "");
-        DEFAULTS.put("FSxBackupRetention", "");
+        DEFAULTS.put("FileSystemStorage", "0");
+        DEFAULTS.put("FileSystemThroughput", "0");
+        DEFAULTS.put("FSxBackupRetention", "0");
         DEFAULTS.put("FSxDailyBackupTime", "");
         DEFAULTS.put("FSxWeeklyMaintenanceTime", "");
-        DEFAULTS.put("OntapVolumeSize", "");
+        DEFAULTS.put("OntapVolumeSize", "20");
         DEFAULTS.put("Disable", "false");
         DEFAULTS.put("OnboardingDdbTable", "");
         DEFAULTS.put("TenantStorageBucket", "");
@@ -79,5 +81,27 @@ public class OnboardingAppStackParameters extends AbstractStackParameters {
 
     public OnboardingAppStackParameters() {
         super(DEFAULTS);
+    }
+
+    @Override
+    protected void validate() {
+        super.validate();
+        List<String> invalidParameters = new ArrayList<>();
+        List<String> required = List.of("Environment", "TenantId", "Tier", "VPC", "SubnetPrivateA", "SubnetPrivateB",
+                "ECSCluster", "ECSSecurityGroup");
+        for (String requiredParameter : required) {
+            if (Utils.isBlank(getProperty(requiredParameter))) {
+                invalidParameters.add(requiredParameter);
+            }
+        }
+        if (Utils.isBlank(getProperty("ECSLoadBalancerHttpListener"))
+                && Utils.isBlank(getProperty("ECSLoadBalancerHttpsListener"))) {
+            invalidParameters.add("ECSLoadBalancerHttpListener");
+            invalidParameters.add("ECSLoadBalancerHttpsListener");
+        }
+        if (!invalidParameters.isEmpty()) {
+            throw new RuntimeException("Missing values for required parameters "
+                    + String.join(",", invalidParameters));
+        }
     }
 }

--- a/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingAppStackParameters.java
+++ b/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingAppStackParameters.java
@@ -1,0 +1,83 @@
+package com.amazon.aws.partners.saasfactory.saasboost;
+
+import java.util.Properties;
+
+public class OnboardingAppStackParameters extends AbstractStackParameters {
+
+    static Properties DEFAULTS = new Properties();
+
+    static {
+        DEFAULTS.put("Environment", "");
+        DEFAULTS.put("TenantId", "");
+        DEFAULTS.put("Tier", "");
+        DEFAULTS.put("ServiceName", "");
+        DEFAULTS.put("ServiceResourceName", "");
+        DEFAULTS.put("ContainerRepository", "");
+        DEFAULTS.put("ContainerRepositoryTag", "latest");
+        DEFAULTS.put("ECSCluster", "");
+        DEFAULTS.put("EnableECSExec", "false");
+        DEFAULTS.put("PubliclyAddressable", "true");
+        DEFAULTS.put("PublicPathRoute", "/*");
+        DEFAULTS.put("PublicPathRulePriority", "1");
+        DEFAULTS.put("VPC", "");
+        DEFAULTS.put("SubnetPrivateA", "");
+        DEFAULTS.put("SubnetPrivateB", "");
+        DEFAULTS.put("PrivateRouteTable", "");
+        DEFAULTS.put("ServiceDiscoveryNamespace", "");
+        DEFAULTS.put("ECSLoadBalancerHttpListener", "");
+        DEFAULTS.put("ECSLoadBalancerHttpsListener", "");
+        DEFAULTS.put("ECSSecurityGroup", "");
+        DEFAULTS.put("ContainerOS", "");
+        DEFAULTS.put("ClusterInstanceType", "");
+        DEFAULTS.put("TaskLaunchType", "");
+        DEFAULTS.put("TaskMemory", "");
+        DEFAULTS.put("TaskCPU", "");
+        DEFAULTS.put("MinTaskCount", "");
+        DEFAULTS.put("MaxTaskCount", "");
+        DEFAULTS.put("MinAutoScalingGroupSize", "");
+        DEFAULTS.put("MaxAutoScalingGroupSize", "");
+        DEFAULTS.put("ContainerPort", "");
+        DEFAULTS.put("ContainerHealthCheckPath", "");
+        DEFAULTS.put("UseRDS", "false");
+        DEFAULTS.put("RDSInstanceClass", "");
+        DEFAULTS.put("RDSEngine", "");
+        DEFAULTS.put("RDSEngineVersion", "");
+        DEFAULTS.put("RDSParameterGroupFamily", "");
+        DEFAULTS.put("RDSUsername", "");
+        DEFAULTS.put("RDSPasswordParam", "");
+        DEFAULTS.put("RDSPort", "");
+        DEFAULTS.put("RDSDatabase", "");
+        DEFAULTS.put("RDSBootstrap", "");
+        DEFAULTS.put("MetricsStream", "");
+        DEFAULTS.put("EventBus", "");
+        DEFAULTS.put("FileSystemMountPoint", "");
+        DEFAULTS.put("UseEFS", "false");
+        DEFAULTS.put("EncryptEFS", "true");
+        DEFAULTS.put("EFSLifecyclePolicy", "NEVER");
+        DEFAULTS.put("UseFSx", "false");
+        DEFAULTS.put("ActiveDirectoryId", "");
+        DEFAULTS.put("ActiveDirectoryDnsIps", "");
+        DEFAULTS.put("ActiveDirectoryDnsName", "");
+        DEFAULTS.put("FSxFileSystemType", "");
+        DEFAULTS.put("FSxWindowsMountDrive", "");
+        DEFAULTS.put("FileSystemStorage", "");
+        DEFAULTS.put("FileSystemThroughput", "");
+        DEFAULTS.put("FSxBackupRetention", "");
+        DEFAULTS.put("FSxDailyBackupTime", "");
+        DEFAULTS.put("FSxWeeklyMaintenanceTime", "");
+        DEFAULTS.put("OntapVolumeSize", "");
+        DEFAULTS.put("Disable", "false");
+        DEFAULTS.put("OnboardingDdbTable", "");
+        DEFAULTS.put("TenantStorageBucket", "");
+        DEFAULTS.put("WIN2022FULL", "/aws/service/ami-windows-latest/Windows_Server-2022-English-Full-ECS_Optimized/image_id");
+        DEFAULTS.put("WIN2022CORE", "/aws/service/ami-windows-latest/Windows_Server-2022-English-Core-ECS_Optimized/image_id");
+        DEFAULTS.put("WIN2019FULL", "/aws/service/ami-windows-latest/Windows_Server-2019-English-Full-ECS_Optimized/image_id");
+        DEFAULTS.put("WIN2019CORE", "/aws/service/ami-windows-latest/Windows_Server-2019-English-Core-ECS_Optimized/image_id");
+        DEFAULTS.put("WIN2016FULL", "/aws/service/ami-windows-latest/Windows_Server-2016-English-Full-ECS_Optimized/image_id");
+        DEFAULTS.put("AMZNLINUX2", "/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id");
+    }
+
+    public OnboardingAppStackParameters() {
+        super(DEFAULTS);
+    }
+}

--- a/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingAppStackParameters.java
+++ b/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingAppStackParameters.java
@@ -62,8 +62,9 @@ public class OnboardingAppStackParameters extends AbstractStackParameters {
         DEFAULTS.put("ActiveDirectoryId", "");
         DEFAULTS.put("ActiveDirectoryDnsIps", "");
         DEFAULTS.put("ActiveDirectoryDnsName", "");
+        DEFAULTS.put("ActiveDirectoryCredentials", "");
         DEFAULTS.put("FSxFileSystemType", "FSX_WINDOWS");
-        DEFAULTS.put("FSxWindowsMountDrive", "");
+        DEFAULTS.put("FSxWindowsMountDrive", "G:");
         DEFAULTS.put("FileSystemStorage", "0");
         DEFAULTS.put("FileSystemThroughput", "0");
         DEFAULTS.put("FSxBackupRetention", "0");

--- a/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingBaseStackParameters.java
+++ b/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingBaseStackParameters.java
@@ -6,7 +6,8 @@ import java.util.Properties;
 
 public class OnboardingBaseStackParameters extends AbstractStackParameters {
 
-    static Properties DEFAULTS = new Properties();
+    static final Properties DEFAULTS = new Properties();
+    static final List<String> REQUIRED_FOR_CREATE = List.of("Environment", "TenantId", "Tier", "CidrPrefix");
 
     static {
         DEFAULTS.put("Environment", "");
@@ -26,11 +27,9 @@ public class OnboardingBaseStackParameters extends AbstractStackParameters {
     }
 
     @Override
-    protected void validate() {
-        super.validate();
+    protected void validateForCreate() {
         List<String> invalidParameters = new ArrayList<>();
-        List<String> required = List.of("Environment", "TenantId", "Tier", "CidrPrefix");
-        for (String requiredParameter : required) {
+        for (String requiredParameter : REQUIRED_FOR_CREATE) {
             if (Utils.isBlank(getProperty(requiredParameter))) {
                 invalidParameters.add(requiredParameter);
             }

--- a/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingBaseStackParameters.java
+++ b/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingBaseStackParameters.java
@@ -1,5 +1,7 @@
 package com.amazon.aws.partners.saasfactory.saasboost;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 
 public class OnboardingBaseStackParameters extends AbstractStackParameters {
@@ -23,4 +25,19 @@ public class OnboardingBaseStackParameters extends AbstractStackParameters {
         super(DEFAULTS);
     }
 
+    @Override
+    protected void validate() {
+        super.validate();
+        List<String> invalidParameters = new ArrayList<>();
+        List<String> required = List.of("Environment", "TenantId", "Tier", "CidrPrefix");
+        for (String requiredParameter : required) {
+            if (Utils.isBlank(getProperty(requiredParameter))) {
+                invalidParameters.add(requiredParameter);
+            }
+        }
+        if (!invalidParameters.isEmpty()) {
+            throw new RuntimeException("Missing values for required parameters "
+                    + String.join(",", invalidParameters));
+        }
+    }
 }

--- a/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingBaseStackParameters.java
+++ b/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingBaseStackParameters.java
@@ -1,0 +1,26 @@
+package com.amazon.aws.partners.saasfactory.saasboost;
+
+import java.util.Properties;
+
+public class OnboardingBaseStackParameters extends AbstractStackParameters {
+
+    static Properties DEFAULTS = new Properties();
+
+    static {
+        DEFAULTS.put("Environment", "");
+        DEFAULTS.put("DomainName", "");
+        DEFAULTS.put("HostedZoneId", "");
+        DEFAULTS.put("SSLCertificateArn", "");
+        DEFAULTS.put("TenantId", "");
+        DEFAULTS.put("TenantSubDomain", "");
+        DEFAULTS.put("CidrPrefix", "");
+        DEFAULTS.put("Tier", "");
+        DEFAULTS.put("PrivateServices", "false");
+        DEFAULTS.put("DeployActiveDirectory", "false");
+    }
+
+    public OnboardingBaseStackParameters() {
+        super(DEFAULTS);
+    }
+
+}

--- a/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingEvent.java
+++ b/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingEvent.java
@@ -26,6 +26,7 @@ public enum OnboardingEvent {
     ONBOARDING_TENANT_ASSIGNED("Onboarding Tenant Assigned"),
     ONBOARDING_STACK_STATUS_CHANGED("Onboarding Stack Status Changed"),
     ONBOARDING_BASE_PROVISIONED("Onboarding Base Provisioned"),
+    ONBOARDING_BASE_UPDATED("Onboarding Base Updated"),
     ONBOARDING_PROVISIONED("Onboarding Provisioned"),
     ONBOARDING_DEPLOYMENT_PIPELINE_CREATED("Onboarding Deployment Pipeline Created"),
     ONBOARDING_DEPLOYMENT_PIPELINE_CHANGED("Onboarding Deployment Pipeline Change"),

--- a/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingService.java
+++ b/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingService.java
@@ -1954,7 +1954,7 @@ public class OnboardingService {
         for (Map<String, Object> service : services.values()) {
             Map<String, Object> filesystem = (Map<String, Object>) service.get("filesystem");
             if (filesystem != null) {
-                configureAd = configureAd || (Boolean) filesystem.getOrDefault("configureManagedAd", false)
+                configureAd = configureAd || (Boolean) filesystem.getOrDefault("configureManagedAd", false);
             }
         }
         return configureAd;
@@ -2116,6 +2116,7 @@ public class OnboardingService {
                         "ACTIVE_DIRECTORY_ID"
                 );
                 if (activeDirectorySettings != null) {
+                    String tenantId = parameters.getProperty("TenantId");
                     parameters.setProperty("ActiveDirectoryId",
                             activeDirectorySettings.getOrDefault(tenantId + "/ACTIVE_DIRECTORY_ID", ""));
                     parameters.setProperty("ActiveDirectoryDnsIps",

--- a/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingServiceDAL.java
+++ b/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingServiceDAL.java
@@ -363,6 +363,9 @@ public class OnboardingServiceDAL {
                     .stream()
                     .map(stack -> {
                         Map<String, AttributeValue> stackItem = new HashMap<>();
+                        if (stack.getService() != null) {
+                            stackItem.put("service", AttributeValue.builder().s(stack.getService()).build());
+                        }
                         if (stack.getName() != null) {
                             stackItem.put("name", AttributeValue.builder().s(stack.getName()).build());
                         }
@@ -468,6 +471,7 @@ public class OnboardingServiceDAL {
                         .map(stackItem -> {
                             Map<String, AttributeValue> stack = stackItem.m();
                             return OnboardingStack.builder()
+                                    .service(stack.containsKey("service") ? stack.get("service").s() : null)
                                     .name(stack.containsKey("name") ? stack.get("name").s() : null)
                                     .arn(stack.containsKey("arn") ? stack.get("arn").s() : null)
                                     .baseStack(stack.containsKey("baseStack") ? stack.get("baseStack").bool() : false)

--- a/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingStack.java
+++ b/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingStack.java
@@ -2,6 +2,7 @@ package com.amazon.aws.partners.saasfactory.saasboost;
 
 public class OnboardingStack {
 
+    private String service;
     private String name;
     private String arn;
     private boolean baseStack;
@@ -13,6 +14,7 @@ public class OnboardingStack {
     }
 
     private OnboardingStack(Builder builder) {
+        this.service = builder.service;
         this.name = builder.name;
         this.arn = builder.arn;
         this.baseStack = builder.baseStack;
@@ -27,12 +29,17 @@ public class OnboardingStack {
 
     public static Builder builder(OnboardingStack copyMe) {
         return new Builder()
+                .service(copyMe.service)
                 .name(copyMe.name)
                 .arn(copyMe.arn)
                 .baseStack(copyMe.baseStack)
                 .status(copyMe.status)
                 .pipeline(copyMe.pipeline)
                 .pipelineStatus(copyMe.pipelineStatus);
+    }
+
+    public String getService() {
+        return service;
     }
 
     public String getName() {
@@ -110,6 +117,7 @@ public class OnboardingStack {
 
     public static final class Builder {
 
+        private String service;
         private String name;
         private String arn;
         private boolean baseStack;
@@ -118,6 +126,11 @@ public class OnboardingStack {
         private String pipelineStatus;
 
         private Builder() {
+        }
+
+        public Builder service(String service) {
+            this.service = service;
+            return this;
         }
 
         public Builder name(String name) {

--- a/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingStack.java
+++ b/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingStack.java
@@ -105,7 +105,11 @@ public class OnboardingStack {
             if (stackId.length > 4) {
                 String region = stackId[3];
                 url = String.format(
-                        "https://%s.console.aws.amazon.com/cloudformation/home?region=%s#/stacks/stackinfo?filteringText=&filteringStatus=active&viewNested=true&hideStacks=false&stackId=%s",
+                        "https://%s.console.aws.amazon.com/cloudformation/home?"
+                                + "region=%s"
+                                + "#/stacks/stackinfo?filteringText=&filteringStatus=active"
+                                + "&viewNested=true&hideStacks=false"
+                                + "&stackId=%s",
                         region,
                         region,
                         arn

--- a/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingStatus.java
+++ b/services/onboarding-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/OnboardingStatus.java
@@ -28,7 +28,8 @@ public enum OnboardingStatus {
     deployed,
     failed,
     deleting,
-    deleted;
+    deleted,
+    unknown;
 
     public static OnboardingStatus fromStackStatus(String stackStatus) {
         OnboardingStatus status;
@@ -38,6 +39,7 @@ public enum OnboardingStatus {
                 status = OnboardingStatus.provisioning;
                 break;
             case "UPDATE_IN_PROGRESS":
+            case "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS":
                 status = OnboardingStatus.updating;
                 break;
             case "DELETE_IN_PROGRESS":
@@ -55,11 +57,21 @@ public enum OnboardingStatus {
             case "CREATE_FAILED":
             case "UPDATE_FAILED":
             case "DELETE_FAILED":
+            case "UPDATE_ROLLBACK_IN_PROGRESS":
+            case "UPDATE_ROLLBACK_COMPLETE":
+            case "UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS":
             case "UPDATE_ROLLBACK_FAILED":
             case "ROLLBACK_IN_PROGRESS":
             case "ROLLBACK_COMPLETE":
             case "ROLLBACK_FAILED":
                 status = OnboardingStatus.failed;
+                break;
+            case "IMPORT_IN_PROGRESS":
+            case "IMPORT_COMPLETE":
+            case "IMPORT_ROLLBACK_IN_PROGRESS":
+            case "IMPORT_ROLLBACK_FAILED":
+            case "IMPORT_ROLLBACK_COMPLETE":
+                status = OnboardingStatus.unknown;
                 break;
             default:
                 status = Utils.isNotBlank(stackStatus) ? OnboardingStatus.created : null;

--- a/services/settings-service/pom.xml
+++ b/services/settings-service/pom.xml
@@ -33,7 +33,7 @@ limitations under the License.
     </licenses>
 
     <properties>
-        <checkstyle.maxAllowedViolations>25</checkstyle.maxAllowedViolations>
+        <checkstyle.maxAllowedViolations>17</checkstyle.maxAllowedViolations>
     </properties>
 
     <build>
@@ -79,6 +79,21 @@ limitations under the License.
             <plugin>
                 <groupId>io.github.git-commit-id</groupId>
                 <artifactId>git-commit-id-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <configuration>
+                    <effort>Max</effort>
+                    <threshold>medium</threshold>
+                    <plugins>
+                        <plugin>
+                            <groupId>software.amazon.lambda.snapstart</groupId>
+                            <artifactId>aws-lambda-snapstart-java-rules</artifactId>
+                            <version>0.1.0</version>
+                        </plugin>
+                    </plugins>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/services/settings-service/pom.xml
+++ b/services/settings-service/pom.xml
@@ -80,21 +80,6 @@ limitations under the License.
                 <groupId>io.github.git-commit-id</groupId>
                 <artifactId>git-commit-id-maven-plugin</artifactId>
             </plugin>
-            <plugin>
-                <groupId>com.github.spotbugs</groupId>
-                <artifactId>spotbugs-maven-plugin</artifactId>
-                <configuration>
-                    <effort>Max</effort>
-                    <threshold>medium</threshold>
-                    <plugins>
-                        <plugin>
-                            <groupId>software.amazon.lambda.snapstart</groupId>
-                            <artifactId>aws-lambda-snapstart-java-rules</artifactId>
-                            <version>0.1.0</version>
-                        </plugin>
-                    </plugins>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/Setting.java
+++ b/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/Setting.java
@@ -97,14 +97,13 @@ public class Setting {
             return false;
         }
         final Setting other = (Setting) obj;
-        return (
-                ((name == null && other.name == null) || (name != null && name.equals(other.name))) // Parameter Store is case sensitive
+        return (((name == null && other.name == null) || (name != null && name.equals(other.name))) // Parameter Store is case sensitive
                 && ((value == null && other.value == null) || (value != null && value.equals(other.value)))
-                && ((description == null && other.description == null) || (description != null && description.equalsIgnoreCase(other.description)))
+                && ((description == null && other.description == null)
+                        || (description != null && description.equalsIgnoreCase(other.description)))
                 && ((version == null && other.version == null) || (version != null && version.equals(other.version)))
                 && (readOnly == other.readOnly)
-                && (secure == other.secure)
-        );
+                && (secure == other.secure));
     }
 
     @Override

--- a/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SettingsService.java
+++ b/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SettingsService.java
@@ -445,10 +445,8 @@ public class SettingsService implements RequestHandler<Map<String, Object>, APIG
 
                     if (AppConfigHelper.isServicesChanged(currentAppConfig, updatedAppConfig)) {
                         LOGGER.info("AppConfig application services changed");
-                        //LOGGER.info(Utils.toJson(currentAppConfig));
-                        //LOGGER.info(Utils.toJson(updatedAppConfig));
-                        Set<String> removedServices = AppConfigHelper.removedServices(
-                                currentAppConfig, updatedAppConfig);
+                        // Currently you can only remove services if there are no provisioned tenants
+                        Set<String> removedServices = AppConfigHelper.removedServices(currentAppConfig, updatedAppConfig);
                         if (!removedServices.isEmpty()) {
                             LOGGER.info("Services {} were removed from AppConfig: deleting their parameters.",
                                     removedServices);
@@ -461,7 +459,6 @@ public class SettingsService implements RequestHandler<Map<String, Object>, APIG
 
                     // TODO how do we want to deal with tier settings changes?
 
-                    // TODO do we want to allow adding new services to the config?
                     LOGGER.info("Persisting updated app config");
                     updatedAppConfig = dal.setAppConfig(updatedAppConfig);
 
@@ -471,6 +468,8 @@ public class SettingsService implements RequestHandler<Map<String, Object>, APIG
                     }
 
                     if (fireUpdateAppConfigEvent) {
+                        // The provisioning system can take care of modifying/adding/removing infra
+                        // due to changes in the app config
                         Utils.publishEvent(eventBridge, SAAS_BOOST_EVENT_BUS, "saas-boost",
                                 AppConfigEvent.APP_CONFIG_CHANGED.detailType(),
                                 Collections.EMPTY_MAP
@@ -606,6 +605,15 @@ public class SettingsService implements RequestHandler<Map<String, Object>, APIG
                             LOGGER.error("Can't find app config service {}", changedServiceName);
                         }
                     }
+                }
+                // If there are provisioned tenants, and we just ran an update to the infrastructure
+                // we need to update the tenant environments to reflect any changes
+                List<Map<String, Object>> provisionedTenants = getProvisionedTenants(context);
+                if (!provisionedTenants.isEmpty()) {
+                    LOGGER.info("Updated app config with provisioned tenants");
+                    Utils.publishEvent(eventBridge, SAAS_BOOST_EVENT_BUS, "saas-boost",
+                            AppConfigEvent.APP_CONFIG_UPDATE_COMPLETED.detailType(),
+                            Collections.EMPTY_MAP);
                 }
             } else {
                 LOGGER.error("Can't parse event detail as AppConfig {}", json);

--- a/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SettingsService.java
+++ b/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SettingsService.java
@@ -535,6 +535,9 @@ public class SettingsService implements RequestHandler<Map<String, Object>, APIG
                     case APP_CONFIG_CHANGED:
                         // We produce this event, but currently aren't consuming it
                         break;
+                    case APP_CONFIG_UPDATE_COMPLETED:
+                        //  We produce this event, but currently aren't consuming it
+                        break;
                     default: {
                         LOGGER.error("Can't find app config event for detail-type {}", event.get("detail-type"));
                         // TODO Throw here? Would end up in DLQ.

--- a/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SettingsServiceDAL.java
+++ b/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/SettingsServiceDAL.java
@@ -136,7 +136,7 @@ public class SettingsServiceDAL {
     }
 
     public Setting getSecret(String settingName) {
-        if(settingName.contains("BILLING_API_KEY")) {
+        if (settingName.contains("BILLING_API_KEY")) {
             settingName = APP_BASE_PATH + settingName;
         }        
         return getSetting(settingName, true);

--- a/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/AppConfig.java
+++ b/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/AppConfig.java
@@ -85,8 +85,7 @@ public class AppConfig {
         return (Utils.isBlank(name) && Utils.isBlank(domainName) && Utils.isBlank(hostedZone)
                 && Utils.isBlank(sslCertificate)
                 && (billing == null || !billing.hasApiKey())
-                && (services == null || services.isEmpty())
-        );
+                && (services == null || services.isEmpty()));
     }
 
     @Override
@@ -108,14 +107,12 @@ public class AppConfig {
             return false;
         }
         final AppConfig other = (AppConfig) obj;
-        return (
-                Utils.nullableEquals(name, other.getName())
+        return (Utils.nullableEquals(name, other.getName())
                 && Utils.nullableEquals(domainName, other.getDomainName())
                 && Utils.nullableEquals(hostedZone, other.getHostedZone())
                 && Utils.nullableEquals(sslCertificate, other.getSslCertificate())
                 && ((services == null && other.services == null) || (servicesEqual(services, other.services)))
-                && Utils.nullableEquals(billing, other.getBilling())
-        );
+                && Utils.nullableEquals(billing, other.getBilling()));
     }
 
     public static boolean servicesEqual(Map<String, ServiceConfig> services, Map<String, ServiceConfig> otherServices) {

--- a/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/AppConfigEvent.java
+++ b/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/AppConfigEvent.java
@@ -4,7 +4,8 @@ import java.util.Map;
 
 public enum AppConfigEvent {
     APP_CONFIG_CHANGED("Application Configuration Changed"),
-    APP_CONFIG_RESOURCE_CHANGED("Application Configuration Resource Changed")
+    APP_CONFIG_RESOURCE_CHANGED("Application Configuration Resource Changed"),
+    APP_CONFIG_UPDATE_COMPLETED("Application Configuration Update Completed")
     ;
 
     private final String detailType;

--- a/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/AppConfigHelper.java
+++ b/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/AppConfigHelper.java
@@ -62,9 +62,36 @@ public final class AppConfigHelper {
     }
 
     public static Set<String> removedServices(AppConfig existing, AppConfig altered) {
-        Set<String> existingServices = new HashSet<>(existing.getServices().keySet());
-        existingServices.removeAll(altered.getServices().keySet());
-        return existingServices;
+        Set<String> removed = new HashSet<>();
+        for (String existingKey : existing.getServices().keySet()) {
+            boolean found = false;
+            for (String alteredKey : altered.getServices().keySet()) {
+                if (existingKey.equalsIgnoreCase(alteredKey)) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                removed.add(existingKey);
+            }
+        }
+        return removed;
+    }
+
+    public static Set<String> addedServices(AppConfig existing, AppConfig altered) {
+        Set<String> added = new HashSet<>();
+        for (String alteredKey : altered.getServices().keySet()) {
+            int found = 0;
+            for (String existingKey : existing.getServices().keySet()) {
+                if (alteredKey.equalsIgnoreCase(existingKey)) {
+                    found++;
+                }
+            }
+            if (found == 0) {
+                added.add(alteredKey);
+            }
+        }
+        return added;
     }
 
     public static boolean isServicesChanged(AppConfig existing, AppConfig altered) {

--- a/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/BillingProvider.java
+++ b/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/BillingProvider.java
@@ -52,9 +52,7 @@ public class BillingProvider {
             return false;
         }
         final BillingProvider other = (BillingProvider) obj;
-        return (
-                (apiKey == null && other.apiKey == null) || (apiKey != null && apiKey.equals(other.apiKey))
-        );
+        return ((apiKey == null && other.apiKey == null) || (apiKey != null && apiKey.equals(other.apiKey)));
     }
 
     @Override

--- a/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/S3Storage.java
+++ b/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/S3Storage.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
- package com.amazon.aws.partners.saasfactory.saasboost.appconfig;
+package com.amazon.aws.partners.saasfactory.saasboost.appconfig;
 
 import com.amazon.aws.partners.saasfactory.saasboost.Utils;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;

--- a/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/ServiceConfig.java
+++ b/services/settings-service/src/main/java/com/amazon/aws/partners/saasfactory/saasboost/appconfig/ServiceConfig.java
@@ -17,8 +17,8 @@
 package com.amazon.aws.partners.saasfactory.saasboost.appconfig;
 
 import com.amazon.aws.partners.saasfactory.saasboost.Utils;
-import com.amazon.aws.partners.saasfactory.saasboost.appconfig.filesystem.AbstractFilesystem;
 import com.amazon.aws.partners.saasfactory.saasboost.appconfig.compute.AbstractCompute;
+import com.amazon.aws.partners.saasfactory.saasboost.appconfig.filesystem.AbstractFilesystem;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;

--- a/services/settings-service/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/AppConfigHelperTest.java
+++ b/services/settings-service/src/test/java/com/amazon/aws/partners/saasfactory/saasboost/AppConfigHelperTest.java
@@ -129,4 +129,50 @@ public class AppConfigHelperTest {
         altered = AppConfig.builder().services(services2).build();
         assertTrue(AppConfigHelper.isServicesChanged(existing, altered));
     }
+
+    @Test
+    public void testRemovedServices() {
+        AppConfig existing = AppConfig.builder().build();
+        AppConfig altered = AppConfig.builder().build();
+        assertTrue(AppConfigHelper.removedServices(existing, altered).isEmpty());
+
+        Map<String, ServiceConfig> services1 = new HashMap<>();
+        services1.put("foo", ServiceConfig.builder().build());
+        Map<String, ServiceConfig> services2 = new HashMap<>();
+        services2.put("FOO", ServiceConfig.builder().build());
+        existing = AppConfig.builder().services(services1).build();
+        altered = AppConfig.builder().services(services2).build();
+        // foo | FOO
+        assertTrue(AppConfigHelper.removedServices(existing, altered).isEmpty());
+
+        // foo | FOO,bar
+        services2.put("bar", ServiceConfig.builder().build());
+        existing = AppConfig.builder().services(services1).build();
+        altered = AppConfig.builder().services(services2).build();
+        assertTrue(AppConfigHelper.removedServices(existing, altered).isEmpty());
+
+        // foo | FOO
+        services2.remove("bar");
+        existing = AppConfig.builder().services(services1).build();
+        altered = AppConfig.builder().services(services2).build();
+        assertTrue(AppConfigHelper.removedServices(existing, altered).isEmpty());
+
+        // foo | bar
+        services2.remove("FOO");
+        services2.put("bar", ServiceConfig.builder().build());
+        existing = AppConfig.builder().services(services1).build();
+        altered = AppConfig.builder().services(services2).build();
+        assertFalse(AppConfigHelper.removedServices(existing, altered).isEmpty());
+
+        // christmas,easter | bar,baz
+        services1.clear();
+        services1.put("christmas", ServiceConfig.builder().build());
+        services1.put("easter", ServiceConfig.builder().build());
+        services2.clear();
+        services2.put("bar", ServiceConfig.builder().build());
+        services2.put("baz", ServiceConfig.builder().build());
+        existing = AppConfig.builder().services(services1).build();
+        altered = AppConfig.builder().services(services2).build();
+        assertFalse(AppConfigHelper.removedServices(existing, altered).isEmpty());
+    }
 }


### PR DESCRIPTION
This PR includes changes to appConfig and onboarding to support adding new application service configs to an existing appConfig when there are provisioned tenants. The new service should be configured and resources provisioned and then each provisioned tenant should be updated to provision and deploy the newly configured service.

This PR does not contain the change to the admin web app to allow updating an existing appConfig with provisioned tenants. For now, to exercise this feature, you must use the Settings Service API to update your appConfig.

Known limitations - adding a new _public_ service with a shorter path prefix that one of the existing services requires all ALB listener rule priorities to be reset prior to the new service being created. Essentially a CloudFormation `update-stack` has to run for each existing tenant-onboarding-app stack prior to the `create-stack` call for the new service attempting to set the new ALB listener rule.

There are also sharp edges around deployment of the new service for existing tenants. You have to update the appConfig, wait for the core stack to provision the new ECR repo for the new service, and then docker push your image for the new service. Behind the scenes SaaS Boost will be updating the existing tenant environments and eventually triggering the CodePipeline for the new service. If the container image for the new service hasn't been pushed yet, the deployment will fail.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
