### PR TITLE
Update to add a permission to onboarding process(saas-boost-svc-onboarding.yaml) to fix a bug.

### DIFF
--- a/resources/saas-boost-svc-onboarding.yaml
+++ b/resources/saas-boost-svc-onboarding.yaml
@@ -713,6 +713,7 @@ Resources:
               - rds:DescribeDBSubnetGroups
               - rds:CreateDBSubnetGroup
               - rds:DeleteDBSubnetGroup
+              - rds:ListTagsForResource
             Resource:
               - !Sub arn:${AWS::Partition}:rds:${AWS::Region}:${AWS::AccountId}:subgrp:sb-${Environment}-*tenant*
           - Effect: Allow


### PR DESCRIPTION
There is an error to create subnet group of RDS. It is added a permission of rds:ListTagsForResource for onboarding process(saas-boost-svc-onboarding.yaml) to fix it


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
