### PR TITLE
Add NoEcho to sensitive CloudFormation password parameters (dependabot/word-wrap)

### DIFF
--- a/resources/saas-boost-metrics-analytics.yaml
+++ b/resources/saas-boost-metrics-analytics.yaml
@@ -146,6 +146,7 @@ Parameters:
     MaxLength: '1024'
     MinLength: '1'
     Type: String
+    NoEcho: true
   # MetricUserPassword:
   #   Description: The master password for the Amazon Redshift cluster.
   #   MaxLength: '1024'

--- a/resources/tenant-onboarding-rds.yaml
+++ b/resources/tenant-onboarding-rds.yaml
@@ -57,6 +57,7 @@ Parameters:
   RDSPasswordParam:
     Description: The Parameter Store secure string parameter and version containing the database password
     Type: String
+    NoEcho: true
   RDSPort:
     Description: The TCP port to connect to the database on
     Type: String


### PR DESCRIPTION
## Summary
- Backport of PR #546 (merged to `main`) onto the `dependabot/npm_and_yarn/client/web/word-wrap-1.2.4` branch
- Adds `NoEcho: true` to `RDSPasswordParam` and `MetricUserPasswordSSMParameter` parameters that feed Password properties but lacked masking
- Resolves ACAT finding [9f369249](https://appsec.corp.amazon.com/talos/finding/9f369249-f0f1-465d-b63d-b90a19ca9031) for this branch

## Note
This dependabot branch is stale. Consider closing PR #525 and deleting this branch instead of merging this fix — the finding will auto-clear when the branch is removed.